### PR TITLE
Introduce `paths` input to support multiple cache paths

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -5,6 +5,9 @@ inputs:
   path:
     description: 'A directory to store and save the cache'
     required: true
+  paths:
+    description: 'A list of directories to store and save the cache'
+    required: false
   key:
     description: 'An explicit key for restoring and saving the cache'
     required: true

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,6 +1,7 @@
 export enum Inputs {
     Key = "key",
     Path = "path",
+    Paths = "paths",
     RestoreKeys = "restore-keys"
 }
 

--- a/src/save.ts
+++ b/src/save.ts
@@ -56,30 +56,32 @@ async function run(): Promise<void> {
 
         cachePathList = [cachePath, ...cachePathList];
 
-        core.debug(`Cache Path: ${cachePath}`);
+        for (const cachePath of cachePathList) {
+            core.debug(`Cache Path: ${cachePath}`);
 
-        const archivePath = path.join(
-            await utils.createTempDirectory(),
-            "cache.tgz"
-        );
-        core.debug(`Archive Path: ${archivePath}`);
-
-        await createTar(archivePath, cachePath);
-
-        const fileSizeLimit = 5 * 1024 * 1024 * 1024; // 5GB per repo limit
-        const archiveFileSize = utils.getArchiveFileSize(archivePath);
-        core.debug(`File Size: ${archiveFileSize}`);
-        if (archiveFileSize > fileSizeLimit) {
-            utils.logWarning(
-                `Cache size of ~${Math.round(
-                    archiveFileSize / (1024 * 1024)
-                )} MB (${archiveFileSize} B) is over the 5GB limit, not saving cache.`
+            const archivePath = path.join(
+                await utils.createTempDirectory(),
+                "cache.tgz"
             );
-            return;
-        }
+            core.debug(`Archive Path: ${archivePath}`);
 
-        core.debug(`Saving Cache (ID: ${cacheId})`);
-        await cacheHttpClient.saveCache(cacheId, archivePath);
+            await createTar(archivePath, cachePath);
+
+            const fileSizeLimit = 5 * 1024 * 1024 * 1024; // 5GB per repo limit
+            const archiveFileSize = utils.getArchiveFileSize(archivePath);
+            core.debug(`File Size: ${archiveFileSize}`);
+            if (archiveFileSize > fileSizeLimit) {
+                utils.logWarning(
+                    `Cache size of ~${Math.round(
+                        archiveFileSize / (1024 * 1024)
+                    )} MB (${archiveFileSize} B) is over the 5GB limit, not saving cache.`
+                );
+                return;
+            }
+
+            core.debug(`Saving Cache (ID: ${cacheId})`);
+            await cacheHttpClient.saveCache(cacheId, archivePath);
+        }
     } catch (error) {
         utils.logWarning(error.message);
     }

--- a/src/save.ts
+++ b/src/save.ts
@@ -46,6 +46,16 @@ async function run(): Promise<void> {
         const cachePath = utils.resolvePath(
             core.getInput(Inputs.Path, { required: true })
         );
+
+        /** TODO use `core.getInputList` instead - see https://github.com/actions/toolkit/pull/336 */
+        let cachePathList = core
+            .getInput(Inputs.Paths, { required: false })
+            .split("\n")
+            .filter(x => x !== "")
+            .map(path => utils.resolvePath(path));
+
+        cachePathList = [cachePath, ...cachePathList];
+
         core.debug(`Cache Path: ${cachePath}`);
 
         const archivePath = path.join(


### PR DESCRIPTION
Fixes https://github.com/actions/cache/issues/16	

---

TODO - actually restore the cache from the multiple paths.

I'm a little not sure about the `getCacheEntry` function @ `cacheHttpClient.ts` - see https://github.com/actions/cache/blob/master/src/cacheHttpClient.ts#L86-L88:

couldn't there be a case that the `response` is an `Array<ArtifactCacheEntry>`, since we would've saved multiple caches with different paths for the same keys?

---

TODO - decide what do we want to do with the current `path` input.
Should it be considered deprecated now & removed in v2?