### PR TITLE
Update Ruby example in documentation to specify bundler path

### DIFF
--- a/examples.md
+++ b/examples.md
@@ -223,9 +223,9 @@ When dependencies are installed later in the workflow, we must specify the same 
 
 ```yaml
 - name: Bundle install
-        run: |
-          bundle config path vendor/bundle
-          bundle install --jobs 4 --retry 3
+  run: |
+    bundle config path vendor/bundle
+    bundle install --jobs 4 --retry 3
 ```
 
 ## Rust - Cargo

--- a/examples.md
+++ b/examples.md
@@ -219,6 +219,14 @@ Replace `~/.cache/pip` with the correct `path` if not using Ubuntu.
     restore-keys: |
       ${{ runner.os }}-gem-
 ```
+When dependencies are installed later in the workflow, we must specify the same path for the bundler.
+
+```yaml
+- name: Bundle install
+        run: |
+          bundle config path vendor/bundle
+          bundle install --jobs 4 --retry 3
+```
 
 ## Rust - Cargo
 


### PR DESCRIPTION
As per the description in #112, we need to specify a path when configuring bundler for dependency installation.