### PR TITLE
Add renv examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ See [Examples](examples.md) for a list of `actions/cache` implementations for us
 - [Node - Yarn](./examples.md#node---yarn)
 - [PHP - Composer](./examples.md#php---composer)
 - [Python - pip](./examples.md#python---pip)
+- [R - renv](./examples.md#r---renv)
 - [Ruby - Bundler](./examples.md#ruby---bundler)
 - [Rust - Cargo](./examples.md#rust---cargo)
 - [Scala - SBT](./examples.md#scala---sbt)

--- a/examples.md
+++ b/examples.md
@@ -10,6 +10,7 @@
 - [Node - Yarn](#node---yarn)
 - [PHP - Composer](#php---composer)
 - [Python - pip](#python---pip)
+- [R - renv](#r---renv)
 - [Ruby - Bundler](#ruby---bundler)
 - [Rust - Cargo](#rust---cargo)
 - [Scala - SBT](#scala---sbt)
@@ -246,6 +247,55 @@ Replace `~/.cache/pip` with the correct `path` if not using Ubuntu.
     key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
     restore-keys: |
       ${{ runner.os }}-pip-
+```
+
+## R - renv
+
+For renv, the cache directory will vary by OS. Look at https://rstudio.github.io/renv/articles/renv.html#cache
+
+Locations:
+ - Ubuntu: `~/.local/share/renv`
+ - macOS: `~/Library/Application Support/renv`
+ - Windows: `%LOCALAPPDATA%/renv`
+
+### Simple example
+```yaml
+- uses: actions/cache@v1
+  with:
+    path: ~/.local/share/renv
+    key: ${{ runner.os }}-renv-${{ hashFiles('**/renv.lock') }}
+    restore-keys: |
+      ${{ runner.os }}-renv-
+```
+
+Replace `~/.local/share/renv` with the correct `path` if not using Ubuntu.
+
+### Multiple OS's in a workflow
+
+```yaml
+- uses: actions/cache@v1
+  if: startsWith(runner.os, 'Linux')
+  with:
+    path: ~/.local/share/renv
+    key: ${{ runner.os }}-renv-${{ hashFiles('**/renv.lock') }}
+    restore-keys: |
+      ${{ runner.os }}-renv-
+
+- uses: actions/cache@v1
+  if: startsWith(runner.os, 'macOS')
+  with:
+    path: ~/Library/Application Support/renv
+    key: ${{ runner.os }}-renv-${{ hashFiles('**/renv.lock') }}
+    restore-keys: |
+      ${{ runner.os }}-renv-
+
+- uses: actions/cache@v1
+  if: startsWith(runner.os, 'Windows')
+  with:
+    path: ~\AppData\Local\renv
+    key: ${{ runner.os }}-renv-${{ hashFiles('**/renv.lock') }}
+    restore-keys: |
+      ${{ runner.os }}-renv-
 ```
 
 ## Ruby - Bundler


### PR DESCRIPTION
The [renv](https://rstudio.github.io/renv/index.html) is a dependency management toolkit for R.
Sample repository is here https://github.com/uribo/renv_ghaction/actions
