### PR TITLE
Remove recommendation to cache node_modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Create a workflow `.yml` file in your repositories `.github/workflows` directory
 ### Example workflow
 
 ```yaml
-name: Example Caching with npm
+name: Caching Primes
 
 on: push
 
@@ -39,22 +39,19 @@ jobs:
     steps:
     - uses: actions/checkout@v1
 
-    - name: Cache node modules
+    - name: Cache Primes
+      id: cache-primes
       uses: actions/cache@v1
       with:
-        path: node_modules
-        key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
-        restore-keys: |
-          ${{ runner.os }}-node-
+        path: prime-numbers
+        key: ${{ runner.os }}-primes
 
-    - name: Install Dependencies
-      run: npm install
+    - name: Generate Prime Numbers
+      if: steps.cache-primes.outputs.cache-hit != 'true'
+      run: /generate-primes.sh -d prime-numbers
     
-    - name: Build
-      run: npm run build
-
-    - name: Test
-      run: npm run test
+    - name: Use Prime Numbers
+      run: /primes.sh -d prime-numbers
 ```
 
 ## Ecosystem Examples

--- a/examples.md
+++ b/examples.md
@@ -111,8 +111,6 @@ For npm, cache files are stored in `~/.npm` on Posix, or `%AppData%/npm-cache` o
       ${{ runner.os }}-node-
 ```
 
-</details>
-
 ## Node - Yarn
 
 ```yaml

--- a/examples.md
+++ b/examples.md
@@ -105,7 +105,7 @@ For npm, cache files are stored in `~/.npm` on Posix, or `%AppData%/npm-cache` o
     echo "::set-output name=dir::$(npm config get cache)"
 - uses: actions/cache@v1
   with:
-    path: ${{ steps.composer-cache.outputs.dir }}
+    path: ${{ steps.npm-cache.outputs.dir }}
     key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
     restore-keys: |
       ${{ runner.os }}-node-

--- a/examples.md
+++ b/examples.md
@@ -70,14 +70,48 @@ Using [NuGet lock files](https://docs.microsoft.com/nuget/consume-packages/packa
 
 ## Node - npm
 
+For npm, cache files are stored in `~/.npm` on Posix, or `%AppData%/npm-cache` on Windows. See https://docs.npmjs.com/cli/cache#cache
+
+>Note: It is not recommended to cache `node_modules`, as it can break across Node versions and won't work with `npm ci`
+
+### macOS and Ubuntu
+
 ```yaml
 - uses: actions/cache@v1
   with:
-    path: node_modules
+    path: ~/.npm
     key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
     restore-keys: |
       ${{ runner.os }}-node-
 ```
+
+### Windows
+
+```yaml
+- uses: actions/cache@v1
+  with:
+    path: ~\AppData\Roaming\npm-cache
+    key: ${{ runner.os }}-node-${{ hashFiles('**\package-lock.json') }}
+    restore-keys: |
+      ${{ runner.os }}-node-
+```
+
+### Using multiple systems and `npm config`
+
+```yaml  
+- name: Get npm cache directory
+  id: npm-cache
+  run: |
+    echo "::set-output name=dir::$(npm config get cache)"
+- uses: actions/cache@v1
+  with:
+    path: ${{ steps.composer-cache.outputs.dir }}
+    key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+    restore-keys: |
+      ${{ runner.os }}-node-
+```
+
+</details>
 
 ## Node - Yarn
 


### PR DESCRIPTION
Resolves https://github.com/actions/cache/issues/67

It's not recommended to cache `node_modules`, so while it may work for basic examples it can cause issues and doesn't work with `npm ci`. `npm` has a folder that we should cache instead, see https://docs.npmjs.com/cli/cache#cache

Added simple examples for Ubuntu, macOS, and Windows as well as a cross-platform scenario that should work for all three.

Also updated the Example Workflow to be a more generic example of caching