### PR TITLE
Update action name to Dependency Caching

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -1,4 +1,4 @@
-name: 'Cache'
+name: 'Dependency Caching'
 description: 'Cache dependencies and build outputs to improve workflow execution time'
 author: 'GitHub'
 inputs:


### PR DESCRIPTION
For publishing to the marketplace, we need a more unique name that isn't taken by an existing action, user or organization name. Verified in the marketplace that a "Dependency Caching" doesn't already exist, and user/org names can't contain spaces as far as I'm aware.