### PR TITLE
Increase cache limit to 5 GBs

### DIFF
--- a/__tests__/save.test.ts
+++ b/__tests__/save.test.ts
@@ -194,7 +194,7 @@ test("save with large cache outputs warning", async () => {
 
     const createTarMock = jest.spyOn(tar, "createTar");
 
-    const cacheSize = 4 * 1024 * 1024 * 1024; //~4GB, over the 2GB limit
+    const cacheSize = 6 * 1024 * 1024 * 1024; //~6GB, over the 5GB limit
     jest.spyOn(actionUtils, "getArchiveFileSize").mockImplementationOnce(() => {
         return cacheSize;
     });
@@ -208,7 +208,7 @@ test("save with large cache outputs warning", async () => {
 
     expect(logWarningMock).toHaveBeenCalledTimes(1);
     expect(logWarningMock).toHaveBeenCalledWith(
-        "Cache size of ~4096 MB (4294967296 B) is over the 2GB limit, not saving cache."
+        "Cache size of ~6144 MB (6442450944 B) is over the 5GB limit, not saving cache."
     );
 
     expect(failedMock).toHaveBeenCalledTimes(0);

--- a/src/save.ts
+++ b/src/save.ts
@@ -56,7 +56,7 @@ async function run(): Promise<void> {
 
         await createTar(archivePath, cachePath);
 
-        const fileSizeLimit = 5 * 1024 * 1024 * 1024; // 2GB per repo limit
+        const fileSizeLimit = 5 * 1024 * 1024 * 1024; // 5GB per repo limit
         const archiveFileSize = utils.getArchiveFileSize(archivePath);
         core.debug(`File Size: ${archiveFileSize}`);
         if (archiveFileSize > fileSizeLimit) {

--- a/src/save.ts
+++ b/src/save.ts
@@ -56,14 +56,14 @@ async function run(): Promise<void> {
 
         await createTar(archivePath, cachePath);
 
-        const fileSizeLimit = 2 * 1024 * 1024 * 1024; // 2GB per repo limit
+        const fileSizeLimit = 5 * 1024 * 1024 * 1024; // 2GB per repo limit
         const archiveFileSize = utils.getArchiveFileSize(archivePath);
         core.debug(`File Size: ${archiveFileSize}`);
         if (archiveFileSize > fileSizeLimit) {
             utils.logWarning(
                 `Cache size of ~${Math.round(
                     archiveFileSize / (1024 * 1024)
-                )} MB (${archiveFileSize} B) is over the 2GB limit, not saving cache.`
+                )} MB (${archiveFileSize} B) is over the 5GB limit, not saving cache.`
             );
             return;
         }


### PR DESCRIPTION
Increases the individual file upload limit to 5 GBs to match the new server-side limit.