### PR TITLE
Use BSD tar on windows

### DIFF
--- a/__tests__/tar.test.ts
+++ b/__tests__/tar.test.ts
@@ -1,0 +1,60 @@
+import * as exec from "@actions/exec";
+import * as io from "@actions/io";
+import * as tar from "../src/tar";
+
+jest.mock("@actions/exec");
+jest.mock("@actions/io");
+
+beforeAll(() => {
+    process.env["windir"] = "C:";
+
+    jest.spyOn(io, "which").mockImplementation(tool => {
+        return Promise.resolve(tool);
+    });
+});
+
+afterAll(() => {
+    delete process.env["windir"];
+});
+
+test("extract tar", async () => {
+    const mkdirMock = jest.spyOn(io, "mkdirP");
+    const execMock = jest.spyOn(exec, "exec");
+
+    const archivePath = "cache.tar";
+    const targetDirectory = "~/.npm/cache";
+    await tar.extractTar(archivePath, targetDirectory);
+
+    expect(mkdirMock).toHaveBeenCalledWith(targetDirectory);
+
+    const IS_WINDOWS = process.platform === "win32";
+    const tarPath = IS_WINDOWS ? "C:\\System32\\tar.exe" : "tar";
+    expect(execMock).toHaveBeenCalledTimes(1);
+    expect(execMock).toHaveBeenCalledWith(`"${tarPath}"`, [
+        "-xz",
+        "-f",
+        archivePath,
+        "-C",
+        targetDirectory
+    ]);
+});
+
+test("create tar", async () => {
+    const execMock = jest.spyOn(exec, "exec");
+
+    const archivePath = "cache.tar";
+    const sourceDirectory = "~/.npm/cache";
+    await tar.createTar(archivePath, sourceDirectory);
+
+    const IS_WINDOWS = process.platform === "win32";
+    const tarPath = IS_WINDOWS ? "C:\\System32\\tar.exe" : "tar";
+    expect(execMock).toHaveBeenCalledTimes(1);
+    expect(execMock).toHaveBeenCalledWith(`"${tarPath}"`, [
+        "-cz",
+        "-f",
+        archivePath,
+        "-C",
+        sourceDirectory,
+        "."
+    ]);
+});

