### PR TITLE
Move examples to their own page

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,87 +50,10 @@ jobs:
     - name: Test
       run: npm run test
 ```
+
 ## Ecosystem Examples
 
-### Node - npm
-
-```yaml
-- uses: actions/cache@preview
-  with:
-    path: node_modules
-    key: ${{ runner.os }}-node
-```
-
-### Node - Yarn
-
-```yaml
-- uses: actions/cache@preview
-  with:
-    path: ~/.cache/yarn
-    key: ${{ runner.os }}-yarn-${{ hashFiles(format('{0}{1}', github.workspace, '/yarn.lock')) }}
-    restore-keys: |
-      ${{ runner.os }}-yarn-
-```
-
-### C# - Nuget
-
-```yaml
-- uses: actions/cache@preview
-  with:
-    path: ~/.nuget/packages
-    key: ${{ runner.os }}-nuget-${{ hashFiles('**/packages.lock.json') }}
-    restore-keys: |
-      ${{ runner.os }}-nuget-
-```
-
-### Java - Gradle
-
-```yaml
-- uses: actions/cache@preview
-  with:
-    path: ~/.gradle/caches
-    key: gradle-${{ runner.os }}-${{ hashFiles('**/*.gradle') }}
-    restore-keys: |
-      gradle-${{ runner.os }}-
-```
-
-### Java - Maven
-```yaml
-- uses: actions/cache@preview
-  with:
-    path: ~/.m2/repository
-    key: ${{ runner.os }}-maven
-```
-
-### Swift, Objective-C - Carthage
-```yaml
-uses: actions/cache@preview
-      with:
-        path: Carthage
-        key: ${{ runner.os }}-carthage-${{ hashFiles('**/Cartfile.resolved') }}
-        restore-keys: |
-          ${{ runner.os }}-carthage-
-```
-
-### Swift, Objective-C - CocoaPods
-```yaml
-- uses: actions/cache@preview
-  with:
-    path: Pods
-    key: ${{ runner.os }}-pods-${{ hashFiles('**/Podfile.lock') }}
-    restore-keys: |
-      ${{ runner.os }}-pods-
-```
-
-### Ruby - Gem
-```yaml
-- uses: actions/cache@preview
-  with:
-    path: vendor/bundle
-    key: ${{ runner.os }}-gem-${{ hashFiles('**/Gemfile.lock') }}
-    restore-keys: |
-      ${{ runner.os }}-gem-
-```
+See [Examples](examples.md)
 
 ## Cache Limits
 

--- a/examples.md
+++ b/examples.md
@@ -1,0 +1,98 @@
+# Examples
+
+- [Node - npm](#node---npm)
+- [Node - Yarn](#node---yarn)
+- [C# - Nuget](#c---nuget)
+- [Java - Gradle](#java---gradle)
+- [Java - Maven](#java---maven)
+- [Swift, Objective-C - Carthage](#swift-objective-c---carthage)
+- [Swift, Objective-C - CocoaPods](#swift-objective-c---cocoapods)
+- [Ruby - Gem](#ruby---gem)
+
+## Node - npm
+
+```yaml
+- uses: actions/cache@preview
+  with:
+    path: node_modules
+    key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+    restore-keys: |
+      ${{ runner.os }}-node-
+```
+
+## Node - Yarn
+
+```yaml
+- uses: actions/cache@preview
+  with:
+    path: ~/.cache/yarn
+    key: ${{ runner.os }}-yarn-${{ hashFiles(format('{0}{1}', github.workspace, '/yarn.lock')) }}
+    restore-keys: |
+      ${{ runner.os }}-yarn-
+```
+
+## C# - Nuget
+
+```yaml
+- uses: actions/cache@preview
+  with:
+    path: ~/.nuget/packages
+    key: ${{ runner.os }}-nuget-${{ hashFiles('**/packages.lock.json') }}
+    restore-keys: |
+      ${{ runner.os }}-nuget-
+```
+
+## Java - Gradle
+
+```yaml
+- uses: actions/cache@preview
+  with:
+    path: ~/.gradle/caches
+    key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
+    restore-keys: |
+      ${{ runner.os }}-gradle-
+```
+
+## Java - Maven
+
+```yaml
+- uses: actions/cache@preview
+  with:
+    path: ~/.m2/repository
+    key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+    restore-keys: |
+      ${{ runner.os }}-maven
+```
+
+## Swift, Objective-C - Carthage
+
+```yaml
+uses: actions/cache@preview
+      with:
+        path: Carthage
+        key: ${{ runner.os }}-carthage-${{ hashFiles('**/Cartfile.resolved') }}
+        restore-keys: |
+          ${{ runner.os }}-carthage-
+```
+
+## Swift, Objective-C - CocoaPods
+
+```yaml
+- uses: actions/cache@preview
+  with:
+    path: Pods
+    key: ${{ runner.os }}-pods-${{ hashFiles('**/Podfile.lock') }}
+    restore-keys: |
+      ${{ runner.os }}-pods-
+```
+
+## Ruby - Gem
+
+```yaml
+- uses: actions/cache@preview
+  with:
+    path: vendor/bundle
+    key: ${{ runner.os }}-gem-${{ hashFiles('**/Gemfile.lock') }}
+    restore-keys: |
+      ${{ runner.os }}-gem-
+```


### PR DESCRIPTION
Until we have more comprehensive docs at https://help.github.com/, we need examples in this repo. Since README.md was getting cluttered, I've moved them to a new location.

Also updated the `Node - npm` and `Java - Maven` examples to match the other formats.

Resolves https://github.com/actions/cache/issues/9