### PR TITLE
Add Another C# Example to use personal cache folder

### DIFF
--- a/examples.md
+++ b/examples.md
@@ -1,6 +1,6 @@
 # Examples
 
-- [C# - Nuget](#c---nuget)
+- [C# - NuGet](#c---nuget)
 - [Elixir - Mix](#elixir---mix)
 - [Go - Modules](#go---modules)
 - [Java - Gradle](#java---gradle)
@@ -14,16 +14,21 @@
 - [Swift, Objective-C - Carthage](#swift-objective-c---carthage)
 - [Swift, Objective-C - CocoaPods](#swift-objective-c---cocoapods)
 
-## C# - Nuget
+## C# - NuGet
 Using [NuGet lock files](https://docs.microsoft.com/nuget/consume-packages/package-references-in-project-files#locking-dependencies):
 
 ```yaml
-- uses: actions/cache@v1
-  with:
-    path: ~/.nuget/packages
-    key: ${{ runner.os }}-nuget-${{ hashFiles('**/packages.lock.json') }}
-    restore-keys: |
-      ${{ runner.os }}-nuget-
+env:
+  # Use personal cache folder because global cache may have huge packages like Xamarin.
+  # Learn more, see issue #115.
+  NUGET_PACKAGES: ${{ github.workspace }}/.nuget/packages
+steps:
+  - uses: actions/cache@v1
+    with:
+      path: ${{ github.workspace }}/.nuget/packages
+      key: ${{ runner.os }}-nuget-${{ hashFiles('**/packages.lock.json') }}
+      restore-keys: |
+        ${{ runner.os }}-nuget-
 ```
 
 ## Elixir - Mix

--- a/examples.md
+++ b/examples.md
@@ -28,7 +28,7 @@ Using [NuGet lock files](https://docs.microsoft.com/nuget/consume-packages/packa
 
 Depending on the environment, huge packages might be pre-installed in the global cache folder.
 If you do not want to include them, consider to move the cache folder like below.
->Note: This workflow does not work for projects that require files to be placed in the global.
+>Note: This workflow does not work for projects that require files to be placed in user profile package folder
 ```yaml
 env:
   NUGET_PACKAGES: ${{ github.workspace }}/.nuget/packages

--- a/examples.md
+++ b/examples.md
@@ -18,9 +18,19 @@
 Using [NuGet lock files](https://docs.microsoft.com/nuget/consume-packages/package-references-in-project-files#locking-dependencies):
 
 ```yaml
+- uses: actions/cache@v1
+  with:
+    path: ~/.nuget/packages
+    key: ${{ runner.os }}-nuget-${{ hashFiles('**/packages.lock.json') }}
+    restore-keys: |
+      ${{ runner.os }}-nuget-
+```
+
+Depending on the environment, huge packages might be pre-installed in the global cache folder.
+If you do not want to include them, consider to move the cache folder like below.
+>Note: This workflow does not work for projects that require files to be placed in the global.
+```yaml
 env:
-  # Use personal cache folder because global cache may have huge packages like Xamarin.
-  # Learn more, see issue #115.
   NUGET_PACKAGES: ${{ github.workspace }}/.nuget/packages
 steps:
   - uses: actions/cache@v1


### PR DESCRIPTION
Resolved #115

`macos-latest` host runner includes the .NET Core SDK and large libraries such as Xamarin.
Therefore, `~/.nuget/packages` folder is so large that it cannot be cached by `actions/cache`.

This PR changes the C# example to use a personal cache folder.

This is my example workflow and it works fine.
https://github.com/nogic1008/dotnet-ci-example/blob/master/.github/workflows/dotnetcore.yml