### PR TITLE
error handling for stream

### DIFF
--- a/dist/restore/index.js
+++ b/dist/restore/index.js
@@ -2379,11 +2379,15 @@ function uploadFile(httpClient, cacheId, archivePath) {
                     const start = offset;
                     const end = offset + chunkSize - 1;
                     offset += MAX_CHUNK_SIZE;
-                    yield uploadChunk(httpClient, resourceUrl, () => fs.createReadStream(archivePath, {
+                    yield uploadChunk(httpClient, resourceUrl, () => fs
+                        .createReadStream(archivePath, {
                         fd,
                         start,
                         end,
                         autoClose: false
+                    })
+                        .on("error", error => {
+                        throw new Error(`Cache upload failed because file read failed with ${error.Message}`);
                     }), start, end);
                 }
             })));

--- a/dist/save/index.js
+++ b/dist/save/index.js
@@ -2379,11 +2379,15 @@ function uploadFile(httpClient, cacheId, archivePath) {
                     const start = offset;
                     const end = offset + chunkSize - 1;
                     offset += MAX_CHUNK_SIZE;
-                    yield uploadChunk(httpClient, resourceUrl, () => fs.createReadStream(archivePath, {
+                    yield uploadChunk(httpClient, resourceUrl, () => fs
+                        .createReadStream(archivePath, {
                         fd,
                         start,
                         end,
                         autoClose: false
+                    })
+                        .on("error", error => {
+                        throw new Error(`Cache upload failed because file read failed with ${error.Message}`);
                     }), start, end);
                 }
             })));

--- a/src/cacheHttpClient.ts
+++ b/src/cacheHttpClient.ts
@@ -295,12 +295,18 @@ async function uploadFile(
                         httpClient,
                         resourceUrl,
                         () =>
-                            fs.createReadStream(archivePath, {
-                                fd,
-                                start,
-                                end,
-                                autoClose: false
-                            }),
+                            fs
+                                .createReadStream(archivePath, {
+                                    fd,
+                                    start,
+                                    end,
+                                    autoClose: false
+                                })
+                                .on("error", error => {
+                                    throw new Error(
+                                        `Cache upload failed because file read failed with ${error.Message}`
+                                    );
+                                }),
                         start,
                         end
                     );


### PR DESCRIPTION
Fixes https://github.com/actions/cache/issues/287

> The 'error' event may be emitted by a Readable implementation at any time. Typically, this may occur if the underlying stream is unable to generate data due to an underlying internal failure, or when a stream implementation attempts to push an invalid chunk of data.

From: https://nodejs.org/api/stream.html#stream_event_error_1

