### PR TITLE
Update the ruby caching example

### DIFF
--- a/examples.md
+++ b/examples.md
@@ -381,17 +381,15 @@ Replace `~/.local/share/renv` with the correct `path` if not using Ubuntu.
 - uses: actions/cache@v1
   with:
     path: vendor/bundle
-    key: ${{ runner.os }}-gems-${{ hashFiles('**/Gemfile.lock') }}
+    key: ${{ runner.os }}-gems-${{ hashFiles('.ruby-version') }}-${{ hashFiles('**/Gemfile.lock') }}
     restore-keys: |
-      ${{ runner.os }}-gems-
+      ${{ runner.os }}-gems-${{ hashFiles('.ruby-version') }}-
 ```
-When dependencies are installed later in the workflow, we must specify the same path for the bundler.
+When dependencies are installed later use the `--deployment` flag which tells bundler to install gems to `vendor/bundle`, and sets other options optimized for a CI workflow.
 
 ```yaml
 - name: Bundle install
-  run: |
-    bundle config path vendor/bundle
-    bundle install --jobs 4 --retry 3
+  run: bundle install --deployment --jobs 4 --retry 3
 ```
 
 ## Rust - Cargo


### PR DESCRIPTION
The ruby version should be a part of the cache hash. Gems built for one version of ruby may not work with a different version of ruby. Making the ruby version a part of the cache key will bust the cache when the ruby version changes.

 Most ruby projects have a `.ruby-version` file that can be hashed into the cache key.

Use the `--deployment` option with `bundle install` to properly set `vendor/bundle` as the gem path, and also set other options optimized for CI deployment. https://bundler.io/v2.0/man/bundle-install.1.html#DEPLOYMENT-MODE

Rather than updating these instructions the ruby example could just link here: https://github.com/ruby/setup-ruby#caching-bundle-install. But I don't know if you want to make these instructions depend on a readme in another project.