### PR TITLE
Update yarn cache example

### DIFF
--- a/examples.md
+++ b/examples.md
@@ -80,12 +80,17 @@ Using [NuGet lock files](https://docs.microsoft.com/nuget/consume-packages/packa
 ```
 
 ## Node - Yarn
+The yarn cache directory will depend on your operating system and version of `yarn`. See https://yarnpkg.com/lang/en/docs/cli/cache/ for more info.
 
 ```yaml
+- name: Get yarn cache
+  id: yarn-cache
+  run: echo "::set-output name=dir::$(yarn cache dir)"
+
 - uses: actions/cache@v1
   with:
-    path: ~/.cache/yarn
-    key: ${{ runner.os }}-yarn-${{ hashFiles(format('{0}{1}', github.workspace, '/yarn.lock')) }}
+    path: ${{ steps.yarn-cache.outputs.dir }}
+    key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock')) }}
     restore-keys: |
       ${{ runner.os }}-yarn-
 ```

--- a/examples.md
+++ b/examples.md
@@ -90,7 +90,7 @@ The yarn cache directory will depend on your operating system and version of `ya
 - uses: actions/cache@v1
   with:
     path: ${{ steps.yarn-cache.outputs.dir }}
-    key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock')) }}
+    key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
     restore-keys: |
       ${{ runner.os }}-yarn-
 ```


### PR DESCRIPTION
Caching `~/.cache/yarn` doesn't work for all scenarios, and in the case of https://github.com/actions/cache/issues/60 contained extra files not needed in the cache.

Using `yarn cache dir` retrieves the correct directory based on the current yarn config, see https://yarnpkg.com/lang/en/docs/cli/cache/

For the hosted runners this resolves to:
- windows-latest: `C:\Users\runneradmin\AppData\Local\Yarn\Cache\v6`
- macOS-latest: `/Users/runner/Library/Caches/Yarn/v6`
- ubuntu-latest: `/home/runner/.cache/yarn/v6`