### PR TITLE
Add Python example using 'pip cache dir' to get cache location

### DIFF
--- a/examples.md
+++ b/examples.md
@@ -294,10 +294,10 @@ Replace `~/.cache/pip` with the correct `path` if not using Ubuntu.
 
 > Note: This uses an internal pip API and may not always work
 ```yaml
-- name: Get pip cache
-   id: pip-cache
-   run: |
-     python -c "from pip._internal.locations import USER_CACHE_DIR; print('::set-output name=dir::' + USER_CACHE_DIR)"
+- name: Get pip cache dir
+ id: pip-cache
+ run: |
+   python -c "from pip._internal.locations import USER_CACHE_DIR; print('::set-output name=dir::' + USER_CACHE_DIR)"
 
 - uses: actions/cache@v1
   with:

--- a/examples.md
+++ b/examples.md
@@ -18,6 +18,7 @@
   - [Python - pip](#python---pip)
     - [Simple example](#simple-example)
     - [Multiple OS's in a workflow](#multiple-oss-in-a-workflow)
+    - [Using pip to get cache location](#using-pip-to-get-cache-location)
     - [Using a script to get cache location](#using-a-script-to-get-cache-location)
   - [R - renv](#r---renv)
     - [Simple example](#simple-example-1)
@@ -285,6 +286,25 @@ Replace `~/.cache/pip` with the correct `path` if not using Ubuntu.
   if: startsWith(runner.os, 'Windows')
   with:
     path: ~\AppData\Local\pip\Cache
+    key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
+    restore-keys: |
+      ${{ runner.os }}-pip-
+```
+
+### Using pip to get cache location
+
+> Note: This requires pip 20.1+
+```yaml
+- name: Get pip cache dir
+  id: pip-cache
+  run: |
+    python -m pip install -U "pip>=20.1"
+    echo "::set-output name=dir::$(pip cache dir)"
+
+- name: pip cache
+  uses: actions/cache@v1
+  with:
+    path: ${{ steps.pip-cache.outputs.dir }}
     key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
     restore-keys: |
       ${{ runner.os }}-pip-

--- a/examples.md
+++ b/examples.md
@@ -298,7 +298,6 @@ Replace `~/.cache/pip` with the correct `path` if not using Ubuntu.
 - name: Get pip cache dir
   id: pip-cache
   run: |
-    python -m pip install -U "pip>=20.1"
     echo "::set-output name=dir::$(pip cache dir)"
 
 - name: pip cache


### PR DESCRIPTION
:tada: I'm happy to say `pip cache dir` has been released in this week's pip 20.1:

* https://github.com/pypa/pip/issues/7350
* https://github.com/pypa/pip/pull/8095
* https://pip.pypa.io/en/stable/news/

This means we can simplify the cache config for multiple operating systems:

```yaml
- name: Get pip cache dir
  id: pip-cache
  run: |
    python -m pip install -U "pip>=20.1"
    echo "::set-output name=dir::$(pip cache dir)"

- name: pip cache
  uses: actions/cache@v1
  with:
    path: ${{ steps.pip-cache.outputs.dir }}
    key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
    restore-keys: |
      ${{ runner.os }}-pip-
```

If/when the https://github.com/actions/virtual-environments/ ship with pip 20.1 or later, `python -m pip install -U "pip>=20.1"` could be removed.

This PR adds this to examples.md, and fixes an indentation problem in an existing example.

---

I didn't remove any of the other examples:

* "Multiple OS's in a workflow" could still be useful, if someone just wanted, say, the Windows config

* "Using a script to get cache location": perhaps this should be removed? It uses an internal pip API, although could still be useful if someone had to use pip<20.1 for some reason.

