### PR TITLE
Readme: fix restore-keys indentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,8 +40,8 @@ jobs:
       with:
         path: node_modules
         key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
-      restore-keys: |
-        ${{ runner.os }}-node-
+        restore-keys: |
+          ${{ runner.os }}-node-
 
     - name: Install Dependencies
       run: npm install


### PR DESCRIPTION
This caused me some pain trying to identify the issue, but the other examples all have `restore-keys` indented.