### PR TITLE
Add a restore-only option to support pulling without saving a cache entry

### DIFF
--- a/__tests__/save.test.ts
+++ b/__tests__/save.test.ts
@@ -414,7 +414,7 @@ test("save skipped with restore only", async () => {
     await run();
 
     expect(infoMock).toHaveBeenCalledWith(
-        "Cache action configured for restore-only, skipping save step"
+        "Cache action configured for restore-only, skipping save step."
     );
 
     expect(reserveCacheMock).toHaveBeenCalledTimes(0);

--- a/__tests__/save.test.ts
+++ b/__tests__/save.test.ts
@@ -376,3 +376,47 @@ test("save with valid inputs uploads a cache", async () => {
 
     expect(failedMock).toHaveBeenCalledTimes(0);
 });
+
+test("save skipped with restore only", async () => {
+    const infoMock = jest.spyOn(core, "info");
+
+    const primaryKey = "Linux-node-bb828da54c148048dd17899ba9fda624811cfb43";
+    const cacheEntry: ArtifactCacheEntry = {
+        cacheKey: "Linux-node-",
+        scope: "refs/heads/master",
+        creationTime: "2019-11-13T19:18:02+00:00",
+        archiveLocation: "www.actionscache.test/download"
+    };
+
+    jest.spyOn(core, "getState")
+        // Cache Entry State
+        .mockImplementationOnce(() => {
+            return JSON.stringify(cacheEntry);
+        })
+        // Cache Key State
+        .mockImplementationOnce(() => {
+            return primaryKey;
+        });
+
+    const inputPath = "node_modules";
+    testUtils.setInput(Inputs.Path, inputPath);
+    testUtils.setInput(Inputs.RestoreOnly, "true");
+
+    const cacheId = 4;
+    const reserveCacheMock = jest
+        .spyOn(cacheHttpClient, "reserveCache")
+        .mockImplementationOnce(() => {
+            return Promise.resolve(cacheId);
+        });
+
+    const saveCacheMock = jest.spyOn(cacheHttpClient, "saveCache");
+
+    await run();
+
+    expect(infoMock).toHaveBeenCalledWith(
+        "Cache action configured for restore-only, skipping save step"
+    );
+
+    expect(reserveCacheMock).toHaveBeenCalledTimes(0);
+    expect(saveCacheMock).toHaveBeenCalledTimes(0);
+});

--- a/action.yml
+++ b/action.yml
@@ -14,6 +14,9 @@ inputs:
   restore-only:
     description: 'Disables saving a new cache entry when true'
     required: false
+  save-only:
+    description: 'Disables downloading and restoring a new cache entry when true'
+    required: false
 outputs:
   cache-hit:
     description: 'A boolean value to indicate an exact match was found for the primary key'

--- a/action.yml
+++ b/action.yml
@@ -11,6 +11,9 @@ inputs:
   restore-keys:
     description: 'An ordered list of keys to use for restoring the cache if no cache hit occurred for key'
     required: false
+  restore-only:
+    description: 'Disables saving a new cache entry when true'
+    required: false
 outputs:
   cache-hit:
     description: 'A boolean value to indicate an exact match was found for the primary key'

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,7 +1,8 @@
 export enum Inputs {
     Key = "key",
     Path = "path",
-    RestoreKeys = "restore-keys"
+    RestoreKeys = "restore-keys",
+    RestoreOnly = "restore-only"
 }
 
 export enum Outputs {

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -2,7 +2,8 @@ export enum Inputs {
     Key = "key",
     Path = "path",
     RestoreKeys = "restore-keys",
-    RestoreOnly = "restore-only"
+    RestoreOnly = "restore-only",
+    SaveOnly = "save-only"
 }
 
 export enum Outputs {

--- a/src/restore.ts
+++ b/src/restore.ts
@@ -67,14 +67,27 @@ async function run(): Promise<void> {
                 return;
             }
 
+            const isExactKeyMatch = utils.isExactKeyMatch(
+                primaryKey,
+                cacheEntry
+            );
+
+            // Store the cache result
+            utils.setCacheState(cacheEntry);
+
+            if (core.getInput(Inputs.SaveOnly) === "true") {
+                core.info(
+                    "Cache action configured for save-only, skipping restore step."
+                );
+                utils.setCacheHitOutput(isExactKeyMatch);
+                return;
+            }
+
             const archivePath = path.join(
                 await utils.createTempDirectory(),
                 "cache.tgz"
             );
             core.debug(`Archive Path: ${archivePath}`);
-
-            // Store the cache result
-            utils.setCacheState(cacheEntry);
 
             // Download the cache from the cache entry
             await cacheHttpClient.downloadCache(
@@ -91,10 +104,6 @@ async function run(): Promise<void> {
 
             await extractTar(archivePath, cachePath);
 
-            const isExactKeyMatch = utils.isExactKeyMatch(
-                primaryKey,
-                cacheEntry
-            );
             utils.setCacheHitOutput(isExactKeyMatch);
 
             core.info(

--- a/src/save.ts
+++ b/src/save.ts
@@ -18,6 +18,13 @@ async function run(): Promise<void> {
             return;
         }
 
+        if (core.getInput(Inputs.RestoreOnly) === "true") {
+            core.info(
+                "Cache action configured for restore-only, skipping save step"
+            );
+            return;
+        }
+
         const state = utils.getCacheState();
 
         // Inputs are re-evaluted before the post action, so we want the original key used for restore

--- a/src/save.ts
+++ b/src/save.ts
@@ -20,7 +20,7 @@ async function run(): Promise<void> {
 
         if (core.getInput(Inputs.RestoreOnly) === "true") {
             core.info(
-                "Cache action configured for restore-only, skipping save step"
+                "Cache action configured for restore-only, skipping save step."
             );
             return;
         }

--- a/src/utils/testUtils.ts
+++ b/src/utils/testUtils.ts
@@ -13,6 +13,8 @@ interface CacheInput {
     path: string;
     key: string;
     restoreKeys?: string[];
+    restoreOnly?: string;
+    saveOnly?: string;
 }
 
 export function setInputs(input: CacheInput): void {
@@ -20,10 +22,14 @@ export function setInputs(input: CacheInput): void {
     setInput(Inputs.Key, input.key);
     input.restoreKeys &&
         setInput(Inputs.RestoreKeys, input.restoreKeys.join("\n"));
+    input.restoreOnly && setInput(Inputs.RestoreOnly, input.restoreOnly);
+    input.saveOnly && setInput(Inputs.SaveOnly, input.saveOnly);
 }
 
 export function clearInputs(): void {
     delete process.env[getInputName(Inputs.Path)];
     delete process.env[getInputName(Inputs.Key)];
     delete process.env[getInputName(Inputs.RestoreKeys)];
+    delete process.env[getInputName(Inputs.RestoreOnly)];
+    delete process.env[getInputName(Inputs.SaveOnly)];
 }


### PR DESCRIPTION
Implements #160 

This feature allows a workflow to minimize storage consumption of the cache by allowing jobs to selectively store. As an example, pull requests, which typically do not have shared use of caches they create, since they are isolated, can be excluded from saving using the following expression: 

` restore-only: ${{ github.event_name == 'pull_request' }}
`
      