### PR TITLE
Chunked Cache Upload APIs

### DIFF
--- a/__tests__/restore.test.ts
+++ b/__tests__/restore.test.ts
@@ -248,7 +248,7 @@ test("restore with cache found", async () => {
     expect(getCacheMock).toHaveBeenCalledWith([key]);
     expect(setCacheStateMock).toHaveBeenCalledWith(cacheEntry);
     expect(createTempDirectoryMock).toHaveBeenCalledTimes(1);
-    expect(downloadCacheMock).toHaveBeenCalledWith(cacheEntry, archivePath);
+    expect(downloadCacheMock).toHaveBeenCalledWith(cacheEntry.archiveLocation, archivePath);
     expect(getArchiveFileSizeMock).toHaveBeenCalledWith(archivePath);
 
     expect(extractTarMock).toHaveBeenCalledTimes(1);
@@ -312,7 +312,7 @@ test("restore with a pull request event and cache found", async () => {
     expect(getCacheMock).toHaveBeenCalledWith([key]);
     expect(setCacheStateMock).toHaveBeenCalledWith(cacheEntry);
     expect(createTempDirectoryMock).toHaveBeenCalledTimes(1);
-    expect(downloadCacheMock).toHaveBeenCalledWith(cacheEntry, archivePath);
+    expect(downloadCacheMock).toHaveBeenCalledWith(cacheEntry.archiveLocation, archivePath);
     expect(getArchiveFileSizeMock).toHaveBeenCalledWith(archivePath);
     expect(infoMock).toHaveBeenCalledWith(`Cache Size: ~60 MB (62915000 B)`);
 
@@ -377,7 +377,7 @@ test("restore with cache found for restore key", async () => {
     expect(getCacheMock).toHaveBeenCalledWith([key, restoreKey]);
     expect(setCacheStateMock).toHaveBeenCalledWith(cacheEntry);
     expect(createTempDirectoryMock).toHaveBeenCalledTimes(1);
-    expect(downloadCacheMock).toHaveBeenCalledWith(cacheEntry, archivePath);
+    expect(downloadCacheMock).toHaveBeenCalledWith(cacheEntry.archiveLocation, archivePath);
     expect(getArchiveFileSizeMock).toHaveBeenCalledWith(archivePath);
     expect(infoMock).toHaveBeenCalledWith(`Cache Size: ~0 MB (142 B)`);
 

--- a/__tests__/restore.test.ts
+++ b/__tests__/restore.test.ts
@@ -248,7 +248,10 @@ test("restore with cache found", async () => {
     expect(getCacheMock).toHaveBeenCalledWith([key]);
     expect(setCacheStateMock).toHaveBeenCalledWith(cacheEntry);
     expect(createTempDirectoryMock).toHaveBeenCalledTimes(1);
-    expect(downloadCacheMock).toHaveBeenCalledWith(cacheEntry.archiveLocation, archivePath);
+    expect(downloadCacheMock).toHaveBeenCalledWith(
+        cacheEntry.archiveLocation,
+        archivePath
+    );
     expect(getArchiveFileSizeMock).toHaveBeenCalledWith(archivePath);
 
     expect(extractTarMock).toHaveBeenCalledTimes(1);
@@ -312,7 +315,10 @@ test("restore with a pull request event and cache found", async () => {
     expect(getCacheMock).toHaveBeenCalledWith([key]);
     expect(setCacheStateMock).toHaveBeenCalledWith(cacheEntry);
     expect(createTempDirectoryMock).toHaveBeenCalledTimes(1);
-    expect(downloadCacheMock).toHaveBeenCalledWith(cacheEntry.archiveLocation, archivePath);
+    expect(downloadCacheMock).toHaveBeenCalledWith(
+        cacheEntry.archiveLocation,
+        archivePath
+    );
     expect(getArchiveFileSizeMock).toHaveBeenCalledWith(archivePath);
     expect(infoMock).toHaveBeenCalledWith(`Cache Size: ~60 MB (62915000 B)`);
 
@@ -377,7 +383,10 @@ test("restore with cache found for restore key", async () => {
     expect(getCacheMock).toHaveBeenCalledWith([key, restoreKey]);
     expect(setCacheStateMock).toHaveBeenCalledWith(cacheEntry);
     expect(createTempDirectoryMock).toHaveBeenCalledTimes(1);
-    expect(downloadCacheMock).toHaveBeenCalledWith(cacheEntry.archiveLocation, archivePath);
+    expect(downloadCacheMock).toHaveBeenCalledWith(
+        cacheEntry.archiveLocation,
+        archivePath
+    );
     expect(getArchiveFileSizeMock).toHaveBeenCalledWith(archivePath);
     expect(infoMock).toHaveBeenCalledWith(`Cache Size: ~0 MB (142 B)`);
 

--- a/__tests__/save.test.ts
+++ b/__tests__/save.test.ts
@@ -208,7 +208,7 @@ test("save with large cache outputs warning", async () => {
 
     expect(logWarningMock).toHaveBeenCalledTimes(1);
     expect(logWarningMock).toHaveBeenCalledWith(
-        "Cache size of ~4 GB (4294967296 B) is over the 2GB limit, not saving cache."
+        "Cache size of ~4096 MB (4294967296 B) is over the 2GB limit, not saving cache."
     );
 
     expect(failedMock).toHaveBeenCalledTimes(0);

--- a/__tests__/save.test.ts
+++ b/__tests__/save.test.ts
@@ -194,7 +194,7 @@ test("save with large cache outputs warning", async () => {
 
     const createTarMock = jest.spyOn(tar, "createTar");
 
-    const cacheSize = 1024 * 1024 * 1024; //~1GB, over the 400MB limit
+    const cacheSize = 4 * 1024 * 1024 * 1024; //~4GB, over the 2GB limit
     jest.spyOn(actionUtils, "getArchiveFileSize").mockImplementationOnce(() => {
         return cacheSize;
     });
@@ -208,7 +208,7 @@ test("save with large cache outputs warning", async () => {
 
     expect(logWarningMock).toHaveBeenCalledTimes(1);
     expect(logWarningMock).toHaveBeenCalledWith(
-        "Cache size of ~1024 MB (1073741824 B) is over the 400MB limit, not saving cache."
+        "Cache size of ~4 GB (4294967296 B) is over the 2GB limit, not saving cache."
     );
 
     expect(failedMock).toHaveBeenCalledTimes(0);

--- a/__tests__/save.test.ts
+++ b/__tests__/save.test.ts
@@ -240,6 +240,13 @@ test("save with server error outputs warning", async () => {
     const cachePath = path.resolve(inputPath);
     testUtils.setInput(Inputs.Path, inputPath);
 
+    const cacheId = 4;
+    const reserveCacheMock = jest
+        .spyOn(cacheHttpClient, "reserveCache")
+        .mockImplementationOnce(() => {
+            return Promise.resolve(cacheId);
+        });
+
     const createTarMock = jest.spyOn(tar, "createTar");
 
     const saveCacheMock = jest
@@ -250,13 +257,16 @@ test("save with server error outputs warning", async () => {
 
     await run();
 
+    expect(reserveCacheMock).toHaveBeenCalledTimes(1);
+    expect(reserveCacheMock).toHaveBeenCalledWith(primaryKey);
+
     const archivePath = path.join("/foo/bar", "cache.tgz");
 
     expect(createTarMock).toHaveBeenCalledTimes(1);
     expect(createTarMock).toHaveBeenCalledWith(archivePath, cachePath);
 
     expect(saveCacheMock).toHaveBeenCalledTimes(1);
-    expect(saveCacheMock).toHaveBeenCalledWith(primaryKey, archivePath);
+    expect(saveCacheMock).toHaveBeenCalledWith(cacheId, archivePath);
 
     expect(logWarningMock).toHaveBeenCalledTimes(1);
     expect(logWarningMock).toHaveBeenCalledWith("HTTP Error Occurred");
@@ -289,10 +299,21 @@ test("save with valid inputs uploads a cache", async () => {
     const cachePath = path.resolve(inputPath);
     testUtils.setInput(Inputs.Path, inputPath);
 
+    const cacheId = 4;
+    const reserveCacheMock = jest
+        .spyOn(cacheHttpClient, "reserveCache")
+        .mockImplementationOnce(() => {
+            return Promise.resolve(cacheId);
+        });
+
     const createTarMock = jest.spyOn(tar, "createTar");
+
     const saveCacheMock = jest.spyOn(cacheHttpClient, "saveCache");
 
     await run();
+
+    expect(reserveCacheMock).toHaveBeenCalledTimes(1);
+    expect(reserveCacheMock).toHaveBeenCalledWith(primaryKey);
 
     const archivePath = path.join("/foo/bar", "cache.tgz");
 
@@ -300,7 +321,7 @@ test("save with valid inputs uploads a cache", async () => {
     expect(createTarMock).toHaveBeenCalledWith(archivePath, cachePath);
 
     expect(saveCacheMock).toHaveBeenCalledTimes(1);
-    expect(saveCacheMock).toHaveBeenCalledWith(primaryKey, archivePath);
+    expect(saveCacheMock).toHaveBeenCalledWith(cacheId, archivePath);
 
     expect(failedMock).toHaveBeenCalledTimes(0);
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "cache",
-  "version": "1.0.3",
+  "version": "1.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cache",
-  "version": "1.0.3",
+  "version": "1.1.0",
   "private": true,
   "description": "Cache dependencies and build outputs",
   "main": "dist/restore/index.js",

--- a/src/cacheHttpClient.ts
+++ b/src/cacheHttpClient.ts
@@ -12,7 +12,7 @@ import {
     ArtifactCacheEntry,
     CommitCacheRequest,
     ReserveCacheRequest,
-    ReserverCacheResponse
+    ReserveCacheResponse
 } from "./contracts";
 import * as utils from "./utils/actionUtils";
 
@@ -113,7 +113,7 @@ export async function reserveCache(key: string): Promise<number> {
     const reserveCacheRequest: ReserveCacheRequest = {
         key
     };
-    const response = await restClient.create<ReserverCacheResponse>(
+    const response = await restClient.create<ReserveCacheResponse>(
         "caches",
         reserveCacheRequest,
         getRequestOptions()

--- a/src/cacheHttpClient.ts
+++ b/src/cacheHttpClient.ts
@@ -201,7 +201,7 @@ async function uploadFile(
     const fd = fs.openSync(archivePath, "r");
 
     const concurrency = Number(process.env["CACHE_UPLOAD_CONCURRENCY"]) ?? 4; // # of HTTP requests in parallel
-    const MAX_CHUNK_SIZE = Number(process.env["CACHE_UPLOAD_CHUNK_SIZE"]) ?? 32000000; // 32 MB Chunks
+    const MAX_CHUNK_SIZE = Number(process.env["CACHE_UPLOAD_CHUNK_SIZE"]) ?? (32 * 1024 * 1024); // 32 MB Chunks
     core.debug(`Concurrency: ${concurrency} and Chunk Size: ${MAX_CHUNK_SIZE}`);
 
     const parallelUploads = [...new Array(concurrency).keys()];

--- a/src/contracts.d.ts
+++ b/src/contracts.d.ts
@@ -14,6 +14,6 @@ export interface ReserveCacheRequest {
     version?: string;
 }
 
-export interface ReserverCacheResponse {
+export interface ReserveCacheResponse {
     cacheId: number;
 }

--- a/src/contracts.d.ts
+++ b/src/contracts.d.ts
@@ -4,3 +4,16 @@ export interface ArtifactCacheEntry {
     creationTime?: string;
     archiveLocation?: string;
 }
+
+export interface CommitCacheRequest {
+    size: number;
+}
+
+export interface ReserveCacheRequest {
+    key: string;
+    version?: string;
+}
+
+export interface ReserverCacheResponse {
+    cacheId: number;
+}

--- a/src/restore.ts
+++ b/src/restore.ts
@@ -60,7 +60,7 @@ async function run(): Promise<void> {
 
         try {
             const cacheEntry = await cacheHttpClient.getCacheEntry(keys);
-            if (!cacheEntry) {
+            if (!cacheEntry || !cacheEntry?.archiveLocation) {
                 core.info(
                     `Cache not found for input keys: ${keys.join(", ")}.`
                 );
@@ -77,7 +77,7 @@ async function run(): Promise<void> {
             utils.setCacheState(cacheEntry);
 
             // Download the cache from the cache entry
-            await cacheHttpClient.downloadCache(cacheEntry, archivePath);
+            await cacheHttpClient.downloadCache(cacheEntry?.archiveLocation, archivePath);
 
             const archiveFileSize = utils.getArchiveFileSize(archivePath);
             core.info(

--- a/src/restore.ts
+++ b/src/restore.ts
@@ -77,7 +77,10 @@ async function run(): Promise<void> {
             utils.setCacheState(cacheEntry);
 
             // Download the cache from the cache entry
-            await cacheHttpClient.downloadCache(cacheEntry?.archiveLocation, archivePath);
+            await cacheHttpClient.downloadCache(
+                cacheEntry?.archiveLocation,
+                archivePath
+            );
 
             const archiveFileSize = utils.getArchiveFileSize(archivePath);
             core.info(

--- a/src/restore.ts
+++ b/src/restore.ts
@@ -60,7 +60,7 @@ async function run(): Promise<void> {
 
         try {
             const cacheEntry = await cacheHttpClient.getCacheEntry(keys);
-            if (!cacheEntry || !cacheEntry?.archiveLocation) {
+            if (!cacheEntry?.archiveLocation) {
                 core.info(
                     `Cache not found for input keys: ${keys.join(", ")}.`
                 );
@@ -78,7 +78,7 @@ async function run(): Promise<void> {
 
             // Download the cache from the cache entry
             await cacheHttpClient.downloadCache(
-                cacheEntry?.archiveLocation,
+                cacheEntry.archiveLocation,
                 archivePath
             );
 

--- a/src/save.ts
+++ b/src/save.ts
@@ -47,14 +47,14 @@ async function run(): Promise<void> {
 
         await createTar(archivePath, cachePath);
 
-        const fileSizeLimit = 400 * 1024 * 1024; // 400MB
+        const fileSizeLimit = 2 * 1024 * 1024 * 1024; // 2GB per repo limit
         const archiveFileSize = utils.getArchiveFileSize(archivePath);
         core.debug(`File Size: ${archiveFileSize}`);
         if (archiveFileSize > fileSizeLimit) {
             utils.logWarning(
                 `Cache size of ~${Math.round(
-                    archiveFileSize / (1024 * 1024)
-                )} MB (${archiveFileSize} B) is over the 400MB limit, not saving cache.`
+                    archiveFileSize / (1024 * 1024 * 1024)
+                )} GB (${archiveFileSize} B) is over the 2GB limit, not saving cache.`
             );
             return;
         }

--- a/src/save.ts
+++ b/src/save.ts
@@ -34,6 +34,15 @@ async function run(): Promise<void> {
             return;
         }
 
+        core.debug("Reserving Cache");
+        const cacheId = await cacheHttpClient.reserveCache(primaryKey);
+        if (cacheId < 0) {
+            core.info(
+                `Unable to reserve cache with key ${primaryKey}, another job may be creating this cache.`
+            );
+            return;
+        }
+        core.debug(`Cache ID: ${cacheId}`);
         const cachePath = utils.resolvePath(
             core.getInput(Inputs.Path, { required: true })
         );
@@ -59,7 +68,8 @@ async function run(): Promise<void> {
             return;
         }
 
-        await cacheHttpClient.saveCache(primaryKey, archivePath);
+        core.debug("Saving Cache");
+        await cacheHttpClient.saveCache(cacheId, archivePath);
     } catch (error) {
         utils.logWarning(error.message);
     }

--- a/src/save.ts
+++ b/src/save.ts
@@ -36,7 +36,7 @@ async function run(): Promise<void> {
 
         core.debug("Reserving Cache");
         const cacheId = await cacheHttpClient.reserveCache(primaryKey);
-        if (cacheId < 0) {
+        if (cacheId == -1) {
             core.info(
                 `Unable to reserve cache with key ${primaryKey}, another job may be creating this cache.`
             );
@@ -62,13 +62,13 @@ async function run(): Promise<void> {
         if (archiveFileSize > fileSizeLimit) {
             utils.logWarning(
                 `Cache size of ~${Math.round(
-                    archiveFileSize / (1024 * 1024 * 1024)
-                )} GB (${archiveFileSize} B) is over the 2GB limit, not saving cache.`
+                    archiveFileSize / (1024 * 1024)
+                )} MB (${archiveFileSize} B) is over the 2GB limit, not saving cache.`
             );
             return;
         }
 
-        core.debug("Saving Cache");
+        core.debug(`Saving Cache (ID: ${cacheId})`);
         await cacheHttpClient.saveCache(cacheId, archivePath);
     } catch (error) {
         utils.logWarning(error.message);


### PR DESCRIPTION
To enable larger cache sizes, we're updating our internal APIs to prevent network timeouts that occur from the large single upload stream of the previous iteration.

Bumping the per cache limit to match the per repo limit, as that's the only limit we have now.