### PR TITLE
Allow all events to access cache 

### DIFF
--- a/__tests__/actionUtils.test.ts
+++ b/__tests__/actionUtils.test.ts
@@ -4,7 +4,7 @@ import { promises as fs } from "fs";
 import * as os from "os";
 import * as path from "path";
 
-import { Events, Outputs, State } from "../src/constants";
+import { Events, Outputs, RefKey, State } from "../src/constants";
 import { ArtifactCacheEntry } from "../src/contracts";
 import * as actionUtils from "../src/utils/actionUtils";
 
@@ -19,6 +19,7 @@ function getTempDir(): string {
 
 afterEach(() => {
     delete process.env[Events.Key];
+    delete process.env[RefKey];
 });
 
 afterAll(async () => {
@@ -185,7 +186,7 @@ test("logWarning logs a message with a warning prefix", () => {
     expect(infoMock).toHaveBeenCalledWith(`[warning]${message}`);
 });
 
-test("isValidEvent returns false for unknown event", () => {
+test("isValidEvent returns false for event that does not have a branch or tag", () => {
     const event = "foo";
     process.env[Events.Key] = event;
 
@@ -325,18 +326,10 @@ test("resolvePaths exclusion pattern returns not found", async () => {
     }
 });
 
-test("isValidEvent returns true for push event", () => {
+test("isValidEvent returns true for event that has a ref", () => {
     const event = Events.Push;
     process.env[Events.Key] = event;
-
-    const isValidEvent = actionUtils.isValidEvent();
-
-    expect(isValidEvent).toBe(true);
-});
-
-test("isValidEvent returns true for pull request event", () => {
-    const event = Events.PullRequest;
-    process.env[Events.Key] = event;
+    process.env[RefKey] = "ref/heads/feature";
 
     const isValidEvent = actionUtils.isValidEvent();
 

--- a/__tests__/restore.test.ts
+++ b/__tests__/restore.test.ts
@@ -6,7 +6,8 @@ import {
     CacheFilename,
     CompressionMethod,
     Events,
-    Inputs
+    Inputs,
+    RefKey
 } from "../src/constants";
 import { ArtifactCacheEntry } from "../src/contracts";
 import run from "../src/restore";
@@ -31,11 +32,6 @@ beforeAll(() => {
         return actualUtils.isValidEvent();
     });
 
-    jest.spyOn(actionUtils, "getSupportedEvents").mockImplementation(() => {
-        const actualUtils = jest.requireActual("../src/utils/actionUtils");
-        return actualUtils.getSupportedEvents();
-    });
-
     jest.spyOn(actionUtils, "getCacheFileName").mockImplementation(cm => {
         const actualUtils = jest.requireActual("../src/utils/actionUtils");
         return actualUtils.getCacheFileName(cm);
@@ -44,11 +40,13 @@ beforeAll(() => {
 
 beforeEach(() => {
     process.env[Events.Key] = Events.Push;
+    process.env[RefKey] = "refs/heads/feature-branch";
 });
 
 afterEach(() => {
     testUtils.clearInputs();
     delete process.env[Events.Key];
+    delete process.env[RefKey];
 });
 
 test("restore with invalid event outputs warning", async () => {
@@ -56,9 +54,10 @@ test("restore with invalid event outputs warning", async () => {
     const failedMock = jest.spyOn(core, "setFailed");
     const invalidEvent = "commit_comment";
     process.env[Events.Key] = invalidEvent;
+    delete process.env[RefKey];
     await run();
     expect(logWarningMock).toHaveBeenCalledWith(
-        `Event Validation Error: The event type ${invalidEvent} is not supported. Only push, pull_request events are supported at this time.`
+        `Event Validation Error: The event type ${invalidEvent} is not supported because it's not tied to a branch or tag ref.`
     );
     expect(failedMock).toHaveBeenCalledTimes(0);
 });

--- a/__tests__/save.test.ts
+++ b/__tests__/save.test.ts
@@ -6,7 +6,8 @@ import {
     CacheFilename,
     CompressionMethod,
     Events,
-    Inputs
+    Inputs,
+    RefKey
 } from "../src/constants";
 import { ArtifactCacheEntry } from "../src/contracts";
 import run from "../src/save";
@@ -41,11 +42,6 @@ beforeAll(() => {
         return actualUtils.isValidEvent();
     });
 
-    jest.spyOn(actionUtils, "getSupportedEvents").mockImplementation(() => {
-        const actualUtils = jest.requireActual("../src/utils/actionUtils");
-        return actualUtils.getSupportedEvents();
-    });
-
     jest.spyOn(actionUtils, "resolvePaths").mockImplementation(
         async filePaths => {
             return filePaths.map(x => path.resolve(x));
@@ -64,11 +60,13 @@ beforeAll(() => {
 
 beforeEach(() => {
     process.env[Events.Key] = Events.Push;
+    process.env[RefKey] = "refs/heads/feature-branch";
 });
 
 afterEach(() => {
     testUtils.clearInputs();
     delete process.env[Events.Key];
+    delete process.env[RefKey];
 });
 
 test("save with invalid event outputs warning", async () => {
@@ -76,9 +74,10 @@ test("save with invalid event outputs warning", async () => {
     const failedMock = jest.spyOn(core, "setFailed");
     const invalidEvent = "commit_comment";
     process.env[Events.Key] = invalidEvent;
+    delete process.env[RefKey];
     await run();
     expect(logWarningMock).toHaveBeenCalledWith(
-        `Event Validation Error: The event type ${invalidEvent} is not supported. Only push, pull_request events are supported at this time.`
+        `Event Validation Error: The event type ${invalidEvent} is not supported because it's not tied to a branch or tag ref.`
     );
     expect(failedMock).toHaveBeenCalledTimes(0);
 });

--- a/dist/restore/index.js
+++ b/dist/restore/index.js
@@ -3309,7 +3309,7 @@ exports.resolvePaths = resolvePaths;
 // Cache token authorized for all events that are tied to a ref
 // See GitHub Context https://help.github.com/actions/automating-your-workflow-with-github-actions/contexts-and-expression-syntax-for-github-actions#github-context
 function isValidEvent() {
-    return constants_1.RefKey in process.env;
+    return constants_1.RefKey in process.env && Boolean(process.env[constants_1.RefKey]);
 }
 exports.isValidEvent = isValidEvent;
 function unlinkFile(path) {

--- a/dist/restore/index.js
+++ b/dist/restore/index.js
@@ -4554,7 +4554,6 @@ var Events;
     Events["Push"] = "push";
     Events["PullRequest"] = "pull_request";
 })(Events = exports.Events || (exports.Events = {}));
-<<<<<<< HEAD
 var CacheFilename;
 (function (CacheFilename) {
     CacheFilename["Gzip"] = "cache.tgz";
@@ -4569,10 +4568,7 @@ var CompressionMethod;
 // over the socket during this period, the socket is destroyed and the download
 // is aborted.
 exports.SocketTimeout = 5000;
-=======
 exports.RefKey = "GITHUB_REF";
-exports.CacheFilename = "cache.tgz";
->>>>>>> Allow all events to access cache
 
 
 /***/ }),

--- a/dist/restore/index.js
+++ b/dist/restore/index.js
@@ -3306,16 +3306,10 @@ function resolvePaths(patterns) {
     });
 }
 exports.resolvePaths = resolvePaths;
-function getSupportedEvents() {
-    return [constants_1.Events.Push, constants_1.Events.PullRequest];
-}
-exports.getSupportedEvents = getSupportedEvents;
-// Currently the cache token is only authorized for push and pull_request events
-// All other events will fail when reading and saving the cache
+// Cache token authorized for all events that are tied to a ref
 // See GitHub Context https://help.github.com/actions/automating-your-workflow-with-github-actions/contexts-and-expression-syntax-for-github-actions#github-context
 function isValidEvent() {
-    const githubEvent = process.env[constants_1.Events.Key] || "";
-    return getSupportedEvents().includes(githubEvent);
+    return constants_1.RefKey in process.env;
 }
 exports.isValidEvent = isValidEvent;
 function unlinkFile(path) {
@@ -4560,6 +4554,7 @@ var Events;
     Events["Push"] = "push";
     Events["PullRequest"] = "pull_request";
 })(Events = exports.Events || (exports.Events = {}));
+<<<<<<< HEAD
 var CacheFilename;
 (function (CacheFilename) {
     CacheFilename["Gzip"] = "cache.tgz";
@@ -4574,6 +4569,10 @@ var CompressionMethod;
 // over the socket during this period, the socket is destroyed and the download
 // is aborted.
 exports.SocketTimeout = 5000;
+=======
+exports.RefKey = "GITHUB_REF";
+exports.CacheFilename = "cache.tgz";
+>>>>>>> Allow all events to access cache
 
 
 /***/ }),
@@ -4667,9 +4666,7 @@ function run() {
         try {
             // Validate inputs, this can cause task failure
             if (!utils.isValidEvent()) {
-                utils.logWarning(`Event Validation Error: The event type ${process.env[constants_1.Events.Key]} is not supported. Only ${utils
-                    .getSupportedEvents()
-                    .join(", ")} events are supported at this time.`);
+                utils.logWarning(`Event Validation Error: The event type ${process.env[constants_1.Events.Key]} is not supported because it's not tied to a branch or tag ref.`);
                 return;
             }
             const primaryKey = core.getInput(constants_1.Inputs.Key, { required: true });

--- a/dist/save/index.js
+++ b/dist/save/index.js
@@ -3309,7 +3309,7 @@ exports.resolvePaths = resolvePaths;
 // Cache token authorized for all events that are tied to a ref
 // See GitHub Context https://help.github.com/actions/automating-your-workflow-with-github-actions/contexts-and-expression-syntax-for-github-actions#github-context
 function isValidEvent() {
-    return constants_1.RefKey in process.env;
+    return constants_1.RefKey in process.env && Boolean(process.env[constants_1.RefKey]);
 }
 exports.isValidEvent = isValidEvent;
 function unlinkFile(path) {

--- a/dist/save/index.js
+++ b/dist/save/index.js
@@ -3306,16 +3306,10 @@ function resolvePaths(patterns) {
     });
 }
 exports.resolvePaths = resolvePaths;
-function getSupportedEvents() {
-    return [constants_1.Events.Push, constants_1.Events.PullRequest];
-}
-exports.getSupportedEvents = getSupportedEvents;
-// Currently the cache token is only authorized for push and pull_request events
-// All other events will fail when reading and saving the cache
+// Cache token authorized for all events that are tied to a ref
 // See GitHub Context https://help.github.com/actions/automating-your-workflow-with-github-actions/contexts-and-expression-syntax-for-github-actions#github-context
 function isValidEvent() {
-    const githubEvent = process.env[constants_1.Events.Key] || "";
-    return getSupportedEvents().includes(githubEvent);
+    return constants_1.RefKey in process.env;
 }
 exports.isValidEvent = isValidEvent;
 function unlinkFile(path) {
@@ -4565,9 +4559,7 @@ function run() {
     return __awaiter(this, void 0, void 0, function* () {
         try {
             if (!utils.isValidEvent()) {
-                utils.logWarning(`Event Validation Error: The event type ${process.env[constants_1.Events.Key]} is not supported. Only ${utils
-                    .getSupportedEvents()
-                    .join(", ")} events are supported at this time.`);
+                utils.logWarning(`Event Validation Error: The event type ${process.env[constants_1.Events.Key]} is not supported because it's not tied to a branch or tag ref.`);
                 return;
             }
             const state = utils.getCacheState();
@@ -4663,6 +4655,7 @@ var CompressionMethod;
 // over the socket during this period, the socket is destroyed and the download
 // is aborted.
 exports.SocketTimeout = 5000;
+exports.RefKey = "GITHUB_REF";
 
 
 /***/ }),

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -33,3 +33,5 @@ export enum CompressionMethod {
 // over the socket during this period, the socket is destroyed and the download
 // is aborted.
 export const SocketTimeout = 5000;
+
+export const RefKey = "GITHUB_REF";

--- a/src/restore.ts
+++ b/src/restore.ts
@@ -13,9 +13,7 @@ async function run(): Promise<void> {
             utils.logWarning(
                 `Event Validation Error: The event type ${
                     process.env[Events.Key]
-                } is not supported. Only ${utils
-                    .getSupportedEvents()
-                    .join(", ")} events are supported at this time.`
+                } is not supported because it's not tied to a branch or tag ref.`
             );
             return;
         }

--- a/src/save.ts
+++ b/src/save.ts
@@ -12,9 +12,7 @@ async function run(): Promise<void> {
             utils.logWarning(
                 `Event Validation Error: The event type ${
                     process.env[Events.Key]
-                } is not supported. Only ${utils
-                    .getSupportedEvents()
-                    .join(", ")} events are supported at this time.`
+                } is not supported because it's not tied to a branch or tag ref.`
             );
             return;
         }

--- a/src/utils/actionUtils.ts
+++ b/src/utils/actionUtils.ts
@@ -7,13 +7,17 @@ import * as path from "path";
 import * as util from "util";
 import * as uuidV4 from "uuid/v4";
 
+<<<<<<< HEAD
 import {
     CacheFilename,
     CompressionMethod,
-    Events,
     Outputs,
+    RefKey,
     State
 } from "../constants";
+=======
+import { Outputs, RefKey, State } from "../constants";
+>>>>>>> Allow all events to access cache
 import { ArtifactCacheEntry } from "../contracts";
 
 // From https://github.com/actions/toolkit/blob/master/packages/tool-cache/src/tool-cache.ts#L23
@@ -108,16 +112,10 @@ export async function resolvePaths(patterns: string[]): Promise<string[]> {
     return paths;
 }
 
-export function getSupportedEvents(): string[] {
-    return [Events.Push, Events.PullRequest];
-}
-
-// Currently the cache token is only authorized for push and pull_request events
-// All other events will fail when reading and saving the cache
+// Cache token authorized for all events that are tied to a ref
 // See GitHub Context https://help.github.com/actions/automating-your-workflow-with-github-actions/contexts-and-expression-syntax-for-github-actions#github-context
 export function isValidEvent(): boolean {
-    const githubEvent = process.env[Events.Key] || "";
-    return getSupportedEvents().includes(githubEvent);
+    return RefKey in process.env;
 }
 
 export function unlinkFile(path: fs.PathLike): Promise<void> {

--- a/src/utils/actionUtils.ts
+++ b/src/utils/actionUtils.ts
@@ -7,7 +7,6 @@ import * as path from "path";
 import * as util from "util";
 import * as uuidV4 from "uuid/v4";
 
-<<<<<<< HEAD
 import {
     CacheFilename,
     CompressionMethod,
@@ -15,9 +14,6 @@ import {
     RefKey,
     State
 } from "../constants";
-=======
-import { Outputs, RefKey, State } from "../constants";
->>>>>>> Allow all events to access cache
 import { ArtifactCacheEntry } from "../contracts";
 
 // From https://github.com/actions/toolkit/blob/master/packages/tool-cache/src/tool-cache.ts#L23

--- a/src/utils/actionUtils.ts
+++ b/src/utils/actionUtils.ts
@@ -115,7 +115,7 @@ export async function resolvePaths(patterns: string[]): Promise<string[]> {
 // Cache token authorized for all events that are tied to a ref
 // See GitHub Context https://help.github.com/actions/automating-your-workflow-with-github-actions/contexts-and-expression-syntax-for-github-actions#github-context
 export function isValidEvent(): boolean {
-    return RefKey in process.env;
+    return RefKey in process.env && Boolean(process.env[RefKey]);
 }
 
 export function unlinkFile(path: fs.PathLike): Promise<void> {


### PR DESCRIPTION
This PR removes the check on the cache actions side and allows all events that are tied to a ref to access cache. It cannot be merged until after the server side change are fully rolled out. 

Fixes: https://github.com/github/c2c-actions-service/issues/369