### PR TITLE
Fix caching directories outside of the working directory (relative paths)

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -47,7 +47,7 @@ jobs:
       run: npm run test
 
   # End to end save and restore
-  test-save:
+  test-save-relative:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macOS-latest]
@@ -63,8 +63,8 @@ jobs:
       with:
         key: test-${{ runner.os }}-${{ github.run_id }}
         path: test-cache
-  test-restore:
-    needs: test-save
+  test-restore-relative:
+    needs: test-save-relative
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macOS-latest]

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -51,6 +51,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macOS-latest]
+      fail-fast: false
     runs-on: ${{ matrix.os }}
     steps:
     - name: Checkout
@@ -68,6 +69,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macOS-latest]
+      fail-fast: false
     runs-on: ${{ matrix.os }}
     steps:
     - name: Checkout
@@ -86,6 +88,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macOS-latest]
+      fail-fast: false
     runs-on: ${{ matrix.os }}
     steps:
     - name: Checkout
@@ -103,6 +106,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macOS-latest]
+      fail-fast: false
     runs-on: ${{ matrix.os }}
     steps:
     - name: Checkout

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -57,7 +57,7 @@ jobs:
       uses: actions/checkout@v2
     - name: Generate files
       shell: bash
-      run: __tests__/create-cache-files.sh ${{ runner.os }}
+      run: __tests__/create-cache-files.sh ${{ runner.os }} test-cache
     - name: Save cache
       uses: ./
       with:
@@ -79,7 +79,42 @@ jobs:
         path: test-cache
     - name: Verify cache
       shell: bash
-      run: __tests__/verify-cache-files.sh ${{ runner.os }}
+      run: __tests__/verify-cache-files.sh ${{ runner.os }} test-cache
+
+  # End to end save and restore with relative paths
+  test-save:
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest, macOS-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+    - name: Generate files
+      shell: bash
+      run: __tests__/create-cache-files.sh ${{ runner.os }} ~/test-cache
+    - name: Save cache
+      uses: ./
+      with:
+        key: test-relative-${{ runner.os }}-${{ github.run_id }}
+        path: ~test-cache
+  test-restore:
+    needs: test-save
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest, macOS-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+    - name: Restore cache
+      uses: ./
+      with:
+        key: test-relative-${{ runner.os }}-${{ github.run_id }}
+        path: test-cache
+    - name: Verify cache
+      shell: bash
+      run: __tests__/verify-cache-files.sh ${{ runner.os }} ~/test-cache
 
   # End to end with proxy
   test-proxy-save:
@@ -98,7 +133,7 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v2
     - name: Generate files
-      run: __tests__/create-cache-files.sh proxy
+      run: __tests__/create-cache-files.sh proxy test-cache
     - name: Save cache
       uses: ./
       with:
@@ -126,4 +161,4 @@ jobs:
         key: test-proxy-${{ github.run_id }}
         path: test-cache
     - name: Verify cache
-      run: __tests__/verify-cache-files.sh proxy
+      run: __tests__/verify-cache-files.sh proxy test-cache

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -56,14 +56,19 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v2
-    - name: Generate files
+    - name: Generate files in working directory
       shell: bash
       run: __tests__/create-cache-files.sh ${{ runner.os }} test-cache
+    - name: Generate files outside working directory
+      shell: bash
+      run: __tests__/create-cache-files.sh ${{ runner.os }} ~/test-cache
     - name: Save cache
       uses: ./
       with:
         key: test-${{ runner.os }}-${{ github.run_id }}
-        path: test-cache
+        path: |
+          test-cache
+          ~/test-cache
   test-restore:
     needs: test-save
     strategy:
@@ -78,45 +83,13 @@ jobs:
       uses: ./
       with:
         key: test-${{ runner.os }}-${{ github.run_id }}
-        path: test-cache
-    - name: Verify cache
+        path: |
+          test-cache
+          ~/test-cache
+    - name: Verify cache files in working directory
       shell: bash
       run: __tests__/verify-cache-files.sh ${{ runner.os }} test-cache
