### PR TITLE
Mask download URL in logs

### DIFF
--- a/src/cacheHttpClient.ts
+++ b/src/cacheHttpClient.ts
@@ -61,11 +61,12 @@ export async function getCacheEntry(
         throw new Error(`Cache service responded with ${response.statusCode}`);
     }
     const cacheResult = response.result;
-    core.debug(`Cache Result:`);
-    core.debug(JSON.stringify(cacheResult));
     if (!cacheResult || !cacheResult.archiveLocation) {
         throw new Error("Cache not found.");
     }
+    core.setSecret(cacheResult.archiveLocation);
+    core.debug(`Cache Result:`);
+    core.debug(JSON.stringify(cacheResult));
 
     return cacheResult;
 }


### PR DESCRIPTION
When debug logging is turned on, the download URL for the cache is logged. While it is recommended that sensitive information is not cached, users may unknowingly be leaking the contents of their cache when turning on debugging.

`core.setSecret` will mask the value from the logs.