### PR TITLE
Add cargo example for Rust project

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,26 +57,6 @@ jobs:
 
 See [Examples](examples.md)
 
-### Rust - Cargo
-
-```
-- name: Cache cargo registry
-  uses: actions/cache@preview
-  with:
-    path: ~/.cargo/registry
-    key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
-- name: Cache cargo index
-  uses: actions/cache@preview
-  with:
-    path: ~/.cargo/git
-    key: ${{ runner.os }}-cargo-index-${{ hashFiles('**/Cargo.lock') }}
-- name: Cache cargo build
-  uses: actions/cache@preview
-  with:
-    path: target
-    key: ${{ runner.os }}-cargo-build-target-${{ hashFiles('**/Cargo.lock') }}
-```
-
 ## Cache Limits
 
 Individual caches are limited to 200MB and a repository can have up to 2GB of caches. Once the 2GB limit is reached, older caches will be evicted based on when the cache was last accessed.

--- a/README.md
+++ b/README.md
@@ -64,17 +64,17 @@ See [Examples](examples.md)
   uses: actions/cache@preview
   with:
     path: ~/.cargo/registry
-    key: ${{ runner.os }}-cargo-registry
+    key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
 - name: Cache cargo index
   uses: actions/cache@preview
   with:
     path: ~/.cargo/git
-    key: ${{ runner.os }}-cargo-index
+    key: ${{ runner.os }}-cargo-index-${{ hashFiles('**/Cargo.lock') }}
 - name: Cache cargo build
   uses: actions/cache@preview
   with:
     path: target
-    key: ${{ runner.os }}-cargo-build-target
+    key: ${{ runner.os }}-cargo-build-target-${{ hashFiles('**/Cargo.lock') }}
 ```
 
 ## Cache Limits

--- a/README.md
+++ b/README.md
@@ -57,6 +57,26 @@ jobs:
 
 See [Examples](examples.md)
 
+### Rust - Cargo
+
+```
+- name: Cache cargo registry
+  uses: actions/cache@preview
+  with:
+    path: ~/.cargo/registry
+    key: ${{ runner.os }}-cargo-registry
+- name: Cache cargo index
+  uses: actions/cache@preview
+  with:
+    path: ~/.cargo/git
+    key: ${{ runner.os }}-cargo-index
+- name: Cache cargo build
+  uses: actions/cache@preview
+  with:
+    path: target
+    key: ${{ runner.os }}-cargo-build-target
+```
+
 ## Cache Limits
 
 Individual caches are limited to 200MB and a repository can have up to 2GB of caches. Once the 2GB limit is reached, older caches will be evicted based on when the cache was last accessed.

--- a/examples.md
+++ b/examples.md
@@ -8,6 +8,7 @@
 - [Swift, Objective-C - Carthage](#swift-objective-c---carthage)
 - [Swift, Objective-C - CocoaPods](#swift-objective-c---cocoapods)
 - [Ruby - Gem](#ruby---gem)
+- [Rust - Cargo](#rust---cargo)
 
 ## Node - npm
 
@@ -95,4 +96,24 @@ uses: actions/cache@preview
     key: ${{ runner.os }}-gem-${{ hashFiles('**/Gemfile.lock') }}
     restore-keys: |
       ${{ runner.os }}-gem-
+```
+
+## Rust - Cargo
+
+```
+- name: Cache cargo registry
+  uses: actions/cache@preview
+  with:
+    path: ~/.cargo/registry
+    key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
+- name: Cache cargo index
+  uses: actions/cache@preview
+  with:
+    path: ~/.cargo/git
+    key: ${{ runner.os }}-cargo-index-${{ hashFiles('**/Cargo.lock') }}
+- name: Cache cargo build
+  uses: actions/cache@preview
+  with:
+    path: target
+    key: ${{ runner.os }}-cargo-build-target-${{ hashFiles('**/Cargo.lock') }}
 ```


### PR DESCRIPTION
This PR adds example for [Cargo](https://github.com/rust-lang/cargo), which is an official build tool for Rust toolchain. In addtion to local `target` build directory, `~/.cargo/registry` (packages registry) and `~/.cargo/git` (packages index) were necessary to be cached for reusing cached build directory.

I already tried this on my project [kiro-editor](https://github.com/rhysd/kiro-editor) and `cargo test` was improved as follows.

- Before (without cache): [job](https://github.com/rhysd/kiro-editor/runs/281423840)
  - Linux: **1m26s** (**1m32s** in total)
  - macOS: **41s** (**1m4s** in total)
- After (with cache): [job](https://github.com/rhysd/kiro-editor/commit/fad2f9487d6d9e3d4585c596a36c2889128963ee/checks?check_suite_id=289340630)
  - Linux: **13s** (**33s** in total)
  - macOS: **18s** (**35s** in total)

6.6x faster on Linux.