### PR TITLE
Link to NuGet lock files documentation

### DIFF
--- a/examples.md
+++ b/examples.md
@@ -32,7 +32,7 @@
 ```
 
 ## C# - Nuget
-
+Using [NuGet lock files](https://docs.microsoft.com/nuget/consume-packages/package-references-in-project-files#locking-dependencies):
 ```yaml
 - uses: actions/cache@preview
   with:


### PR DESCRIPTION
Lock files are relatively new in NuGet and are not enabled by default, so add a link for awareness.