--- a/__tests__/tar.test.ts
+++ b/__tests__/tar.test.ts
@@ -22,7 +22,9 @@ test("extract tar", async () => {
     expect(mkdirMock).toHaveBeenCalledWith(targetDirectory);
 
     const IS_WINDOWS = process.platform === "win32";
-    const tarPath = IS_WINDOWS ? `${process.env["windir"]}\\System32\\tar.exe` : "tar";
+    const tarPath = IS_WINDOWS
+        ? `${process.env["windir"]}\\System32\\tar.exe`
+        : "tar";
     expect(execMock).toHaveBeenCalledTimes(1);
     expect(execMock).toHaveBeenCalledWith(`"${tarPath}"`, [
         "-xz",
@@ -41,7 +43,9 @@ test("create tar", async () => {
     await tar.createTar(archivePath, sourceDirectory);
 
     const IS_WINDOWS = process.platform === "win32";
-    const tarPath = IS_WINDOWS ? `${process.env["windir"]}\\System32\\tar.exe` : "tar";
+    const tarPath = IS_WINDOWS
+        ? `${process.env["windir"]}\\System32\\tar.exe`
+        : "tar";
     expect(execMock).toHaveBeenCalledTimes(1);
     expect(execMock).toHaveBeenCalledWith(`"${tarPath}"`, [
         "-cz",

--- a/__tests__/tar.test.ts
+++ b/__tests__/tar.test.ts
@@ -6,15 +6,9 @@ jest.mock("@actions/exec");
 jest.mock("@actions/io");
 
 beforeAll(() => {
-    process.env["windir"] = "C:";
-
     jest.spyOn(io, "which").mockImplementation(tool => {
         return Promise.resolve(tool);
     });
-});
-
-afterAll(() => {
-    delete process.env["windir"];
 });
 
 test("extract tar", async () => {
@@ -28,7 +22,7 @@ test("extract tar", async () => {
     expect(mkdirMock).toHaveBeenCalledWith(targetDirectory);
 
     const IS_WINDOWS = process.platform === "win32";
-    const tarPath = IS_WINDOWS ? "C:\\System32\\tar.exe" : "tar";
+    const tarPath = IS_WINDOWS ? `${process.env["windir"]}\\System32\\tar.exe` : "tar";
     expect(execMock).toHaveBeenCalledTimes(1);
     expect(execMock).toHaveBeenCalledWith(`"${tarPath}"`, [
         "-xz",
@@ -47,7 +41,7 @@ test("create tar", async () => {
     await tar.createTar(archivePath, sourceDirectory);
 
     const IS_WINDOWS = process.platform === "win32";
-    const tarPath = IS_WINDOWS ? "C:\\System32\\tar.exe" : "tar";
+    const tarPath = IS_WINDOWS ? `${process.env["windir"]}\\System32\\tar.exe` : "tar";
     expect(execMock).toHaveBeenCalledTimes(1);
     expect(execMock).toHaveBeenCalledWith(`"${tarPath}"`, [
         "-cz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -4859,9 +4859,9 @@
       "dev": true
     },
     "prettier": {
-      "version": "1.18.2",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.18.2.tgz",
-      "integrity": "sha512-OeHeMc0JhFE9idD4ZdtNibzY0+TPHSpSSb9h8FqtP+YnoZZ1sl8Vc9b1sasjfymH3SonAF4QcA2+mzHPhMvIiw==",
+      "version": "1.19.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.19.1.tgz",
+      "integrity": "sha512-s7PoyDv/II1ObgQunCbB9PdLmUcBZcnWOcxDh7O0N/UwDEsHyqkW+Qh28jW+mVuCdx7gLB0BotYI1Y6uI9iyew==",
       "dev": true
     },
     "prettier-linter-helpers": {
@@ -5983,9 +5983,9 @@
       }
     },
     "typescript": {
-      "version": "3.6.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.6.4.tgz",
-      "integrity": "sha512-unoCll1+l+YK4i4F8f22TaNVPRHcD9PA3yCuZ8g5e0qGqlVlJ/8FSateOLLSagn+Yg5+ZwuPkL8LFUc0Jcvksg==",
+      "version": "3.7.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.7.3.tgz",
+      "integrity": "sha512-Mcr/Qk7hXqFBXMN7p7Lusj1ktCBydylfQM/FZCk5glCNQJrCUKPkMHdo9R0MTFWsC/4kPFvDS0fDPvukfCkFsw==",
       "dev": true
     },
     "uglify-js": {

--- a/package.json
+++ b/package.json
@@ -46,8 +46,8 @@
     "jest": "^24.8.0",
     "jest-circus": "^24.7.1",
     "nock": "^11.7.0",
-    "prettier": "1.18.2",
+    "prettier": "^1.19.1",
     "ts-jest": "^24.0.2",
-    "typescript": "^3.6.4"
+    "typescript": "^3.7.3"
   }
 }

--- a/src/restore.ts
+++ b/src/restore.ts
@@ -1,9 +1,8 @@
 import * as core from "@actions/core";
-import { exec } from "@actions/exec";
-import * as io from "@actions/io";
 import * as path from "path";
 import * as cacheHttpClient from "./cacheHttpClient";
 import { Events, Inputs, State } from "./constants";
+import { extractTar } from "./tar";
 import * as utils from "./utils/actionUtils";
 
 async function run(): Promise<void> {
@@ -87,27 +86,7 @@ async function run(): Promise<void> {
                 )} MB (${archiveFileSize} B)`
             );
 
-            // Create directory to extract tar into
-            await io.mkdirP(cachePath);
-
-            // http://man7.org/linux/man-pages/man1/tar.1.html
-            // tar [-options] <name of the tar archive> [files or directories which to add into archive]
-            const IS_WINDOWS = process.platform === "win32";
-            const args = IS_WINDOWS
-                ? [
-                      "-xz",
-                      "--force-local",
-                      "-f",
-                      archivePath.replace(/\\/g, "/"),
-                      "-C",
-                      cachePath.replace(/\\/g, "/")
-                  ]
-                : ["-xz", "-f", archivePath, "-C", cachePath];
-
-            const tarPath = await io.which("tar", true);
-            core.debug(`Tar Path: ${tarPath}`);
-
-            await exec(`"${tarPath}"`, args);
+            await extractTar(archivePath, cachePath);
 
             const isExactKeyMatch = utils.isExactKeyMatch(
                 primaryKey,

--- a/src/save.ts
+++ b/src/save.ts
@@ -1,9 +1,8 @@
 import * as core from "@actions/core";
-import { exec } from "@actions/exec";
-import * as io from "@actions/io";
 import * as path from "path";
 import * as cacheHttpClient from "./cacheHttpClient";
 import { Events, Inputs, State } from "./constants";
+import { createTar } from "./tar";
 import * as utils from "./utils/actionUtils";
 
 async function run(): Promise<void> {
@@ -46,24 +45,7 @@ async function run(): Promise<void> {
         );
         core.debug(`Archive Path: ${archivePath}`);
 
-        // http://man7.org/linux/man-pages/man1/tar.1.html
-        // tar [-options] <name of the tar archive> [files or directories which to add into archive]
-        const IS_WINDOWS = process.platform === "win32";
-        const args = IS_WINDOWS
-            ? [
-                  "-cz",
-                  "--force-local",
-                  "-f",
-                  archivePath.replace(/\\/g, "/"),
-                  "-C",
-                  cachePath.replace(/\\/g, "/"),
-                  "."
-              ]
-            : ["-cz", "-f", archivePath, "-C", cachePath, "."];
-
-        const tarPath = await io.which("tar", true);
-        core.debug(`Tar Path: ${tarPath}`);
-        await exec(`"${tarPath}"`, args);
+        await createTar(archivePath, cachePath);
 
         const fileSizeLimit = 400 * 1024 * 1024; // 400MB
         const archiveFileSize = utils.getArchiveFileSize(archivePath);

--- a/src/tar.ts
+++ b/src/tar.ts
@@ -1,0 +1,27 @@
+import { exec } from "@actions/exec";
+import * as io from "@actions/io";
+
+export async function extractTar(archivePath: string, targetDirectory: string) {
+    // Create directory to extract tar into
+    await io.mkdirP(targetDirectory);
+
+    // http://man7.org/linux/man-pages/man1/tar.1.html
+    // tar [-options] <name of the tar archive> [files or directories which to add into archive]
+    const args = ["-xz", "-f", archivePath, "-C", targetDirectory];
+    await exec(`"${await getTarPath()}"`, args);
+}
+
+export async function createTar(archivePath: string, sourceDirectory: string) {
+    // http://man7.org/linux/man-pages/man1/tar.1.html
+    // tar [-options] <name of the tar archive> [files or directories which to add into archive]
+    const args = ["-cz", "-f", archivePath, "-C", sourceDirectory, "."];
+    await exec(`"${await getTarPath()}"`, args);
+}
+
+async function getTarPath(): Promise<string> {
+    // Explicitly use BSD Tar on Windows
+    const IS_WINDOWS = process.platform === "win32";
+    return IS_WINDOWS
+        ? `${process.env["windir"]}\\System32\\tar.exe`
+        : await io.which("tar", true);
+}

--- a/src/tar.ts
+++ b/src/tar.ts
@@ -1,7 +1,18 @@
 import { exec } from "@actions/exec";
 import * as io from "@actions/io";
 
-export async function extractTar(archivePath: string, targetDirectory: string) {
+async function getTarPath(): Promise<string> {
+    // Explicitly use BSD Tar on Windows
+    const IS_WINDOWS = process.platform === "win32";
+    return IS_WINDOWS
+        ? `${process.env["windir"]}\\System32\\tar.exe`
+        : await io.which("tar", true);
+}
+
+export async function extractTar(
+    archivePath: string,
+    targetDirectory: string
+): Promise<void> {
     // Create directory to extract tar into
     await io.mkdirP(targetDirectory);
 
@@ -11,17 +22,12 @@ export async function extractTar(archivePath: string, targetDirectory: string) {
     await exec(`"${await getTarPath()}"`, args);
 }
 
-export async function createTar(archivePath: string, sourceDirectory: string) {
+export async function createTar(
+    archivePath: string,
+    sourceDirectory: string
+): Promise<void> {
     // http://man7.org/linux/man-pages/man1/tar.1.html
     // tar [-options] <name of the tar archive> [files or directories which to add into archive]
     const args = ["-cz", "-f", archivePath, "-C", sourceDirectory, "."];
     await exec(`"${await getTarPath()}"`, args);
-}
-
-async function getTarPath(): Promise<string> {
-    // Explicitly use BSD Tar on Windows
-    const IS_WINDOWS = process.platform === "win32";
-    return IS_WINDOWS
-        ? `${process.env["windir"]}\\System32\\tar.exe`
-        : await io.which("tar", true);
 }


### PR DESCRIPTION
Resolves https://github.com/actions/cache/issues/91

On the Windows Hosted Runners, GNU tar is prepended to the path from the installation of minGW (http://www.mingw.org/). This version of tar doesn't work out of the box with Windows file paths, and required using `--force-local` and `\` file manipulation to work correctly.

On self-hosted runners, there's no guarantee that `tar` on the PATH will be GNU tar, and BSD tar will fail when encountering the extra `--force-local` option.

This change enforces using the BSD Tar on Windows, allowing for self-hosted runners to use this action. Self-hosted runners without the system tar will fail, but this is better than the current situation where no self-hosted runners work.

Most of the changes in this PR are just moving the `tar` code into its own module to isolate testing and reduce repeated code.

The only behavior change is in `getTarPath`

I verified these changes with a new cache as well as using a cache created by the current `v1` to verify compatibility: https://github.com/joshmgross/cache-canary/runs/346337525