### PR TITLE
Add docker layer caching example

### DIFF
--- a/examples.md
+++ b/examples.md
@@ -174,7 +174,7 @@ Using [NuGet lock files](https://docs.microsoft.com/nuget/consume-packages/packa
     if [ -d "docker-cache" ]; then
       cat docker-cache/x* > my-image.tar
       docker load < my-image.tar
-      rm -fr docker-cache
+      rm -rf docker-cache
     fi
 - name: Build image
   if: steps.cache.outputs.cache-hit != 'true'

--- a/examples.md
+++ b/examples.md
@@ -1,6 +1,7 @@
 # Examples
 
 - [C# - Nuget](#c---nuget)
+- [Docker](#docker)
 - [Elixir - Mix](#elixir---mix)
 - [Go - Modules](#go---modules)
 - [Java - Gradle](#java---gradle)
@@ -156,4 +157,30 @@ Using [NuGet lock files](https://docs.microsoft.com/nuget/consume-packages/packa
     key: ${{ runner.os }}-pods-${{ hashFiles('**/Podfile.lock') }}
     restore-keys: |
       ${{ runner.os }}-pods-
+```
+
+## Docker
+
+```yaml
+- uses: actions/cache@preview
+  id: cache
+  with:
+    path: docker-cache
+    key: ${{ runner.os }}-docker-${{ hashFiles('**/Dockerfile') }}
+    restore-keys: |
+      ${{ runner.os }}-docker-
+- name: Load cached Docker layers
+  run: |
+    if [ -d "docker-cache" ]; then
+      cat docker-cache/x* > my-image.tar
+      docker load < my-image.tar
+      rm -fr docker-cache
+    fi
+- name: Build image
+  if: steps.cache.outputs.cache-hit != 'true'
+  run: |
+    docker build --cache-from my-image -t my-image .
+    docker save my-image > my-image.tar
+    mkdir docker-cache
+    split -b 100m my-image.tar docker-cache/x
 ```

--- a/examples.md
+++ b/examples.md
@@ -166,7 +166,7 @@ Using [NuGet lock files](https://docs.microsoft.com/nuget/consume-packages/packa
   id: cache
   with:
     path: docker-cache
-    key: ${{ runner.os }}-docker-${{ hashFiles('**/Dockerfile') }}
+    key: ${{ runner.os }}-docker-${{ github.sha }}
     restore-keys: |
       ${{ runner.os }}-docker-
 - name: Load cached Docker layers

--- a/examples.md
+++ b/examples.md
@@ -162,7 +162,7 @@ Using [NuGet lock files](https://docs.microsoft.com/nuget/consume-packages/packa
 ## Docker
 
 ```yaml
-- uses: actions/cache@preview
+- uses: actions/cache@v1
   id: cache
   with:
     path: docker-cache

--- a/examples.md
+++ b/examples.md
@@ -180,7 +180,7 @@ Using [NuGet lock files](https://docs.microsoft.com/nuget/consume-packages/packa
   if: steps.cache.outputs.cache-hit != 'true'
   run: |
     docker build --cache-from my-image -t my-image .
-    docker save my-image > my-image.tar
+    docker save my-image $(docker history -q my-image | awk '!/<missing>/{print}') > my-image.tar
     mkdir docker-cache
     split -b 100m my-image.tar docker-cache/x
 ```


### PR DESCRIPTION
This is a working example for Docker layer caching. Not sure if it will be considered a bit too complicated for these examples. The complication is mainly due to splitting the image into chunks to workaround the 200MB limit.