### PR TITLE
Add trailing dash to Maven fallback key

### DIFF
--- a/examples.md
+++ b/examples.md
@@ -61,7 +61,7 @@
     path: ~/.m2/repository
     key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
     restore-keys: |
-      ${{ runner.os }}-maven
+      ${{ runner.os }}-maven-
 ```
 
 ## Swift, Objective-C - Carthage


### PR DESCRIPTION
Other examples have the trailing dash, which is recommend since the key matching is prefix-based.