### PR TITLE
Use posix archive format.

### DIFF
--- a/__tests__/tar.test.ts
+++ b/__tests__/tar.test.ts
@@ -70,6 +70,7 @@ test("create tar", async () => {
     expect(execMock).toHaveBeenCalledWith(
         `"${tarPath}"`,
         [
+            "--posix",
             "-cz",
             "-f",
             CacheFilename,

--- a/dist/restore/index.js
+++ b/dist/restore/index.js
@@ -2182,12 +2182,12 @@ var __importStar = (this && this.__importStar) || function (mod) {
 };
 Object.defineProperty(exports, "__esModule", { value: true });
 const core = __importStar(__webpack_require__(470));
-const fs = __importStar(__webpack_require__(747));
-const crypto = __importStar(__webpack_require__(417));
 const http_client_1 = __webpack_require__(539);
 const auth_1 = __webpack_require__(226);
-const utils = __importStar(__webpack_require__(443));
+const crypto = __importStar(__webpack_require__(417));
+const fs = __importStar(__webpack_require__(747));
 const constants_1 = __webpack_require__(694);
+const utils = __importStar(__webpack_require__(443));
 const versionSalt = "1.0";
 function isSuccessStatusCode(statusCode) {
     if (!statusCode) {
@@ -3185,8 +3185,8 @@ var __importStar = (this && this.__importStar) || function (mod) {
 };
 Object.defineProperty(exports, "__esModule", { value: true });
 const core = __importStar(__webpack_require__(470));
-const io = __importStar(__webpack_require__(1));
 const glob = __importStar(__webpack_require__(281));
+const io = __importStar(__webpack_require__(1));
 const fs = __importStar(__webpack_require__(747));
 const path = __importStar(__webpack_require__(622));
 const util = __importStar(__webpack_require__(669));
@@ -5013,6 +5013,7 @@ function createTar(archiveFolder, sourceDirectories) {
         fs_1.writeFileSync(path.join(archiveFolder, manifestFilename), sourceDirectories.join("\n"));
         const workingDirectory = getWorkingDirectory();
         const args = [
+            "--posix",
             "-cz",
             "-f",
             constants_1.CacheFilename,

--- a/dist/save/index.js
+++ b/dist/save/index.js
@@ -2182,12 +2182,12 @@ var __importStar = (this && this.__importStar) || function (mod) {
 };
 Object.defineProperty(exports, "__esModule", { value: true });
 const core = __importStar(__webpack_require__(470));
-const fs = __importStar(__webpack_require__(747));
-const crypto = __importStar(__webpack_require__(417));
 const http_client_1 = __webpack_require__(539);
 const auth_1 = __webpack_require__(226);
-const utils = __importStar(__webpack_require__(443));
+const crypto = __importStar(__webpack_require__(417));
+const fs = __importStar(__webpack_require__(747));
 const constants_1 = __webpack_require__(694);
+const utils = __importStar(__webpack_require__(443));
 const versionSalt = "1.0";
 function isSuccessStatusCode(statusCode) {
     if (!statusCode) {
@@ -3185,8 +3185,8 @@ var __importStar = (this && this.__importStar) || function (mod) {
 };
 Object.defineProperty(exports, "__esModule", { value: true });
 const core = __importStar(__webpack_require__(470));
-const io = __importStar(__webpack_require__(1));
 const glob = __importStar(__webpack_require__(281));
+const io = __importStar(__webpack_require__(1));
 const fs = __importStar(__webpack_require__(747));
 const path = __importStar(__webpack_require__(622));
 const util = __importStar(__webpack_require__(669));
@@ -4990,6 +4990,7 @@ function createTar(archiveFolder, sourceDirectories) {
         fs_1.writeFileSync(path.join(archiveFolder, manifestFilename), sourceDirectories.join("\n"));
         const workingDirectory = getWorkingDirectory();
         const args = [
+            "--posix",
             "-cz",
             "-f",
             constants_1.CacheFilename,

--- a/src/tar.ts
+++ b/src/tar.ts
@@ -56,6 +56,7 @@ export async function createTar(
 
     const workingDirectory = getWorkingDirectory();
     const args = [
+        "--posix",
         "-cz",
         "-f",
         CacheFilename,


### PR DESCRIPTION
This preserves timestamps with nanoseconds precision and makes the cache usable by tools which rely on it (eg https://www.scala-sbt.org/).