### PR TITLE
Use different IDs for 1) getting the directory of yarn cache 2) the cache itself

### DIFF
--- a/examples.md
+++ b/examples.md
@@ -162,7 +162,7 @@ The yarn cache directory will depend on your operating system and version of `ya
   run: echo "::set-output name=dir::$(yarn cache dir)"
 
 - uses: actions/cache@v1
-  id: yarn-cache
+  id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
   with:
     path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
     key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}

--- a/examples.md
+++ b/examples.md
@@ -140,7 +140,7 @@ For npm, cache files are stored in `~/.npm` on Posix, or `%AppData%/npm-cache` o
 
 ### Using multiple systems and `npm config`
 
-```yaml  
+```yaml
 - name: Get npm cache directory
   id: npm-cache
   run: |
@@ -157,21 +157,23 @@ For npm, cache files are stored in `~/.npm` on Posix, or `%AppData%/npm-cache` o
 The yarn cache directory will depend on your operating system and version of `yarn`. See https://yarnpkg.com/lang/en/docs/cli/cache/ for more info.
 
 ```yaml
-- name: Get yarn cache
-  id: yarn-cache
+- name: Get yarn cache directory path
+  id: yarn-cache-dir-path
   run: echo "::set-output name=dir::$(yarn cache dir)"
 
 - uses: actions/cache@v1
+  id: yarn-cache
   with:
-    path: ${{ steps.yarn-cache.outputs.dir }}
+    path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
     key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
     restore-keys: |
       ${{ runner.os }}-yarn-
 ```
 
+
 ## PHP - Composer
 
-```yaml  
+```yaml
 - name: Get Composer Cache Directory
   id: composer-cache
   run: |


### PR DESCRIPTION
Using the current example + https://github.com/actions/cache#skipping-steps-based-on-cache-hit,
I came to a wrong conclusion that I could skip a step if the `cache-hit` was `true`:
the ID I used was from the wrong step - the `get yarn cache directory` step, instead of the `get yarn cache itself` step.

I've updated the example in hopes that it'll be clearer for others aswell!

P.S. I'd recommend doing the same for other examples that have more than 1 step & might be confusing as to which step to use for the `cache-hit`. 🚀

---

Edit: Okay so I realized that you cannot skip the `yarn install [--frozen-lockfile]` step even if you have the cache, unless you're caching `node_modules` themselves - is that even recommended or nah?