### PR TITLE
Fallback to GNU tar if BSD tar is unavailable

### DIFF
--- a/__tests__/tar.test.ts
+++ b/__tests__/tar.test.ts
@@ -96,7 +96,7 @@ test("create BSD tar", async () => {
     const workspace = process.env["GITHUB_WORKSPACE"];
     const sourceDirectories = ["~/.npm/cache", `${workspace}/dist`];
 
-    await fs.mkdir(archiveFolder, () => void { recursive: true });
+    await fs.promises.mkdir(archiveFolder, { recursive: true });
 
     await tar.createTar(archiveFolder, sourceDirectories);
 

--- a/__tests__/tar.test.ts
+++ b/__tests__/tar.test.ts
@@ -51,10 +51,10 @@ test("extract BSD tar", async () => {
         [
             "-xz",
             "-f",
-            archivePath?.replace(/\\/g, "/"),
+            IS_WINDOWS ? archivePath.replace(/\\/g, "/") : archivePath,
             "-P",
             "-C",
-            workspace?.replace(/\\/g, "/")
+            IS_WINDOWS ? workspace?.replace(/\\/g, "/") : workspace
         ],
         { cwd: undefined }
     );
@@ -78,7 +78,7 @@ test("extract GNU tar", async () => {
             [
                 "-xz",
                 "-f",
-                archivePath?.replace(/\\/g, "/"),
+                archivePath.replace(/\\/g, "/"),
                 "-P",
                 "-C",
                 workspace?.replace(/\\/g, "/"),
@@ -111,10 +111,10 @@ test("create BSD tar", async () => {
         [
             "-cz",
             "-f",
-            CacheFilename?.replace(/\\/g, "/"),
+            IS_WINDOWS ? CacheFilename.replace(/\\/g, "/") : CacheFilename,
             "-P",
             "-C",
-            workspace?.replace(/\\/g, "/"),
+            IS_WINDOWS ? workspace?.replace(/\\/g, "/") : workspace,
             "--files-from",
             "manifest.txt"
         ],

--- a/__tests__/tar.test.ts
+++ b/__tests__/tar.test.ts
@@ -1,10 +1,11 @@
 import * as exec from "@actions/exec";
 import * as io from "@actions/io";
-import * as fs from "fs";
 import * as path from "path";
 
 import { CacheFilename } from "../src/constants";
 import * as tar from "../src/tar";
+
+import fs = require("fs");
 
 jest.mock("@actions/exec");
 jest.mock("@actions/io");
@@ -62,25 +63,18 @@ test("extract BSD tar", async () => {
 test("extract GNU tar", async () => {
     const IS_WINDOWS = process.platform === "win32";
     if (IS_WINDOWS) {
-        jest.mock("fs");
+        jest.spyOn(fs, "existsSync").mockReturnValueOnce(false);
+        jest.spyOn(tar, "isGnuTar").mockReturnValue(Promise.resolve(true));
 
         const execMock = jest.spyOn(exec, "exec");
-        const existsSyncMock = jest
-            .spyOn(fs, "existsSync")
-            .mockReturnValue(false);
-        const isGnuTarMock = jest
-            .spyOn(tar, "isGnuTar")
-            .mockReturnValue(Promise.resolve(true));
         const archivePath = `${process.env["windir"]}\\fakepath\\cache.tar`;
         const workspace = process.env["GITHUB_WORKSPACE"];
 
         await tar.extractTar(archivePath);
 
-        expect(existsSyncMock).toHaveBeenCalledTimes(1);
-        expect(isGnuTarMock).toHaveBeenCalledTimes(1);
         expect(execMock).toHaveBeenCalledTimes(2);
         expect(execMock).toHaveBeenLastCalledWith(
-            "tar",
+            `"tar"`,
             [
                 "-xz",
                 "-f",

--- a/dist/restore/index.js
+++ b/dist/restore/index.js
@@ -5041,12 +5041,8 @@ function createTar(archiveFolder, sourceDirectories) {
         const args = [
             "-cz",
             "-f",
-<<<<<<< HEAD
-            constants_1.CacheFilename,
-            "-P",
-=======
             (_a = constants_1.CacheFilename) === null || _a === void 0 ? void 0 : _a.replace(/\\/g, "/"),
->>>>>>> Fallback to GNU tar if BSD tar is unavailable
+            "-P",
             "-C",
             (_b = workingDirectory) === null || _b === void 0 ? void 0 : _b.replace(/\\/g, "/"),
             "--files-from",

--- a/dist/restore/index.js
+++ b/dist/restore/index.js
@@ -4959,12 +4959,30 @@ var __importStar = (this && this.__importStar) || function (mod) {
     return result;
 };
 Object.defineProperty(exports, "__esModule", { value: true });
+const core = __importStar(__webpack_require__(470));
 const exec_1 = __webpack_require__(986);
 const io = __importStar(__webpack_require__(1));
 const fs_1 = __webpack_require__(747);
 const path = __importStar(__webpack_require__(622));
 const constants_1 = __webpack_require__(694);
-function getTarPath() {
+function isGnuTar() {
+    return __awaiter(this, void 0, void 0, function* () {
+        core.debug("Checking tar --version");
+        let versionOutput = "";
+        yield exec_1.exec("tar --version", [], {
+            ignoreReturnCode: true,
+            silent: true,
+            listeners: {
+                stdout: (data) => (versionOutput += data.toString()),
+                stderr: (data) => (versionOutput += data.toString())
+            }
+        });
+        core.debug(versionOutput.trim());
+        return versionOutput.toUpperCase().includes("GNU TAR");
+    });
+}
+exports.isGnuTar = isGnuTar;
+function getTarPath(args) {
     return __awaiter(this, void 0, void 0, function* () {
         // Explicitly use BSD Tar on Windows
         const IS_WINDOWS = process.platform === "win32";
@@ -4973,22 +4991,21 @@ function getTarPath() {
             if (fs_1.existsSync(systemTar)) {
                 return systemTar;
             }
+            else if (isGnuTar()) {
+                args.push("--force-local");
+            }
         }
         return yield io.which("tar", true);
     });
 }
 function execTar(args, cwd) {
-    var _a, _b;
+    var _a;
     return __awaiter(this, void 0, void 0, function* () {
         try {
-            yield exec_1.exec(`"${yield getTarPath()}"`, args, { cwd: cwd });
+            yield exec_1.exec(`"${yield getTarPath(args)}"`, args, { cwd: cwd });
         }
         catch (error) {
-            const IS_WINDOWS = process.platform === "win32";
-            if (IS_WINDOWS) {
-                throw new Error(`Tar failed with error: ${(_a = error) === null || _a === void 0 ? void 0 : _a.message}. Ensure BSD tar is installed and on the PATH.`);
-            }
-            throw new Error(`Tar failed with error: ${(_b = error) === null || _b === void 0 ? void 0 : _b.message}`);
+            throw new Error(`Tar failed with error: ${(_a = error) === null || _a === void 0 ? void 0 : _a.message}`);
         }
     });
 }
@@ -4997,16 +5014,25 @@ function getWorkingDirectory() {
     return _a = process.env["GITHUB_WORKSPACE"], (_a !== null && _a !== void 0 ? _a : process.cwd());
 }
 function extractTar(archivePath) {
+    var _a, _b;
     return __awaiter(this, void 0, void 0, function* () {
         // Create directory to extract tar into
         const workingDirectory = getWorkingDirectory();
         yield io.mkdirP(workingDirectory);
-        const args = ["-xz", "-f", archivePath, "-P", "-C", workingDirectory];
+        const args = [
+            "-xz",
+            "-f",
+            (_a = archivePath) === null || _a === void 0 ? void 0 : _a.replace(/\\/g, "/"),
+            "-P",
+            "-C",
+            (_b = workingDirectory) === null || _b === void 0 ? void 0 : _b.replace(/\\/g, "/")
+        ];
         yield execTar(args);
     });
 }
 exports.extractTar = extractTar;
 function createTar(archiveFolder, sourceDirectories) {
+    var _a, _b;
     return __awaiter(this, void 0, void 0, function* () {
         // Write source directories to manifest.txt to avoid command length limits
         const manifestFilename = "manifest.txt";
@@ -5015,10 +5041,14 @@ function createTar(archiveFolder, sourceDirectories) {
         const args = [
             "-cz",
             "-f",
+<<<<<<< HEAD
             constants_1.CacheFilename,
             "-P",
+=======
+            (_a = constants_1.CacheFilename) === null || _a === void 0 ? void 0 : _a.replace(/\\/g, "/"),
+>>>>>>> Fallback to GNU tar if BSD tar is unavailable
             "-C",
-            workingDirectory,
+            (_b = workingDirectory) === null || _b === void 0 ? void 0 : _b.replace(/\\/g, "/"),
             "--files-from",
             manifestFilename
         ];

--- a/dist/restore/index.js
+++ b/dist/restore/index.js
@@ -5014,7 +5014,6 @@ function getWorkingDirectory() {
     return _a = process.env["GITHUB_WORKSPACE"], (_a !== null && _a !== void 0 ? _a : process.cwd());
 }
 function extractTar(archivePath) {
-    var _a, _b;
     return __awaiter(this, void 0, void 0, function* () {
         // Create directory to extract tar into
         const workingDirectory = getWorkingDirectory();
@@ -5022,17 +5021,16 @@ function extractTar(archivePath) {
         const args = [
             "-xz",
             "-f",
-            (_a = archivePath) === null || _a === void 0 ? void 0 : _a.replace(/\\/g, "/"),
+            archivePath.replace(new RegExp("\\" + path.sep, "g"), "/"),
             "-P",
             "-C",
-            (_b = workingDirectory) === null || _b === void 0 ? void 0 : _b.replace(/\\/g, "/")
+            workingDirectory.replace(new RegExp("\\" + path.sep, "g"), "/")
         ];
         yield execTar(args);
     });
 }
 exports.extractTar = extractTar;
 function createTar(archiveFolder, sourceDirectories) {
-    var _a, _b;
     return __awaiter(this, void 0, void 0, function* () {
         // Write source directories to manifest.txt to avoid command length limits
         const manifestFilename = "manifest.txt";
@@ -5041,10 +5039,10 @@ function createTar(archiveFolder, sourceDirectories) {
         const args = [
             "-cz",
             "-f",
-            (_a = constants_1.CacheFilename) === null || _a === void 0 ? void 0 : _a.replace(/\\/g, "/"),
+            constants_1.CacheFilename.replace(new RegExp("\\" + path.sep, "g"), "/"),
             "-P",
             "-C",
-            (_b = workingDirectory) === null || _b === void 0 ? void 0 : _b.replace(/\\/g, "/"),
+            workingDirectory.replace(new RegExp("\\" + path.sep, "g"), "/"),
             "--files-from",
             manifestFilename
         ];

--- a/dist/save/index.js
+++ b/dist/save/index.js
@@ -4936,12 +4936,30 @@ var __importStar = (this && this.__importStar) || function (mod) {
     return result;
 };
 Object.defineProperty(exports, "__esModule", { value: true });
+const core = __importStar(__webpack_require__(470));
 const exec_1 = __webpack_require__(986);
 const io = __importStar(__webpack_require__(1));
 const fs_1 = __webpack_require__(747);
 const path = __importStar(__webpack_require__(622));
 const constants_1 = __webpack_require__(694);
-function getTarPath() {
+function isGnuTar() {
+    return __awaiter(this, void 0, void 0, function* () {
+        core.debug("Checking tar --version");
+        let versionOutput = "";
+        yield exec_1.exec("tar --version", [], {
+            ignoreReturnCode: true,
+            silent: true,
+            listeners: {
+                stdout: (data) => (versionOutput += data.toString()),
+                stderr: (data) => (versionOutput += data.toString())
+            }
+        });
+        core.debug(versionOutput.trim());
+        return versionOutput.toUpperCase().includes("GNU TAR");
+    });
+}
+exports.isGnuTar = isGnuTar;
+function getTarPath(args) {
     return __awaiter(this, void 0, void 0, function* () {
         // Explicitly use BSD Tar on Windows
         const IS_WINDOWS = process.platform === "win32";
@@ -4950,22 +4968,21 @@ function getTarPath() {
             if (fs_1.existsSync(systemTar)) {
                 return systemTar;
             }
+            else if (isGnuTar()) {
+                args.push("--force-local");
+            }
         }
         return yield io.which("tar", true);
     });
 }
 function execTar(args, cwd) {
-    var _a, _b;
+    var _a;
     return __awaiter(this, void 0, void 0, function* () {
         try {
-            yield exec_1.exec(`"${yield getTarPath()}"`, args, { cwd: cwd });
+            yield exec_1.exec(`"${yield getTarPath(args)}"`, args, { cwd: cwd });
         }
         catch (error) {
-            const IS_WINDOWS = process.platform === "win32";
-            if (IS_WINDOWS) {
-                throw new Error(`Tar failed with error: ${(_a = error) === null || _a === void 0 ? void 0 : _a.message}. Ensure BSD tar is installed and on the PATH.`);
-            }
-            throw new Error(`Tar failed with error: ${(_b = error) === null || _b === void 0 ? void 0 : _b.message}`);
+            throw new Error(`Tar failed with error: ${(_a = error) === null || _a === void 0 ? void 0 : _a.message}`);
         }
     });
 }
@@ -4974,16 +4991,25 @@ function getWorkingDirectory() {
     return _a = process.env["GITHUB_WORKSPACE"], (_a !== null && _a !== void 0 ? _a : process.cwd());
 }
 function extractTar(archivePath) {
+    var _a, _b;
     return __awaiter(this, void 0, void 0, function* () {
         // Create directory to extract tar into
         const workingDirectory = getWorkingDirectory();
         yield io.mkdirP(workingDirectory);
-        const args = ["-xz", "-f", archivePath, "-P", "-C", workingDirectory];
+        const args = [
+            "-xz",
+            "-f",
+            (_a = archivePath) === null || _a === void 0 ? void 0 : _a.replace(/\\/g, "/"),
+            "-P",
+            "-C",
+            (_b = workingDirectory) === null || _b === void 0 ? void 0 : _b.replace(/\\/g, "/")
+        ];
         yield execTar(args);
     });
 }
 exports.extractTar = extractTar;
 function createTar(archiveFolder, sourceDirectories) {
+    var _a, _b;
     return __awaiter(this, void 0, void 0, function* () {
         // Write source directories to manifest.txt to avoid command length limits
         const manifestFilename = "manifest.txt";
@@ -4992,10 +5018,14 @@ function createTar(archiveFolder, sourceDirectories) {
         const args = [
             "-cz",
             "-f",
+<<<<<<< HEAD
             constants_1.CacheFilename,
             "-P",
+=======
+            (_a = constants_1.CacheFilename) === null || _a === void 0 ? void 0 : _a.replace(/\\/g, "/"),
+>>>>>>> Fallback to GNU tar if BSD tar is unavailable
             "-C",
-            workingDirectory,
+            (_b = workingDirectory) === null || _b === void 0 ? void 0 : _b.replace(/\\/g, "/"),
             "--files-from",
             manifestFilename
         ];

--- a/dist/save/index.js
+++ b/dist/save/index.js
@@ -4991,7 +4991,6 @@ function getWorkingDirectory() {
     return _a = process.env["GITHUB_WORKSPACE"], (_a !== null && _a !== void 0 ? _a : process.cwd());
 }
 function extractTar(archivePath) {
-    var _a, _b;
     return __awaiter(this, void 0, void 0, function* () {
         // Create directory to extract tar into
         const workingDirectory = getWorkingDirectory();
@@ -4999,17 +4998,16 @@ function extractTar(archivePath) {
         const args = [
             "-xz",
             "-f",
-            (_a = archivePath) === null || _a === void 0 ? void 0 : _a.replace(/\\/g, "/"),
+            archivePath.replace(new RegExp("\\" + path.sep, "g"), "/"),
             "-P",
             "-C",
-            (_b = workingDirectory) === null || _b === void 0 ? void 0 : _b.replace(/\\/g, "/")
+            workingDirectory.replace(new RegExp("\\" + path.sep, "g"), "/")
         ];
         yield execTar(args);
     });
 }
 exports.extractTar = extractTar;
 function createTar(archiveFolder, sourceDirectories) {
-    var _a, _b;
     return __awaiter(this, void 0, void 0, function* () {
         // Write source directories to manifest.txt to avoid command length limits
         const manifestFilename = "manifest.txt";
@@ -5018,10 +5016,10 @@ function createTar(archiveFolder, sourceDirectories) {
         const args = [
             "-cz",
             "-f",
-            (_a = constants_1.CacheFilename) === null || _a === void 0 ? void 0 : _a.replace(/\\/g, "/"),
+            constants_1.CacheFilename.replace(new RegExp("\\" + path.sep, "g"), "/"),
             "-P",
             "-C",
-            (_b = workingDirectory) === null || _b === void 0 ? void 0 : _b.replace(/\\/g, "/"),
+            workingDirectory.replace(new RegExp("\\" + path.sep, "g"), "/"),
             "--files-from",
             manifestFilename
         ];

--- a/dist/save/index.js
+++ b/dist/save/index.js
@@ -5018,12 +5018,8 @@ function createTar(archiveFolder, sourceDirectories) {
         const args = [
             "-cz",
             "-f",
-<<<<<<< HEAD
-            constants_1.CacheFilename,
-            "-P",
-=======
             (_a = constants_1.CacheFilename) === null || _a === void 0 ? void 0 : _a.replace(/\\/g, "/"),
->>>>>>> Fallback to GNU tar if BSD tar is unavailable
+            "-P",
             "-C",
             (_b = workingDirectory) === null || _b === void 0 ? void 0 : _b.replace(/\\/g, "/"),
             "--files-from",

--- a/src/tar.ts
+++ b/src/tar.ts
@@ -56,10 +56,10 @@ export async function extractTar(archivePath: string): Promise<void> {
     const args = [
         "-xz",
         "-f",
-        archivePath?.replace(/\\/g, "/"),
+        archivePath.replace(new RegExp("\\" + path.sep, "g"), "/"),
         "-P",
         "-C",
-        workingDirectory?.replace(/\\/g, "/")
+        workingDirectory.replace(new RegExp("\\" + path.sep, "g"), "/")
     ];
     await execTar(args);
 }
@@ -79,10 +79,10 @@ export async function createTar(
     const args = [
         "-cz",
         "-f",
-        CacheFilename?.replace(/\\/g, "/"),
+        CacheFilename.replace(new RegExp("\\" + path.sep, "g"), "/"),
         "-P",
         "-C",
-        workingDirectory?.replace(/\\/g, "/"),
+        workingDirectory.replace(new RegExp("\\" + path.sep, "g"), "/"),
         "--files-from",
         manifestFilename
     ];


### PR DESCRIPTION
Test added for the fallback scenario. 

Fixes https://github.com/actions/cache/issues/153 and https://github.com/github/c2c-actions-service/issues/854