### PR TITLE
Fix cache version in lerna example

### DIFF
--- a/examples.md
+++ b/examples.md
@@ -189,7 +189,7 @@ The yarn cache directory will depend on your operating system and version of `ya
 
 ```yaml
 - name: restore lerna
-  uses: actions/cache@v2
+  uses: actions/cache@v1
    with:
      path: |
        node_modules


### PR DESCRIPTION
As far as I know, there is no `cache@v2`.