### PR TITLE
Format cache size and display on info

### DIFF
--- a/__tests__/restore.test.ts
+++ b/__tests__/restore.test.ts
@@ -219,7 +219,7 @@ test("restore with cache found", async () => {
     const setCacheStateMock = jest.spyOn(actionUtils, "setCacheState");
     const downloadCacheMock = jest.spyOn(cacheHttpClient, "downloadCache");
 
-    const fileSize = 142;
+    const fileSize = 62915000;
     const getArchiveFileSizeMock = jest
         .spyOn(actionUtils, "getArchiveFileSize")
         .mockReturnValue(fileSize);
@@ -236,6 +236,7 @@ test("restore with cache found", async () => {
     expect(createTempDirectoryMock).toHaveBeenCalledTimes(1);
     expect(downloadCacheMock).toHaveBeenCalledWith(cacheEntry, archivePath);
     expect(getArchiveFileSizeMock).toHaveBeenCalledWith(archivePath);
+    expect(infoMock).toHaveBeenCalledWith(`Cache Size: ~60 MB (62915000 B)`);
     expect(mkdirMock).toHaveBeenCalledWith(cachePath);
 
     const IS_WINDOWS = process.platform === "win32";
@@ -312,6 +313,7 @@ test("restore with cache found for restore key", async () => {
     expect(createTempDirectoryMock).toHaveBeenCalledTimes(1);
     expect(downloadCacheMock).toHaveBeenCalledWith(cacheEntry, archivePath);
     expect(getArchiveFileSizeMock).toHaveBeenCalledWith(archivePath);
+    expect(infoMock).toHaveBeenCalledWith(`Cache Size: ~0 MB (142 B)`);
     expect(mkdirMock).toHaveBeenCalledWith(cachePath);
 
     const IS_WINDOWS = process.platform === "win32";

--- a/src/restore.ts
+++ b/src/restore.ts
@@ -72,7 +72,11 @@ async function run() {
             await cacheHttpClient.downloadCache(cacheEntry, archivePath);
 
             const archiveFileSize = utils.getArchiveFileSize(archivePath);
-            core.debug(`File Size: ${archiveFileSize}`);
+            core.info(
+                `Cache Size: ~${Math.round(
+                    archiveFileSize / (1024 * 1024)
+                )} MB (${archiveFileSize} B)`
+            );
 
             io.mkdirP(cachePath);
 

--- a/src/save.ts
+++ b/src/save.ts
@@ -59,7 +59,9 @@ async function run() {
         core.debug(`File Size: ${archiveFileSize}`);
         if (archiveFileSize > fileSizeLimit) {
             core.warning(
-                `Cache size of ${archiveFileSize} bytes is over the 400MB limit, not saving cache.`
+                `Cache size of ~${Math.round(
+                    archiveFileSize / (1024 * 1024)
+                )} MB (${archiveFileSize} B) is over the 400MB limit, not saving cache.`
             );
             return;
         }


### PR DESCRIPTION
Resolves https://github.com/actions/cache/issues/80 and https://github.com/actions/cache/issues/84

- Printing out cache file size on info (`stdout`) instead of debug
- Formatting message to display MB and B