-
-  # End to end save and restore with relative paths
-  test-save-relative:
-    strategy:
-      matrix:
-        os: [ubuntu-latest, windows-latest, macOS-latest]
-      fail-fast: false
-    runs-on: ${{ matrix.os }}
-    steps:
-    - name: Checkout
-      uses: actions/checkout@v2
-    - name: Generate files
-      shell: bash
-      run: __tests__/create-cache-files.sh ${{ runner.os }} ~/test-cache
-    - name: Save cache
-      uses: ./
-      with:
-        key: test-relative-${{ runner.os }}-${{ github.run_id }}
-        path: ~test-cache
-  test-restore-relative:
-    needs: test-save-relative
-    strategy:
-      matrix:
-        os: [ubuntu-latest, windows-latest, macOS-latest]
-      fail-fast: false
-    runs-on: ${{ matrix.os }}
-    steps:
-    - name: Checkout
-      uses: actions/checkout@v2
-    - name: Restore cache
-      uses: ./
-      with:
-        key: test-relative-${{ runner.os }}-${{ github.run_id }}
-        path: ~test-cache
-    - name: Verify cache
+    - name: Verify cache files outside working directory
       shell: bash
       run: __tests__/verify-cache-files.sh ${{ runner.os }} ~/test-cache
 

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -47,7 +47,7 @@ jobs:
       run: npm run test
 
   # End to end save and restore
-  test-save-relative:
+  test-save:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macOS-latest]
@@ -63,8 +63,8 @@ jobs:
       with:
         key: test-${{ runner.os }}-${{ github.run_id }}
         path: test-cache
-  test-restore-relative:
-    needs: test-save-relative
+  test-restore:
+    needs: test-save
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macOS-latest]
@@ -82,7 +82,7 @@ jobs:
       run: __tests__/verify-cache-files.sh ${{ runner.os }} test-cache
 
   # End to end save and restore with relative paths
-  test-save:
+  test-save-relative:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macOS-latest]
@@ -98,8 +98,8 @@ jobs:
       with:
         key: test-relative-${{ runner.os }}-${{ github.run_id }}
         path: ~test-cache
-  test-restore:
-    needs: test-save
+  test-restore-relative:
+    needs: test-save-relative
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macOS-latest]

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -111,7 +111,7 @@ jobs:
       uses: ./
       with:
         key: test-relative-${{ runner.os }}-${{ github.run_id }}
-        path: test-cache
+        path: ~test-cache
     - name: Verify cache
       shell: bash
       run: __tests__/verify-cache-files.sh ${{ runner.os }} ~/test-cache

--- a/__tests__/create-cache-files.sh
+++ b/__tests__/create-cache-files.sh
@@ -7,5 +7,11 @@ if [ -z "$prefix" ]; then
   exit 1
 fi
 
-mkdir test-cache
-echo "$prefix $GITHUB_RUN_ID" > test-cache/test-file.txt
+path="$2"
+if [ -z "$path" ]; then
+  echo "Must supply path argument"
+  exit 1
+fi
+
+mkdir -p $path
+echo "$prefix $GITHUB_RUN_ID" > $path/test-file.txt

