### PR TITLE
Bump cache limit to 400MB

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ See [Examples](examples.md)
 
 ## Cache Limits
 
-Individual caches are limited to 200MB and a repository can have up to 2GB of caches. Once the 2GB limit is reached, older caches will be evicted based on when the cache was last accessed.  Caches that are not accessed within the last week will also be evicted.
+Individual caches are limited to 400MB and a repository can have up to 2GB of caches. Once the 2GB limit is reached, older caches will be evicted based on when the cache was last accessed.  Caches that are not accessed within the last week will also be evicted.
 
 ## Skipping steps based on cache-hit
 

--- a/src/save.ts
+++ b/src/save.ts
@@ -54,12 +54,12 @@ async function run() {
         core.debug(`Tar Path: ${tarPath}`);
         await exec(`"${tarPath}"`, args);
 
-        const fileSizeLimit = 200 * 1024 * 1024; // 200MB
+        const fileSizeLimit = 400 * 1024 * 1024; // 400MB
         const archiveFileSize = fs.statSync(archivePath).size;
         core.debug(`File Size: ${archiveFileSize}`);
         if (archiveFileSize > fileSizeLimit) {
             core.warning(
-                `Cache size of ${archiveFileSize} bytes is over the 200MB limit, not saving cache.`
+                `Cache size of ${archiveFileSize} bytes is over the 400MB limit, not saving cache.`
             );
             return;
         }


### PR DESCRIPTION
We've updated the server-side to allow for increasing the individual cache limit to 400MB. We're continuing to work on increasing this limit.

Related: https://github.com/actions/cache/issues/6

Release notes: This will be part of release `v1.0.1`, if you're pinned to `v1` you'll get this updated.