### PR TITLE
Remove validation failures and warning annotations

### DIFF
--- a/__tests__/actionUtils.test.ts
+++ b/__tests__/actionUtils.test.ts
@@ -162,6 +162,16 @@ test("getCacheState with valid state", () => {
     expect(getStateMock).toHaveBeenCalledTimes(1);
 });
 
+test("logWarning logs a message with a warning prefix", () => {
+    const message = "A warning occurred.";
+
+    const infoMock = jest.spyOn(core, "info");
+
+    actionUtils.logWarning(message);
+
+    expect(infoMock).toHaveBeenCalledWith(`[warning]${message}`);
+});
+
 test("isValidEvent returns false for unknown event", () => {
     const event = "foo";
     process.env[Events.Key] = event;

--- a/__tests__/restore.test.ts
+++ b/__tests__/restore.test.ts
@@ -50,14 +50,16 @@ afterEach(() => {
     delete process.env[Events.Key];
 });
 
-test("restore with invalid event", async () => {
+test("restore with invalid event outputs warning", async () => {
+    const logWarningMock = jest.spyOn(actionUtils, "logWarning");
     const failedMock = jest.spyOn(core, "setFailed");
     const invalidEvent = "commit_comment";
     process.env[Events.Key] = invalidEvent;
     await run();
-    expect(failedMock).toHaveBeenCalledWith(
+    expect(logWarningMock).toHaveBeenCalledWith(
         `Event Validation Error: The event type ${invalidEvent} is not supported. Only push, pull_request events are supported at this time.`
     );
+    expect(failedMock).toHaveBeenCalledTimes(0);
 });
 
 test("restore with no path should fail", async () => {
@@ -126,7 +128,6 @@ test("restore with no cache found", async () => {
     });
 
     const infoMock = jest.spyOn(core, "info");
-    const warningMock = jest.spyOn(core, "warning");
     const failedMock = jest.spyOn(core, "setFailed");
     const stateMock = jest.spyOn(core, "saveState");
 
@@ -138,7 +139,6 @@ test("restore with no cache found", async () => {
     await run();
 
     expect(stateMock).toHaveBeenCalledWith("CACHE_KEY", key);
-    expect(warningMock).toHaveBeenCalledTimes(0);
     expect(failedMock).toHaveBeenCalledTimes(0);
 
     expect(infoMock).toHaveBeenCalledWith(
@@ -153,7 +153,7 @@ test("restore with server error should fail", async () => {
         key
     });
 
-    const warningMock = jest.spyOn(core, "warning");
+    const logWarningMock = jest.spyOn(actionUtils, "logWarning");
     const failedMock = jest.spyOn(core, "setFailed");
     const stateMock = jest.spyOn(core, "saveState");
 
@@ -168,8 +168,8 @@ test("restore with server error should fail", async () => {
 
     expect(stateMock).toHaveBeenCalledWith("CACHE_KEY", key);
 
-    expect(warningMock).toHaveBeenCalledTimes(1);
-    expect(warningMock).toHaveBeenCalledWith("HTTP Error Occurred");
+    expect(logWarningMock).toHaveBeenCalledTimes(1);
+    expect(logWarningMock).toHaveBeenCalledWith("HTTP Error Occurred");
 
     expect(setCacheHitOutputMock).toHaveBeenCalledTimes(1);
     expect(setCacheHitOutputMock).toHaveBeenCalledWith(false);
@@ -187,7 +187,6 @@ test("restore with restore keys and no cache found", async () => {
     });
 
     const infoMock = jest.spyOn(core, "info");
-    const warningMock = jest.spyOn(core, "warning");
     const failedMock = jest.spyOn(core, "setFailed");
     const stateMock = jest.spyOn(core, "saveState");
 
@@ -199,7 +198,6 @@ test("restore with restore keys and no cache found", async () => {
     await run();
 
     expect(stateMock).toHaveBeenCalledWith("CACHE_KEY", key);
-    expect(warningMock).toHaveBeenCalledTimes(0);
     expect(failedMock).toHaveBeenCalledTimes(0);
 
     expect(infoMock).toHaveBeenCalledWith(
@@ -216,7 +214,6 @@ test("restore with cache found", async () => {
     });
 
     const infoMock = jest.spyOn(core, "info");
-    const warningMock = jest.spyOn(core, "warning");
     const failedMock = jest.spyOn(core, "setFailed");
     const stateMock = jest.spyOn(core, "saveState");
 
@@ -281,7 +278,6 @@ test("restore with cache found", async () => {
     expect(setCacheHitOutputMock).toHaveBeenCalledWith(true);
 
     expect(infoMock).toHaveBeenCalledWith(`Cache restored from key: ${key}`);
-    expect(warningMock).toHaveBeenCalledTimes(0);
     expect(failedMock).toHaveBeenCalledTimes(0);
 });
 
@@ -296,7 +292,6 @@ test("restore with a pull request event and cache found", async () => {
     process.env[Events.Key] = Events.PullRequest;
 
     const infoMock = jest.spyOn(core, "info");
-    const warningMock = jest.spyOn(core, "warning");
     const failedMock = jest.spyOn(core, "setFailed");
     const stateMock = jest.spyOn(core, "saveState");
 
@@ -362,7 +357,6 @@ test("restore with a pull request event and cache found", async () => {
     expect(setCacheHitOutputMock).toHaveBeenCalledWith(true);
 
     expect(infoMock).toHaveBeenCalledWith(`Cache restored from key: ${key}`);
-    expect(warningMock).toHaveBeenCalledTimes(0);
     expect(failedMock).toHaveBeenCalledTimes(0);
 });
 
@@ -377,7 +371,6 @@ test("restore with cache found for restore key", async () => {
     });
 
     const infoMock = jest.spyOn(core, "info");
-    const warningMock = jest.spyOn(core, "warning");
     const failedMock = jest.spyOn(core, "setFailed");
     const stateMock = jest.spyOn(core, "saveState");
 
@@ -445,6 +438,5 @@ test("restore with cache found for restore key", async () => {
     expect(infoMock).toHaveBeenCalledWith(
         `Cache restored from key: ${restoreKey}`
     );
-    expect(warningMock).toHaveBeenCalledTimes(0);
     expect(failedMock).toHaveBeenCalledTimes(0);
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "cache",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cache",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "private": true,
   "description": "Cache dependencies and build outputs",
   "main": "dist/restore/index.js",

--- a/src/restore.ts
+++ b/src/restore.ts
@@ -10,13 +10,14 @@ async function run(): Promise<void> {
     try {
         // Validate inputs, this can cause task failure
         if (!utils.isValidEvent()) {
-            core.setFailed(
+            utils.logWarning(
                 `Event Validation Error: The event type ${
                     process.env[Events.Key]
                 } is not supported. Only ${utils
                     .getSupportedEvents()
                     .join(", ")} events are supported at this time.`
             );
+            return;
         }
 
         const cachePath = utils.resolvePath(
@@ -118,7 +119,7 @@ async function run(): Promise<void> {
                 `Cache restored from key: ${cacheEntry && cacheEntry.cacheKey}`
             );
         } catch (error) {
-            core.warning(error.message);
+            utils.logWarning(error.message);
             utils.setCacheHitOutput(false);
         }
     } catch (error) {

--- a/src/utils/actionUtils.ts
+++ b/src/utils/actionUtils.ts
@@ -77,7 +77,7 @@ export function getCacheState(): ArtifactCacheEntry | undefined {
     return undefined;
 }
 
-export function logWarning(message: string) {
+export function logWarning(message: string): void {
     const warningPrefix = "[warning]";
     core.info(`${warningPrefix}${message}`);
 }

--- a/src/utils/actionUtils.ts
+++ b/src/utils/actionUtils.ts
@@ -77,6 +77,11 @@ export function getCacheState(): ArtifactCacheEntry | undefined {
     return undefined;
 }
 
+export function logWarning(message: string) {
+    const warningPrefix = "[warning]";
+    core.info(`${warningPrefix}${message}`);
+}
+
 export function resolvePath(filePath: string): string {
     if (filePath[0] === "~") {
         const home = os.homedir();


### PR DESCRIPTION
With https://github.com/actions/cache/pull/68, unsupported event types throw errors instead of failing during save. This breaks multi-event workflows that use the cache (such as a workflow that runs on schedules and push), as the scheduled build will now break due to the cache step failing.

While an `if` statement could be used, requiring that for a common workflow scenario can get verbose, especially as more events are added.

Example using `if`:
```yaml
   - name: My Cache
      if: github.event_name == 'push' || github.event_name == 'pull_request'
      uses: actions/cache@v1
      with:
        path: .github
        key: ${{ runner.os }}-github
```

This PR changes the validation error into a warning and returns early.

Also updated to prefix warnings with a `[warning]` and log them normally,  which will allow the highlighting in the logs without creating annotations.
Example using the `[warning]` prefix:
<img width="305" alt="Screen Shot 2019-11-20 at 1 27 21 PM" src="https://user-images.githubusercontent.com/16631042/69266626-80618d00-0b99-11ea-9ae7-04de4ae88134.png">
