### PR TITLE
Fix Lerna Example

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ See [Examples](examples.md) for a list of `actions/cache` implementations for us
 - [Java - Gradle](./examples.md#java---gradle)
 - [Java - Maven](./examples.md#java---maven)
 - [Node - npm](./examples.md#node---npm)
+- [Node - Lerna](./examples.md#node---lerna)
 - [Node - Yarn](./examples.md#node---yarn)
 - [OCaml/Reason - esy](./examples.md##ocamlreason---esy)
 - [PHP - Composer](./examples.md#php---composer)

--- a/examples.md
+++ b/examples.md
@@ -11,8 +11,8 @@
     - [macOS and Ubuntu](#macos-and-ubuntu)
     - [Windows](#windows)
     - [Using multiple systems and `npm config`](#using-multiple-systems-and-npm-config)
-  - [Node - Yarn](#node---yarn)
   - [Node - Lerna](#node---lerna)
+  - [Node - Yarn](#node---yarn)
   - [OCaml/Reason - esy](#ocamlreason---esy)
   - [PHP - Composer](#php---composer)
   - [Python - pip](#python---pip)
@@ -168,6 +168,19 @@ For npm, cache files are stored in `~/.npm` on Posix, or `%AppData%/npm-cache` o
       ${{ runner.os }}-node-
 ```
 
+## Node - Lerna
+
+>Note this example uses the new multi-paths feature and is only available at `master`
+```yaml
+- name: restore lerna
+  uses: actions/cache@master
+   with:
+     path: |
+       node_modules
+        */*/node_modules
+     key: ${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
+```
+
 ## Node - Yarn
 The yarn cache directory will depend on your operating system and version of `yarn`. See https://yarnpkg.com/lang/en/docs/cli/cache/ for more info.
 
@@ -183,18 +196,6 @@ The yarn cache directory will depend on your operating system and version of `ya
     key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
     restore-keys: |
       ${{ runner.os }}-yarn-
-```
-
-## Node - Lerna
-
-```yaml
-- name: restore lerna
-  uses: actions/cache@v2
-   with:
-     path: |
-       node_modules
-        */*/node_modules
-     key: ${{ runner.os }}-${{ hashFiles('yarn.lock') }}
 ```
 
 ## OCaml/Reason - esy

--- a/examples.md
+++ b/examples.md
@@ -174,11 +174,11 @@ For npm, cache files are stored in `~/.npm` on Posix, or `%AppData%/npm-cache` o
 ```yaml
 - name: restore lerna
   uses: actions/cache@master
-   with:
-     path: |
-       node_modules
-        */*/node_modules
-     key: ${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
+  with:
+    path: |
+      node_modules
+      */*/node_modules
+    key: ${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
 ```
 
 ## Node - Yarn


### PR DESCRIPTION
This updates the Lerna example to reference the `master` branch since `v2` is still a work-in-progress and the multi-path feature (https://github.com/actions/cache/pull/212) is not yet released.

Also updating the `hashFiles` to reference every `yarn.lock` file
>Lerna uses yarn.lock at root but also in every package.
>https://github.com/actions/cache/pull/212#issuecomment-607772401
