### PR TITLE
Better error handling during download

### DIFF
--- a/dist/restore/index.js
+++ b/dist/restore/index.js
@@ -2186,6 +2186,8 @@ const http_client_1 = __webpack_require__(539);
 const auth_1 = __webpack_require__(226);
 const crypto = __importStar(__webpack_require__(417));
 const fs = __importStar(__webpack_require__(747));
+const stream = __importStar(__webpack_require__(794));
+const util = __importStar(__webpack_require__(669));
 const constants_1 = __webpack_require__(694);
 const utils = __importStar(__webpack_require__(443));
 const versionSalt = "1.0";
@@ -2271,13 +2273,10 @@ function getCacheEntry(keys) {
     });
 }
 exports.getCacheEntry = getCacheEntry;
-function pipeResponseToStream(response, stream) {
+function pipeResponseToStream(response, output) {
     return __awaiter(this, void 0, void 0, function* () {
-        return new Promise(resolve => {
-            response.message.pipe(stream).on("close", () => {
-                resolve();
-            });
-        });
+        const pipeline = util.promisify(stream.pipeline);
+        yield pipeline(response.message, output);
     });
 }
 function downloadCache(archiveLocation, archivePath) {
@@ -4661,6 +4660,13 @@ function run() {
 run();
 exports.default = run;
 
+
+/***/ }),
+
+/***/ 794:
+/***/ (function(module) {
+
+module.exports = require("stream");
 
 /***/ }),
 

--- a/dist/save/index.js
+++ b/dist/save/index.js
@@ -2186,6 +2186,8 @@ const http_client_1 = __webpack_require__(539);
 const auth_1 = __webpack_require__(226);
 const crypto = __importStar(__webpack_require__(417));
 const fs = __importStar(__webpack_require__(747));
+const stream = __importStar(__webpack_require__(794));
+const util = __importStar(__webpack_require__(669));
 const constants_1 = __webpack_require__(694);
 const utils = __importStar(__webpack_require__(443));
 const versionSalt = "1.0";
@@ -2271,13 +2273,10 @@ function getCacheEntry(keys) {
     });
 }
 exports.getCacheEntry = getCacheEntry;
-function pipeResponseToStream(response, stream) {
+function pipeResponseToStream(response, output) {
     return __awaiter(this, void 0, void 0, function* () {
-        return new Promise(resolve => {
-            response.message.pipe(stream).on("close", () => {
-                resolve();
-            });
-        });
+        const pipeline = util.promisify(stream.pipeline);
+        yield pipeline(response.message, output);
     });
 }
 function downloadCache(archiveLocation, archivePath) {
@@ -4638,6 +4637,13 @@ exports.SearchState = SearchState;
 /***/ (function(module) {
 
 module.exports = require("fs");
+
+/***/ }),
+
+/***/ 794:
+/***/ (function(module) {
+
+module.exports = require("stream");
 
 /***/ }),
 

--- a/src/cacheHttpClient.ts
+++ b/src/cacheHttpClient.ts
@@ -8,6 +8,8 @@ import {
 } from "@actions/http-client/interfaces";
 import * as crypto from "crypto";
 import * as fs from "fs";
+import * as stream from "stream";
+import * as util from "util";
 
 import { Inputs, SocketTimeout } from "./constants";
 import {
@@ -128,13 +130,10 @@ export async function getCacheEntry(
 
 async function pipeResponseToStream(
     response: IHttpClientResponse,
-    stream: NodeJS.WritableStream
+    output: NodeJS.WritableStream
 ): Promise<void> {
-    return new Promise(resolve => {
-        response.message.pipe(stream).on("close", () => {
-            resolve();
-        });
-    });
+    const pipeline = util.promisify(stream.pipeline);
+    await pipeline(response.message, output);
 }
 
 export async function downloadCache(


### PR DESCRIPTION
Improves error handling by using the same fix described in https://github.com/actions/toolkit/pull/369.

For example, in the case the download stream is interrupted before all bytes are downloaded, this will raise the error `Premature close`.  This should eliminate the need to check the content length header, but it also doesn't hurt to leave the content length check in place.