### PR TITLE
Fix race condition in restore

### DIFF
--- a/src/restore.ts
+++ b/src/restore.ts
@@ -86,7 +86,8 @@ async function run(): Promise<void> {
                 )} MB (${archiveFileSize} B)`
             );
 
-            io.mkdirP(cachePath);
+            // Create directory to extract tar into
+            await io.mkdirP(cachePath);
 
             // http://man7.org/linux/man-pages/man1/tar.1.html
             // tar [-options] <name of the tar archive> [files or directories which to add into archive]


### PR DESCRIPTION
Before extracting the cache tar file, we create a directory at `path` using `io.mkdirP`.

This is an async function (see https://github.com/actions/toolkit/blob/master/packages/io/src/io.ts#L163) so we need to `await` it.

Not awaiting it caused a race condition where sometimes the directory would not be created by the time the tar is extracted, see https://github.com/actions/cache/issues/97