### PR TITLE
Add Haskell Example

### DIFF
--- a/examples.md
+++ b/examples.md
@@ -9,6 +9,7 @@
 - [Swift, Objective-C - CocoaPods](#swift-objective-c---cocoapods)
 - [Ruby - Gem](#ruby---gem)
 - [Go - Modules](#go---modules)
+- [Haskell - Cabal](#haskell---cabal)
 
 ## Node - npm
 
@@ -107,4 +108,13 @@ uses: actions/cache@preview
     key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
     restore-keys: |
       ${{ runner.os }}-go-
+```
+
+## Haskell - Cabal
+
+```yaml
+- uses: actions/cache@preview
+  with:
+    path: ~/.cabal/store
+    key: ${{ runner.os }}-haskell-${{ matrix.ghc }}
 ```

--- a/examples.md
+++ b/examples.md
@@ -118,3 +118,5 @@ uses: actions/cache@preview
     path: ~/.cabal/store
     key: ${{ runner.os }}-haskell-${{ matrix.ghc }}
 ```
+
+Note: `matrix.ghc` denotes the Haskell compiler version (see also https://github.com/actions/setup-haskell)

--- a/examples.md
+++ b/examples.md
@@ -113,7 +113,7 @@ uses: actions/cache@preview
 ## Haskell - Cabal
 
 ```yaml
-- uses: actions/cache@preview
+- uses: actions/cache@v1
   with:
     path: ~/.cabal/store
     key: ${{ runner.os }}-haskell-${{ matrix.ghc }}


### PR DESCRIPTION
Cabal's [Nix-style Local Builds](https://www.haskell.org/cabal/users-guide/nix-local-build-overview.html) caches built dependencies in `~/.cabal/store`; caching this folder often makes a difference between  15+ minute build-times or a speedy 1-2 minute job.