### PR TITLE
Use cache in workflows

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -29,6 +29,18 @@ jobs:
       with:
         node-version: '12.x'
 
+    - name: Get npm cache directory
+      id: npm-cache
+      run: |
+        echo "::set-output name=dir::$(npm config get cache)"
+
+    - uses: actions/cache@v1
+      with:
+        path: ${{ steps.npm-cache.outputs.dir }}
+        key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+        restore-keys: |
+          ${{ runner.os }}-node-
+
     - run: npm ci
 
     - name: Prettier Format Check


### PR DESCRIPTION
Using `actions/cache` in the test workflows for PR and CI validation.

See [Wiki: Recursion](https://en.wikipedia.org/wiki/Recursion)