### PR TITLE
Include Kotlinscript Gradle files

### DIFF
--- a/examples.md
+++ b/examples.md
@@ -104,7 +104,7 @@ We cache the elements of the Cabal store separately, as the entirety of `~/.caba
 - uses: actions/cache@v1
   with:
     path: ~/.gradle/caches
-    key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
+    key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*') }}
     restore-keys: |
       ${{ runner.os }}-gradle-
 ```


### PR DESCRIPTION
Tested this with my own repo which uses a mix of `build.gradle` and `build.gradle.kts` files and this glob seems to be working correctly.

As an aside, please checkout #215 as it would make the process of verifying these globs easier!