### PR TITLE
Attempt to delete the archive after extraction

### DIFF
--- a/__tests__/actionUtils.test.ts
+++ b/__tests__/actionUtils.test.ts
@@ -1,4 +1,5 @@
 import * as core from "@actions/core";
+import * as fs from "fs";
 import * as os from "os";
 import * as path from "path";
 
@@ -233,4 +234,16 @@ test("isValidEvent returns true for pull request event", () => {
     const isValidEvent = actionUtils.isValidEvent();
 
     expect(isValidEvent).toBe(true);
+});
+
+test("unlinkFile unlinks file", async () => {
+    const testDirectory = fs.mkdtempSync("unlinkFileTest");
+    const testFile = path.join(testDirectory, "test.txt");
+    fs.writeFileSync(testFile, "hello world");
+
+    await actionUtils.unlinkFile(testFile);
+
+    expect(fs.existsSync(testFile)).toBe(false);
+
+    fs.rmdirSync(testDirectory);
 });

--- a/__tests__/restore.test.ts
+++ b/__tests__/restore.test.ts
@@ -240,6 +240,7 @@ test("restore with cache found", async () => {
         .mockReturnValue(fileSize);
 
     const extractTarMock = jest.spyOn(tar, "extractTar");
+    const unlinkFileMock = jest.spyOn(actionUtils, "unlinkFile");
     const setCacheHitOutputMock = jest.spyOn(actionUtils, "setCacheHitOutput");
 
     await run();
@@ -256,6 +257,9 @@ test("restore with cache found", async () => {
 
     expect(extractTarMock).toHaveBeenCalledTimes(1);
     expect(extractTarMock).toHaveBeenCalledWith(archivePath, cachePath);
+
+    expect(unlinkFileMock).toHaveBeenCalledTimes(1);
+    expect(unlinkFileMock).toHaveBeenCalledWith(archivePath);
 
     expect(setCacheHitOutputMock).toHaveBeenCalledTimes(1);
     expect(setCacheHitOutputMock).toHaveBeenCalledWith(true);

--- a/dist/save/index.js
+++ b/dist/save/index.js
@@ -1651,6 +1651,7 @@ const io = __importStar(__webpack_require__(1));
 const fs = __importStar(__webpack_require__(747));
 const os = __importStar(__webpack_require__(87));
 const path = __importStar(__webpack_require__(622));
+const util = __importStar(__webpack_require__(669));
 const uuidV4 = __importStar(__webpack_require__(826));
 const constants_1 = __webpack_require__(694);
 // From https://github.com/actions/toolkit/blob/master/packages/tool-cache/src/tool-cache.ts#L23
@@ -1743,6 +1744,10 @@ function isValidEvent() {
     return getSupportedEvents().includes(githubEvent);
 }
 exports.isValidEvent = isValidEvent;
+function unlinkFile(path) {
+    return util.promisify(fs.unlink)(path);
+}
+exports.unlinkFile = unlinkFile;
 
 
 /***/ }),

--- a/src/restore.ts
+++ b/src/restore.ts
@@ -74,20 +74,29 @@ async function run(): Promise<void> {
             // Store the cache result
             utils.setCacheState(cacheEntry);
 
-            // Download the cache from the cache entry
-            await cacheHttpClient.downloadCache(
-                cacheEntry.archiveLocation,
-                archivePath
-            );
+            try {
+                // Download the cache from the cache entry
+                await cacheHttpClient.downloadCache(
+                    cacheEntry.archiveLocation,
+                    archivePath
+                );
 
-            const archiveFileSize = utils.getArchiveFileSize(archivePath);
-            core.info(
-                `Cache Size: ~${Math.round(
-                    archiveFileSize / (1024 * 1024)
-                )} MB (${archiveFileSize} B)`
-            );
+                const archiveFileSize = utils.getArchiveFileSize(archivePath);
+                core.info(
+                    `Cache Size: ~${Math.round(
+                        archiveFileSize / (1024 * 1024)
+                    )} MB (${archiveFileSize} B)`
+                );
 
-            await extractTar(archivePath, cachePath);
+                await extractTar(archivePath, cachePath);
+            } finally {
+                // Try to delete the archive to save space
+                try {
+                    await utils.unlinkFile(archivePath);
+                } catch (error) {
+                    core.debug(`Failed to delete archive: ${error}`);
+                }
+            }
 
             const isExactKeyMatch = utils.isExactKeyMatch(
                 primaryKey,

--- a/src/utils/actionUtils.ts
+++ b/src/utils/actionUtils.ts
@@ -3,6 +3,7 @@ import * as io from "@actions/io";
 import * as fs from "fs";
 import * as os from "os";
 import * as path from "path";
+import * as util from "util";
 import * as uuidV4 from "uuid/v4";
 
 import { Events, Outputs, State } from "../constants";
@@ -104,4 +105,8 @@ export function getSupportedEvents(): string[] {
 export function isValidEvent(): boolean {
     const githubEvent = process.env[Events.Key] || "";
     return getSupportedEvents().includes(githubEvent);
+}
+
+export function unlinkFile(path: fs.PathLike): Promise<void> {
+    return util.promisify(fs.unlink)(path);
 }


### PR DESCRIPTION
This PR modifies the `restore` job to attempt to delete the downloaded archive once it has been extracted.  This reduces storage space used on the Actions runner once the cache Action has finished executing.

This change is particularly useful for users using a large proportion of the 5GB of currently available cache space, as keeping both the archives and the unzipped content could use close to 10GB of the available [14GB](https://help.github.com/en/actions/reference/virtual-environments-for-github-hosted-runners#supported-runners-and-hardware-resources) of storage on GitHub-hosted Actions runners.