### PR TITLE
Minor typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ steps:
     run: /install.sh
 ```
 
-> Note: The `id` defined in `actions/cache` must match the `id` in the `if` statement (i.e. `steps.[ID].outupts.cache-hit`)
+> Note: The `id` defined in `actions/cache` must match the `id` in the `if` statement (i.e. `steps.[ID].outputs.cache-hit`)
 
 ## Contributing
 We would love for you to contribute to `@actions/cache`, pull requests are welcome! Please see the [CONTRIBUTING.md](CONTRIBUTING.md) for more information.


### PR DESCRIPTION
from `steps.[ID].outupts.cache-hit` to `steps.[ID].outputs.cache-hit`