### PR TITLE
Add D example using DUB

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ Every programming language and framework has its own way of caching.
 See [Examples](examples.md) for a list of `actions/cache` implementations for use with:
 
 - [C# - Nuget](./examples.md#c---nuget)
+- [D - DUB](./examples.md#d---dub)
 - [Elixir - Mix](./examples.md#elixir---mix)
 - [Go - Modules](./examples.md#go---modules)
 - [Haskell - Cabal](./examples.md#haskell---cabal)

--- a/examples.md
+++ b/examples.md
@@ -2,6 +2,7 @@
 
 - [Examples](#examples)
   - [C# - NuGet](#c---nuget)
+  - [D - DUB](#d---dub)
   - [Elixir - Mix](#elixir---mix)
   - [Go - Modules](#go---modules)
   - [Haskell - Cabal](#haskell---cabal)
@@ -55,6 +56,30 @@ steps:
       key: ${{ runner.os }}-nuget-${{ hashFiles('**/packages.lock.json') }}
       restore-keys: |
         ${{ runner.os }}-nuget-
+```
+
+## D - DUB
+
+### POSIX
+
+```yaml
+- uses: actions/cache@v1
+  with:
+    path: ~/.dub
+    key: ${{ runner.os }}-dub-${{ hashFiles('**/dub.json') }}
+    restore-keys: |
+      ${{ runner.os }}-dub-
+```
+
+### Windows
+
+```yaml
+- uses: actions/cache@v1
+  with:
+    path: ~\AppData\Local\dub
+    key: ${{ runner.os }}-dub-${{ hashFiles('**/dub.json') }}
+    restore-keys: |
+      ${{ runner.os }}-dub-
 ```
 
 ## Elixir - Mix


### PR DESCRIPTION
D typically uses DUB to describe package dependencies in [dub.json](https://dub.pm/package-format-json). And I confirmed its (undocumented) local package path in https://github.com/dlang/dub/blob/4ed2091d04952c46a2a02b467a6ae08689e7bf5d/source/dub/dub.d#L270-L281 and my local env.

You can also find working examples in https://github.com/ShigekiKarita/tfd/actions