### PR TITLE
Recommend --deployment flag for Bundler

### DIFF
--- a/examples.md
+++ b/examples.md
@@ -385,7 +385,13 @@ Replace `~/.local/share/renv` with the correct `path` if not using Ubuntu.
     restore-keys: |
       ${{ runner.os }}-gems-
 ```
-When dependencies are installed later in the workflow, we must specify the same path for the bundler.
+When dependencies are installed later in the workflow, we must use the `--deployment` flag to install gems to `vendor/bundle`.
+
+```yaml
+- name: Bundle install
+  run: bundle install --deployment --jobs 4 --retry 3
+```
+If you don’t want to run Bundler in deployment mode, you can instead use `bundle config`.
 
 ```yaml
 - name: Bundle install


### PR DESCRIPTION
Bundler’s `--deployment` flag activates [deployment mode](https://bundler.io/v2.0/man/bundle-install.1.html#DEPLOYMENT-MODE) which is specifically optimized for deployment and continuous integration. As these use cases arguably cover the majority of workflows, I think it should be recommended over manually setting the path using `bundle config`.