### PR TITLE
Update Ruby docs. "Gem" -> "Bundler"

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ See [Examples](examples.md) for a list of `actions/cache` implementations for us
 - [Node - Yarn](./examples.md#node---yarn)
 - [PHP - Composer](./examples.md#php---composer)
 - [Python - pip](./examples.md#python---pip)
-- [Ruby - Gem](./examples.md#ruby---gem)
+- [Ruby - Bundler](./examples.md#ruby---bundler)
 - [Rust - Cargo](./examples.md#rust---cargo)
 - [Scala - SBT](./examples.md#scala---sbt)
 - [Swift, Objective-C - Carthage](./examples.md#swift-objective-c---carthage)

--- a/examples.md
+++ b/examples.md
@@ -10,7 +10,7 @@
 - [Node - Yarn](#node---yarn)
 - [PHP - Composer](#php---composer)
 - [Python - pip](#python---pip)
-- [Ruby - Gem](#ruby---gem)
+- [Ruby - Bundler](#ruby---bundler)
 - [Rust - Cargo](#rust---cargo)
 - [Scala - SBT](#scala---sbt)
 - [Swift, Objective-C - Carthage](#swift-objective-c---carthage)

--- a/examples.md
+++ b/examples.md
@@ -248,15 +248,15 @@ Replace `~/.cache/pip` with the correct `path` if not using Ubuntu.
       ${{ runner.os }}-pip-
 ```
 
-## Ruby - Gem
+## Ruby - Bundler
 
 ```yaml
 - uses: actions/cache@v1
   with:
     path: vendor/bundle
-    key: ${{ runner.os }}-gem-${{ hashFiles('**/Gemfile.lock') }}
+    key: ${{ runner.os }}-gems-${{ hashFiles('**/Gemfile.lock') }}
     restore-keys: |
-      ${{ runner.os }}-gem-
+      ${{ runner.os }}-gems-
 ```
 When dependencies are installed later in the workflow, we must specify the same path for the bundler.
 


### PR DESCRIPTION
Small docs tweak.

"Gem" isn't wrong, but not typically what a Ruby developer would think of.

Bundler is the package manager. "Gems" are what it installs.