### PR TITLE
Add pip (with virtual environments) example for Python project

### DIFF
--- a/examples.md
+++ b/examples.md
@@ -120,7 +120,7 @@ uses: actions/cache@preview
       ${{ runner.os }}-mix-
 ```
 
-### Python - pip
+## Python - pip
 
 Use with virtual environments.
 

--- a/examples.md
+++ b/examples.md
@@ -10,7 +10,7 @@
 - [Ruby - Gem](#ruby---gem)
 - [Go - Modules](#go---modules)
 - [Elixir - Mix](#elixir---mix)
-- [Python - pip](#python---pip)
+- [Python - pip, virtuelenv](#python---pip,-virtuelenv)
 
 ## Node - npm
 
@@ -111,6 +111,7 @@ uses: actions/cache@preview
       ${{ runner.os }}-go-
 ```
 
+<<<<<<< HEAD
 ## Elixir - Mix
 ```yaml
 - uses: actions/cache@preview
@@ -122,6 +123,9 @@ uses: actions/cache@preview
 ```
 
 ## Python - pip
+=======
+## Python - pip, virtuelenv
+>>>>>>> Add virtualenv for title and fix wrong format
 
 Use with virtual environments.
 
@@ -129,11 +133,7 @@ Use with virtual environments.
 - uses: actions/cache@preview
   with:
     path: .venv
-    key: ${{ runner.os }}-pip-${{ hashFiles(format('{0}/{1}', github.workspace, '**/requirements.txt')) }}
+    key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
     restore-keys: |
       ${{ runner.os }}-pip-
-- run: |
-    python -m venv .venv
-    source .venv/bin/activate
-    python -m pip install -r requirements.txt
 ```

--- a/examples.md
+++ b/examples.md
@@ -123,7 +123,7 @@ uses: actions/cache@preview
 
 ## Python - pip, virtualenv
 
-Use with virtual environments.
+If caching the virtualenv, you have to activate the environment for each tasks.
 
 ```yaml
 - uses: actions/cache@preview

--- a/examples.md
+++ b/examples.md
@@ -125,8 +125,17 @@ uses: actions/cache@preview
 
 ```yaml
 - uses: actions/cache@preview
+  if: startsWith(runner.os, 'Linux')
   with:
     path: ~/.cache/pip
+    key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
+    restore-keys: |
+      ${{ runner.os }}-pip-
+
+- uses: actions/cache@preview
+  if: startsWith(runner.os, 'macOS')
+  with:
+    path: ~/Library/Caches/pip
     key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
     restore-keys: |
       ${{ runner.os }}-pip-

--- a/examples.md
+++ b/examples.md
@@ -129,7 +129,7 @@ Use with virtual environments.
 - uses: actions/cache@preview
   with:
     path: .venv
-    key: ${{ runner.os }}-pip-${{ hashFiles(format('{0}/{1}', github.workspace, 'requirements.txt')) }}
+    key: ${{ runner.os }}-pip-${{ hashFiles(format('{0}/{1}', github.workspace, '**/requirements.txt')) }}
     restore-keys: |
       ${{ runner.os }}-pip-
 - run: |

--- a/examples.md
+++ b/examples.md
@@ -10,6 +10,7 @@
 - [Ruby - Gem](#ruby---gem)
 - [Go - Modules](#go---modules)
 - [Elixir - Mix](#elixir---mix)
+- [Python - pip](#python---pip)
 
 ## Node - npm
 

--- a/examples.md
+++ b/examples.md
@@ -10,7 +10,7 @@
 - [Ruby - Gem](#ruby---gem)
 - [Go - Modules](#go---modules)
 - [Elixir - Mix](#elixir---mix)
-- [Python - pip, virtuelenv](#python---pip,-virtuelenv)
+- [Python - pip, virtuelenv](#python---pip-virtuelenv)
 
 ## Node - npm
 
@@ -111,7 +111,6 @@ uses: actions/cache@preview
       ${{ runner.os }}-go-
 ```
 
-<<<<<<< HEAD
 ## Elixir - Mix
 ```yaml
 - uses: actions/cache@preview
@@ -122,10 +121,7 @@ uses: actions/cache@preview
       ${{ runner.os }}-mix-
 ```
 
-## Python - pip
-=======
 ## Python - pip, virtuelenv
->>>>>>> Add virtualenv for title and fix wrong format
 
 Use with virtual environments.
 

--- a/examples.md
+++ b/examples.md
@@ -119,3 +119,20 @@ uses: actions/cache@preview
     restore-keys: |
       ${{ runner.os }}-mix-
 ```
+
+### Python - pip
+
+Use with virtual environments.
+
+```yaml
+- uses: actions/cache@preview
+  with:
+    path: .venv
+    key: ${{ runner.os }}-pip-${{ hashFiles(format('{0}/{1}', github.workspace, 'requirements.txt')) }}
+    restore-keys: |
+      ${{ runner.os }}-pip-
+- run: |
+    python -m venv .venv
+    source .venv/bin/activate
+    python -m pip install -r requirements.txt
+```

--- a/examples.md
+++ b/examples.md
@@ -10,7 +10,7 @@
 - [Ruby - Gem](#ruby---gem)
 - [Go - Modules](#go---modules)
 - [Elixir - Mix](#elixir---mix)
-- [Python - pip, virtualenv](#python---pip-virtualenv)
+- [Python - pip](#python---pip)
 
 ## Node - npm
 
@@ -121,14 +121,12 @@ uses: actions/cache@preview
       ${{ runner.os }}-mix-
 ```
 
-## Python - pip, virtualenv
-
-If caching the virtualenv, you have to activate the environment for each tasks.
+## Python - pip
 
 ```yaml
 - uses: actions/cache@preview
   with:
-    path: .venv
+    path: ~/.cache/pip
     key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
     restore-keys: |
       ${{ runner.os }}-pip-

--- a/examples.md
+++ b/examples.md
@@ -10,7 +10,7 @@
 - [Ruby - Gem](#ruby---gem)
 - [Go - Modules](#go---modules)
 - [Elixir - Mix](#elixir---mix)
-- [Python - pip, virtuelenv](#python---pip-virtuelenv)
+- [Python - pip, virtualenv](#python---pip-virtualenv)
 
 ## Node - npm
 
@@ -121,7 +121,7 @@ uses: actions/cache@preview
       ${{ runner.os }}-mix-
 ```
 
-## Python - pip, virtuelenv
+## Python - pip, virtualenv
 
 Use with virtual environments.
 


### PR DESCRIPTION
This PR adds example for cache Python packages with virtual environments.

Default install path is like `/opt/hostedtoolcache/Python/3.7.5/x64/lib/python3.7/site-packages/`.
So use virtual environment to install packages into workspace and cache it.

## First time (no cache)

<img width="426" alt="Screenshot 2019-11-01 00 43 47" src="https://user-images.githubusercontent.com/31176/67962859-11031800-fc41-11e9-8698-f9dafad25072.png">

## Second time (use cache)

<img width="423" alt="Screenshot 2019-11-01 00 47 49" src="https://user-images.githubusercontent.com/31176/67963015-43147a00-fc41-11e9-9141-84ce6fe35085.png">