--- a/__tests__/tar.test.ts
+++ b/__tests__/tar.test.ts
@@ -73,6 +73,7 @@ test("create tar", async () => {
             "-cz",
             "-f",
             CacheFilename,
+            "-P",
             "-C",
             workspace,
             "--files-from",

--- a/__tests__/verify-cache-files.sh
+++ b/__tests__/verify-cache-files.sh
@@ -7,6 +7,12 @@ if [ -z "$prefix" ]; then
   exit 1
 fi
 
+path="$2"
+if [ -z "$path" ]; then
+  echo "Must specify path argument"
+  exit 1
+fi
+
 # Sanity check GITHUB_RUN_ID defined
 if [ -z "$GITHUB_RUN_ID" ]; then
   echo "GITHUB_RUN_ID not defined"
@@ -14,7 +20,7 @@ if [ -z "$GITHUB_RUN_ID" ]; then
 fi
 
 # Verify file exists
-file="test-cache/test-file.txt"
+file="$path/test-file.txt"
 echo "Checking for $file"
 if [ ! -e $file ]; then
   echo "File does not exist"

--- a/dist/restore/index.js
+++ b/dist/restore/index.js
@@ -2182,12 +2182,12 @@ var __importStar = (this && this.__importStar) || function (mod) {
 };
 Object.defineProperty(exports, "__esModule", { value: true });
 const core = __importStar(__webpack_require__(470));
-const fs = __importStar(__webpack_require__(747));
-const crypto = __importStar(__webpack_require__(417));
 const http_client_1 = __webpack_require__(539);
 const auth_1 = __webpack_require__(226);
-const utils = __importStar(__webpack_require__(443));
+const crypto = __importStar(__webpack_require__(417));
+const fs = __importStar(__webpack_require__(747));
 const constants_1 = __webpack_require__(694);
+const utils = __importStar(__webpack_require__(443));
 const versionSalt = "1.0";
 function isSuccessStatusCode(statusCode) {
     if (!statusCode) {
@@ -3185,8 +3185,8 @@ var __importStar = (this && this.__importStar) || function (mod) {
 };
 Object.defineProperty(exports, "__esModule", { value: true });
 const core = __importStar(__webpack_require__(470));
-const io = __importStar(__webpack_require__(1));
 const glob = __importStar(__webpack_require__(281));
+const io = __importStar(__webpack_require__(1));
 const fs = __importStar(__webpack_require__(747));
 const path = __importStar(__webpack_require__(622));
 const util = __importStar(__webpack_require__(669));
@@ -5016,6 +5016,7 @@ function createTar(archiveFolder, sourceDirectories) {
             "-cz",
             "-f",
             constants_1.CacheFilename,
+            "-P",
             "-C",
             workingDirectory,
             "--files-from",

--- a/dist/save/index.js
+++ b/dist/save/index.js
@@ -2182,12 +2182,12 @@ var __importStar = (this && this.__importStar) || function (mod) {
 };
 Object.defineProperty(exports, "__esModule", { value: true });
 const core = __importStar(__webpack_require__(470));
-const fs = __importStar(__webpack_require__(747));
-const crypto = __importStar(__webpack_require__(417));
 const http_client_1 = __webpack_require__(539);
 const auth_1 = __webpack_require__(226);
-const utils = __importStar(__webpack_require__(443));
+const crypto = __importStar(__webpack_require__(417));
+const fs = __importStar(__webpack_require__(747));
 const constants_1 = __webpack_require__(694);
+const utils = __importStar(__webpack_require__(443));
 const versionSalt = "1.0";
 function isSuccessStatusCode(statusCode) {
     if (!statusCode) {
@@ -3185,8 +3185,8 @@ var __importStar = (this && this.__importStar) || function (mod) {
 };
 Object.defineProperty(exports, "__esModule", { value: true });
 const core = __importStar(__webpack_require__(470));
-const io = __importStar(__webpack_require__(1));
 const glob = __importStar(__webpack_require__(281));
+const io = __importStar(__webpack_require__(1));
 const fs = __importStar(__webpack_require__(747));
 const path = __importStar(__webpack_require__(622));
 const util = __importStar(__webpack_require__(669));
@@ -4993,6 +4993,7 @@ function createTar(archiveFolder, sourceDirectories) {
             "-cz",
             "-f",
             constants_1.CacheFilename,
+            "-P",
             "-C",
             workingDirectory,
             "--files-from",

--- a/src/tar.ts
+++ b/src/tar.ts
@@ -59,6 +59,7 @@ export async function createTar(
         "-cz",
         "-f",
         CacheFilename,
+        "-P",
         "-C",
         workingDirectory,
         "--files-from",


### PR DESCRIPTION
Adds tests for including relative paths that are outside the working directory.  For example, it's common to cache `~/.nuget`, so we need to ensure these are restored to the correct location.

Fixes relative paths by adding the `-P` flag to tar creation to prevent `tar` from stripping leading paths.

Example without the `-P` flag:
```/bin/tar: Removing leading `../../../' from member names```

Fixes https://github.com/actions/cache/issues/249