### PR TITLE
Encode cache keys

### DIFF
--- a/src/restore.ts
+++ b/src/restore.ts
@@ -17,11 +17,15 @@ async function run() {
         );
         core.debug(`Cache Path: ${cachePath}`);
 
-        const primaryKey = core.getInput(Inputs.Key, { required: true });
+        const keys = [
+            core.getInput(Inputs.Key, { required: true }),
+            ...core
+                .getInput(Inputs.RestoreKeys)
+                .split(/\s*\n\s*/)
+                .filter(x => x)
+        ].map(key => encodeURIComponent(key).replace(/%/g, " "));
+        const primaryKey = keys[0];
         core.saveState(State.CacheKey, primaryKey);
-
-        const restoreKeys = core.getInput(Inputs.RestoreKeys).split("\n");
-        const keys = [primaryKey, ...restoreKeys];
 
         core.debug("Resolved Keys:");
         core.debug(JSON.stringify(keys));
@@ -36,13 +40,6 @@ async function run() {
             if (key.length > 512) {
                 core.setFailed(
                     `Key Validation Error: ${key} cannot be larger than 512 characters.`
-                );
-                return;
-            }
-            const regex = /^[^,]*$/;
-            if (!regex.test(key)) {
-                core.setFailed(
-                    `Key Validation Error: ${key} cannot contain commas.`
                 );
                 return;
             }


### PR DESCRIPTION
Reading the restore portion of this action:
https://github.com/actions/cache/blob/ce4a52af49a216b8cf2738812233f8a51dee225d/src/cacheHttpClient.ts#L18-L20

The key-separating commas are getting encoded alongside most non-alphanumeric characters as well, so the middleware must be processing the raw key values instead of encoded ones, which it apparently cannot handle.

So let's encode the keys on top to ensure smooth operations - that way we can remove the restrictions on using commas in key names as well.



Fixes #53