### PR TITLE
Cherry-pick commits for v1

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -4,51 +4,130 @@ on:
   pull_request:
     branches:
       - master
+      - releases/**
     paths-ignore:
       - '**.md'
   push:
     branches:
       - master
+      - releases/**
     paths-ignore:
       - '**.md'
 
 jobs:
-  test:
-    name: Test on ${{ matrix.os }}
-
+  # Build and unit test
+  build:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macOS-latest]
       fail-fast: false
-
     runs-on: ${{ matrix.os }}
-
     steps:
-    - uses: actions/checkout@v1
-
-    - uses: actions/setup-node@v1
+    - name: Checkout
+      uses: actions/checkout@v2
+    - name: Setup Node.js
+      uses: actions/setup-node@v1
       with:
         node-version: '12.x'
-
-    - name: Get npm cache directory
+    - name: Determine npm cache directory
       id: npm-cache
       run: |
         echo "::set-output name=dir::$(npm config get cache)"
-
-    - uses: actions/cache@v1
+    - name: Restore npm cache
+      uses: actions/cache@v1
       with:
         path: ${{ steps.npm-cache.outputs.dir }}
         key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
         restore-keys: |
           ${{ runner.os }}-node-
-
     - run: npm ci
-
     - name: Prettier Format Check
       run: npm run format-check
-
     - name: ESLint Check
       run: npm run lint
-
     - name: Build & Test
       run: npm run test
+
+  # End to end save and restore
+  test-save:
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest, macOS-latest]
+      fail-fast: false
+    runs-on: ${{ matrix.os }}
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+    - name: Generate files
+      shell: bash
+      run: __tests__/create-cache-files.sh ${{ runner.os }}
+    - name: Save cache
+      uses: ./
+      with:
+        key: test-${{ runner.os }}-${{ github.run_id }}
+        path: test-cache
+  test-restore:
+    needs: test-save
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest, macOS-latest]
+      fail-fast: false
+    runs-on: ${{ matrix.os }}
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+    - name: Restore cache
+      uses: ./
+      with:
+        key: test-${{ runner.os }}-${{ github.run_id }}
+        path: test-cache
+    - name: Verify cache
+      shell: bash
+      run: __tests__/verify-cache-files.sh ${{ runner.os }}
+
+  # End to end with proxy
+  test-proxy-save:
+    runs-on: ubuntu-latest
+    container:
+      image: ubuntu:latest
+      options: --dns 127.0.0.1
+    services:
+      squid-proxy:
+        image: datadog/squid:latest
+        ports:
+          - 3128:3128
+    env:
+      https_proxy: http://squid-proxy:3128
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+    - name: Generate files
+      run: __tests__/create-cache-files.sh proxy
+    - name: Save cache
+      uses: ./
+      with:
+        key: test-proxy-${{ github.run_id }}
+        path: test-cache
+  test-proxy-restore:
+    needs: test-proxy-save
+    runs-on: ubuntu-latest
+    container:
+      image: ubuntu:latest
+      options: --dns 127.0.0.1
+    services:
+      squid-proxy:
+        image: datadog/squid:latest
+        ports:
+          - 3128:3128
+    env:
+      https_proxy: http://squid-proxy:3128
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+    - name: Restore cache
+      uses: ./
+      with:
+        key: test-proxy-${{ github.run_id }}
+        path: test-cache
+    - name: Verify cache
+      run: __tests__/verify-cache-files.sh proxy

--- a/__tests__/cacheHttpsClient.test.ts
+++ b/__tests__/cacheHttpsClient.test.ts
@@ -1,0 +1,144 @@
+import { retry } from "../src/cacheHttpClient";
+import * as testUtils from "../src/utils/testUtils";
+
+afterEach(() => {
+    testUtils.clearInputs();
+});
+
+interface TestResponse {
+    statusCode: number;
+    result: string | null;
+}
+
+function handleResponse(
+    response: TestResponse | undefined
+): Promise<TestResponse> {
+    if (!response) {
+        fail("Retry method called too many times");
+    }
+
+    if (response.statusCode === 999) {
+        throw Error("Test Error");
+    } else {
+        return Promise.resolve(response);
+    }
+}
+
+async function testRetryExpectingResult(
+    responses: Array<TestResponse>,
+    expectedResult: string | null
+): Promise<void> {
+    responses = responses.reverse(); // Reverse responses since we pop from end
+
+    const actualResult = await retry(
+        "test",
+        () => handleResponse(responses.pop()),
+        (response: TestResponse) => response.statusCode
+    );
+
+    expect(actualResult.result).toEqual(expectedResult);
+}
+
+async function testRetryExpectingError(
+    responses: Array<TestResponse>
+): Promise<void> {
+    responses = responses.reverse(); // Reverse responses since we pop from end
+
+    expect(
+        retry(
+            "test",
+            () => handleResponse(responses.pop()),
+            (response: TestResponse) => response.statusCode
+        )
+    ).rejects.toBeInstanceOf(Error);
+}
+
+test("retry works on successful response", async () => {
+    await testRetryExpectingResult(
+        [
+            {
+                statusCode: 200,
+                result: "Ok"
+            }
+        ],
+        "Ok"
+    );
+});
+
+test("retry works after retryable status code", async () => {
+    await testRetryExpectingResult(
+        [
+            {
+                statusCode: 503,
+                result: null
+            },
+            {
+                statusCode: 200,
+                result: "Ok"
+            }
+        ],
+        "Ok"
+    );
+});
+
+test("retry fails after exhausting retries", async () => {
+    await testRetryExpectingError([
+        {
+            statusCode: 503,
+            result: null
+        },
+        {
+            statusCode: 503,
+            result: null
+        },
+        {
+            statusCode: 200,
+            result: "Ok"
+        }
+    ]);
+});
+
+test("retry fails after non-retryable status code", async () => {
+    await testRetryExpectingError([
+        {
+            statusCode: 500,
+            result: null
+        },
+        {
+            statusCode: 200,
+            result: "Ok"
+        }
+    ]);
+});
+
+test("retry works after error", async () => {
+    await testRetryExpectingResult(
+        [
+            {
+                statusCode: 999,
+                result: null
+            },
+            {
+                statusCode: 200,
+                result: "Ok"
+            }
+        ],
+        "Ok"
+    );
+});
+
+test("retry returns after client error", async () => {
+    await testRetryExpectingResult(
+        [
+            {
+                statusCode: 400,
+                result: null
+            },
+            {
+                statusCode: 200,
+                result: "Ok"
+            }
+        ],
+        null
+    );
+});

--- a/__tests__/create-cache-files.sh
+++ b/__tests__/create-cache-files.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+# Validate args
+prefix="$1"
+if [ -z "$prefix" ]; then
+  echo "Must supply prefix argument"
+  exit 1
+fi
+
+mkdir test-cache
+echo "$prefix $GITHUB_RUN_ID" > test-cache/test-file.txt

--- a/__tests__/tar.test.ts
+++ b/__tests__/tar.test.ts
@@ -51,7 +51,7 @@ test("extract GNU tar", async () => {
 
         await tar.extractTar(archivePath, targetDirectory);
 
-        expect(execMock).toHaveBeenCalledTimes(2);
+        expect(execMock).toHaveBeenCalledTimes(1);
         expect(execMock).toHaveBeenLastCalledWith(`"tar"`, [
             "-xz",
             "-f",

--- a/__tests__/tar.test.ts
+++ b/__tests__/tar.test.ts
@@ -1,8 +1,9 @@
 import * as exec from "@actions/exec";
 import * as io from "@actions/io";
-import * as fs from "fs";
 import * as path from "path";
 import * as tar from "../src/tar";
+
+import fs = require("fs");
 
 jest.mock("@actions/exec");
 jest.mock("@actions/io");
@@ -42,25 +43,18 @@ test("extract BSD tar", async () => {
 test("extract GNU tar", async () => {
     const IS_WINDOWS = process.platform === "win32";
     if (IS_WINDOWS) {
-        jest.mock("fs");
+        jest.spyOn(fs, "existsSync").mockReturnValueOnce(false);
+        jest.spyOn(tar, "isGnuTar").mockReturnValue(Promise.resolve(true));
 
         const execMock = jest.spyOn(exec, "exec");
-        const existsSyncMock = jest
-            .spyOn(fs, "existsSync")
-            .mockReturnValue(false);
-        const isGnuTarMock = jest
-            .spyOn(tar, "isGnuTar")
-            .mockReturnValue(Promise.resolve(true));
         const archivePath = `${process.env["windir"]}\\fakepath\\cache.tar`;
         const targetDirectory = "~/.npm/cache";
 
         await tar.extractTar(archivePath, targetDirectory);
 
-        expect(existsSyncMock).toHaveBeenCalledTimes(1);
-        expect(isGnuTarMock).toHaveBeenCalledTimes(1);
         expect(execMock).toHaveBeenCalledTimes(2);
         expect(execMock).toHaveBeenLastCalledWith(
-            "tar",
+            `"tar"`,
             [
                 "-xz",
                 "-f",

--- a/__tests__/tar.test.ts
+++ b/__tests__/tar.test.ts
@@ -1,6 +1,5 @@
 import * as exec from "@actions/exec";
 import * as io from "@actions/io";
-import * as path from "path";
 import * as tar from "../src/tar";
 
 import fs = require("fs");
@@ -34,9 +33,9 @@ test("extract BSD tar", async () => {
     expect(execMock).toHaveBeenCalledWith(`"${tarPath}"`, [
         "-xz",
         "-f",
-        archivePath?.replace(/\\/g, "/"),
+        IS_WINDOWS ? archivePath.replace(/\\/g, "/") : archivePath,
         "-C",
-        targetDirectory?.replace(/\\/g, "/"),
+        IS_WINDOWS ? targetDirectory?.replace(/\\/g, "/") : targetDirectory
     ]);
 });
 
@@ -53,18 +52,14 @@ test("extract GNU tar", async () => {
         await tar.extractTar(archivePath, targetDirectory);
 
         expect(execMock).toHaveBeenCalledTimes(2);
-        expect(execMock).toHaveBeenLastCalledWith(
-            `"tar"`,
-            [
-                "-xz",
-                "-f",
-                archivePath?.replace(/\\/g, "/"),
-                "-C",
-                targetDirectory?.replace(/\\/g, "/"),
-                "--force-local"
-            ],
-            { cwd: undefined }
-        );
+        expect(execMock).toHaveBeenLastCalledWith(`"tar"`, [
+            "-xz",
+            "-f",
+            archivePath.replace(/\\/g, "/"),
+            "-C",
+            targetDirectory?.replace(/\\/g, "/"),
+            "--force-local"
+        ]);
     }
 });
 
@@ -83,9 +78,9 @@ test("create BSD tar", async () => {
     expect(execMock).toHaveBeenCalledWith(`"${tarPath}"`, [
         "-cz",
         "-f",
-        archivePath?.replace(/\\/g, "/"),
+        IS_WINDOWS ? archivePath.replace(/\\/g, "/") : archivePath,
         "-C",
-        sourceDirectory?.replace(/\\/g, "/"),
+        IS_WINDOWS ? sourceDirectory?.replace(/\\/g, "/") : sourceDirectory,
         "."
     ]);
 });

--- a/__tests__/verify-cache-files.sh
+++ b/__tests__/verify-cache-files.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+# Validate args
+prefix="$1"
+if [ -z "$prefix" ]; then
+  echo "Must supply prefix argument"
+  exit 1
+fi
+
+# Sanity check GITHUB_RUN_ID defined
+if [ -z "$GITHUB_RUN_ID" ]; then
+  echo "GITHUB_RUN_ID not defined"
+  exit 1
+fi
+
+# Verify file exists
+file="test-cache/test-file.txt"
+echo "Checking for $file"
+if [ ! -e $file ]; then
+  echo "File does not exist"
+  exit 1
+fi
+
+# Verify file content
+content="$(cat $file)"
+echo "File content:\n$content"
+if [ -z "$(echo $content | grep --fixed-strings "$prefix $GITHUB_RUN_ID")" ]; then
+  echo "Unexpected file content"
+  exit 1
+fi

--- a/dist/restore/index.js
+++ b/dist/restore/index.js
@@ -2750,6 +2750,9 @@ var Events;
     Events["Push"] = "push";
     Events["PullRequest"] = "pull_request";
 })(Events = exports.Events || (exports.Events = {}));
+// Socket timeout in milliseconds during download.  If no traffic is received
+// over the socket during this period, the socket is destroyed and the download
+// is aborted.
 exports.SocketTimeout = 5000;
 
 

--- a/dist/restore/index.js
+++ b/dist/restore/index.js
@@ -1252,19 +1252,24 @@ var __importStar = (this && this.__importStar) || function (mod) {
 };
 Object.defineProperty(exports, "__esModule", { value: true });
 const core = __importStar(__webpack_require__(470));
-const fs = __importStar(__webpack_require__(747));
-const auth_1 = __webpack_require__(226);
 const http_client_1 = __webpack_require__(539);
+const auth_1 = __webpack_require__(226);
+const fs = __importStar(__webpack_require__(747));
 const stream = __importStar(__webpack_require__(794));
 const util = __importStar(__webpack_require__(669));
 const constants_1 = __webpack_require__(694);
 const utils = __importStar(__webpack_require__(443));
-const constants_1 = __webpack_require__(694);
 function isSuccessStatusCode(statusCode) {
     if (!statusCode) {
         return false;
     }
     return statusCode >= 200 && statusCode < 300;
+}
+function isServerErrorStatusCode(statusCode) {
+    if (!statusCode) {
+        return true;
+    }
+    return statusCode >= 500;
 }
 function isRetryableStatusCode(statusCode) {
     if (!statusCode) {
@@ -1305,12 +1310,56 @@ function createHttpClient() {
     const bearerCredentialHandler = new auth_1.BearerCredentialHandler(token);
     return new http_client_1.HttpClient("actions/cache", [bearerCredentialHandler], getRequestOptions());
 }
+function retry(name, method, getStatusCode, maxAttempts = 2) {
+    return __awaiter(this, void 0, void 0, function* () {
+        let response = undefined;
+        let statusCode = undefined;
+        let isRetryable = false;
+        let errorMessage = "";
+        let attempt = 1;
+        while (attempt <= maxAttempts) {
+            try {
+                response = yield method();
+                statusCode = getStatusCode(response);
+                if (!isServerErrorStatusCode(statusCode)) {
+                    return response;
+                }
+                isRetryable = isRetryableStatusCode(statusCode);
+                errorMessage = `Cache service responded with ${statusCode}`;
+            }
+            catch (error) {
+                isRetryable = true;
+                errorMessage = error.message;
+            }
+            core.debug(`${name} - Attempt ${attempt} of ${maxAttempts} failed with error: ${errorMessage}`);
+            if (!isRetryable) {
+                core.debug(`${name} - Error is not retryable`);
+                break;
+            }
+            attempt++;
+        }
+        throw Error(`${name} failed: ${errorMessage}`);
+    });
+}
+exports.retry = retry;
+function retryTypedResponse(name, method, maxAttempts = 2) {
+    return __awaiter(this, void 0, void 0, function* () {
+        return yield retry(name, method, (response) => response.statusCode, maxAttempts);
+    });
+}
+exports.retryTypedResponse = retryTypedResponse;
+function retryHttpClientResponse(name, method, maxAttempts = 2) {
+    return __awaiter(this, void 0, void 0, function* () {
+        return yield retry(name, method, (response) => response.message.statusCode, maxAttempts);
+    });
+}
+exports.retryHttpClientResponse = retryHttpClientResponse;
 function getCacheEntry(keys) {
     var _a;
     return __awaiter(this, void 0, void 0, function* () {
         const httpClient = createHttpClient();
         const resource = `cache?keys=${encodeURIComponent(keys.join(","))}`;
-        const response = yield httpClient.getJson(getCacheApiUrl(resource));
+        const response = yield retryTypedResponse("getCacheEntry", () => httpClient.getJson(getCacheApiUrl(resource)));
         if (response.statusCode === 204) {
             return null;
         }
@@ -1339,7 +1388,7 @@ function downloadCache(archiveLocation, archivePath) {
     return __awaiter(this, void 0, void 0, function* () {
         const stream = fs.createWriteStream(archivePath);
         const httpClient = new http_client_1.HttpClient("actions/cache");
-        const downloadResponse = yield httpClient.get(archiveLocation);
+        const downloadResponse = yield retryHttpClientResponse("downloadCache", () => httpClient.get(archiveLocation));
         // Abort download if no traffic received over the socket.
         downloadResponse.message.socket.setTimeout(constants_1.SocketTimeout, () => {
             downloadResponse.message.destroy();
@@ -1369,7 +1418,7 @@ function reserveCache(key) {
         const reserveCacheRequest = {
             key
         };
-        const response = yield httpClient.postJson(getCacheApiUrl("caches"), reserveCacheRequest);
+        const response = yield retryTypedResponse("reserveCache", () => httpClient.postJson(getCacheApiUrl("caches"), reserveCacheRequest));
         return _c = (_b = (_a = response) === null || _a === void 0 ? void 0 : _a.result) === null || _b === void 0 ? void 0 : _b.cacheId, (_c !== null && _c !== void 0 ? _c : -1);
     });
 }
@@ -1391,21 +1440,7 @@ function uploadChunk(httpClient, resourceUrl, openStream, start, end) {
             "Content-Type": "application/octet-stream",
             "Content-Range": getContentRange(start, end)
         };
-        const uploadChunkRequest = () => __awaiter(this, void 0, void 0, function* () {
-            return yield httpClient.sendStream("PATCH", resourceUrl, openStream(), additionalHeaders);
-        });
-        const response = yield uploadChunkRequest();
-        if (isSuccessStatusCode(response.message.statusCode)) {
-            return;
-        }
-        if (isRetryableStatusCode(response.message.statusCode)) {
-            core.debug(`Received ${response.message.statusCode}, retrying chunk at offset ${start}.`);
-            const retryResponse = yield uploadChunkRequest();
-            if (isSuccessStatusCode(retryResponse.message.statusCode)) {
-                return;
-            }
-        }
-        throw new Error(`Cache service responded with ${response.message.statusCode} during chunk upload.`);
+        yield retryHttpClientResponse(`uploadChunk (start: ${start}, end: ${end})`, () => httpClient.sendStream("PATCH", resourceUrl, openStream(), additionalHeaders));
     });
 }
 function parseEnvNumber(key) {
@@ -1457,7 +1492,7 @@ function uploadFile(httpClient, cacheId, archivePath) {
 function commitCache(httpClient, cacheId, filesize) {
     return __awaiter(this, void 0, void 0, function* () {
         const commitCacheRequest = { size: filesize };
-        return yield httpClient.postJson(getCacheApiUrl(`caches/${cacheId.toString()}`), commitCacheRequest);
+        return yield retryTypedResponse("commitCache", () => httpClient.postJson(getCacheApiUrl(`caches/${cacheId.toString()}`), commitCacheRequest));
     });
 }
 function saveCache(cacheId, archivePath) {
@@ -1499,9 +1534,7 @@ class BasicCredentialHandler {
         this.password = password;
     }
     prepareRequest(options) {
-        options.headers['Authorization'] =
-            'Basic ' +
-                Buffer.from(this.username + ':' + this.password).toString('base64');
+        options.headers['Authorization'] = 'Basic ' + Buffer.from(this.username + ':' + this.password).toString('base64');
     }
     // This handler cannot handle 401
     canHandleAuthentication(response) {
@@ -1537,8 +1570,7 @@ class PersonalAccessTokenCredentialHandler {
     // currently implements pre-authorization
     // TODO: support preAuth = false where it hooks on 401
     prepareRequest(options) {
-        options.headers['Authorization'] =
-            'Basic ' + Buffer.from('PAT:' + this.token).toString('base64');
+        options.headers['Authorization'] = 'Basic ' + Buffer.from('PAT:' + this.token).toString('base64');
     }
     // This handler cannot handle 401
     canHandleAuthentication(response) {
@@ -2007,7 +2039,6 @@ var HttpCodes;
     HttpCodes[HttpCodes["RequestTimeout"] = 408] = "RequestTimeout";
     HttpCodes[HttpCodes["Conflict"] = 409] = "Conflict";
     HttpCodes[HttpCodes["Gone"] = 410] = "Gone";
-    HttpCodes[HttpCodes["TooManyRequests"] = 429] = "TooManyRequests";
     HttpCodes[HttpCodes["InternalServerError"] = 500] = "InternalServerError";
     HttpCodes[HttpCodes["NotImplemented"] = 501] = "NotImplemented";
     HttpCodes[HttpCodes["BadGateway"] = 502] = "BadGateway";
@@ -2032,18 +2063,8 @@ function getProxyUrl(serverUrl) {
     return proxyUrl ? proxyUrl.href : '';
 }
 exports.getProxyUrl = getProxyUrl;
-const HttpRedirectCodes = [
-    HttpCodes.MovedPermanently,
-    HttpCodes.ResourceMoved,
-    HttpCodes.SeeOther,
-    HttpCodes.TemporaryRedirect,
-    HttpCodes.PermanentRedirect
-];
-const HttpResponseRetryCodes = [
-    HttpCodes.BadGateway,
-    HttpCodes.ServiceUnavailable,
-    HttpCodes.GatewayTimeout
-];
+const HttpRedirectCodes = [HttpCodes.MovedPermanently, HttpCodes.ResourceMoved, HttpCodes.SeeOther, HttpCodes.TemporaryRedirect, HttpCodes.PermanentRedirect];
+const HttpResponseRetryCodes = [HttpCodes.BadGateway, HttpCodes.ServiceUnavailable, HttpCodes.GatewayTimeout];
 const RetryableHttpVerbs = ['OPTIONS', 'GET', 'DELETE', 'HEAD'];
 const ExponentialBackoffCeiling = 10;
 const ExponentialBackoffTimeSlice = 5;
@@ -2056,12 +2077,6 @@ class HttpClientResponse {
             let output = Buffer.alloc(0);
             this.message.on('data', (chunk) => {
                 output = Buffer.concat([output, chunk]);
-            });
-            this.message.on('aborted', () => {
-                reject("Request was aborted or closed prematurely");
-            });
-            this.message.on('timeout', (socket) => {
-                reject("Request timed out");
             });
             this.message.on('end', () => {
                 resolve(output.toString());
@@ -2174,23 +2189,18 @@ class HttpClient {
      */
     async request(verb, requestUrl, data, headers) {
         if (this._disposed) {
-            throw new Error('Client has already been disposed.');
+            throw new Error("Client has already been disposed.");
         }
         let parsedUrl = url.parse(requestUrl);
         let info = this._prepareRequest(verb, parsedUrl, headers);
         // Only perform retries on reads since writes may not be idempotent.
-        let maxTries = this._allowRetries && RetryableHttpVerbs.indexOf(verb) != -1
-            ? this._maxRetries + 1
-            : 1;
+        let maxTries = (this._allowRetries && RetryableHttpVerbs.indexOf(verb) != -1) ? this._maxRetries + 1 : 1;
         let numTries = 0;
         let response;
         while (numTries < maxTries) {
             response = await this.requestRaw(info, data);
-
             // Check if it's an authentication challenge
-            if (response &&
-                response.message &&
-                response.message.statusCode === HttpCodes.Unauthorized) {
+            if (response && response.message && response.message.statusCode === HttpCodes.Unauthorized) {
                 let authenticationHandler;
                 for (let i = 0; i < this.handlers.length; i++) {
                     if (this.handlers[i].canHandleAuthentication(response)) {
@@ -2208,32 +2218,21 @@ class HttpClient {
                 }
             }
             let redirectsRemaining = this._maxRedirects;
-            while (HttpRedirectCodes.indexOf(response.message.statusCode) != -1 &&
-                this._allowRedirects &&
-                redirectsRemaining > 0) {
-                const redirectUrl = response.message.headers['location'];
+            while (HttpRedirectCodes.indexOf(response.message.statusCode) != -1
+                && this._allowRedirects
+                && redirectsRemaining > 0) {
+                const redirectUrl = response.message.headers["location"];
                 if (!redirectUrl) {
                     // if there's no location to redirect to, we won't
                     break;
                 }
                 let parsedRedirectUrl = url.parse(redirectUrl);
-                if (parsedUrl.protocol == 'https:' &&
-                    parsedUrl.protocol != parsedRedirectUrl.protocol &&
-                    !this._allowRedirectDowngrade) {
-                    throw new Error('Redirect from HTTPS to HTTP protocol. This downgrade is not allowed for security reasons. If you want to allow this behavior, set the allowRedirectDowngrade option to true.');
+                if (parsedUrl.protocol == 'https:' && parsedUrl.protocol != parsedRedirectUrl.protocol && !this._allowRedirectDowngrade) {
+                    throw new Error("Redirect from HTTPS to HTTP protocol. This downgrade is not allowed for security reasons. If you want to allow this behavior, set the allowRedirectDowngrade option to true.");
                 }
                 // we need to finish reading the response before reassigning response
                 // which will leak the open socket.
                 await response.readBody();
-                // strip authorization header if redirected to a different hostname
-                if (parsedRedirectUrl.hostname !== parsedUrl.hostname) {
-                    for (let header in headers) {
-                        // header names are case insensitive
-                        if (header.toLowerCase() === 'authorization') {
-                            delete headers[header];
-                        }
-                    }
-                }
                 // let's make the request with the new redirectUrl
                 info = this._prepareRequest(verb, parsedRedirectUrl, headers);
                 response = await this.requestRaw(info, data);
@@ -2284,8 +2283,8 @@ class HttpClient {
      */
     requestRawWithCallback(info, data, onResult) {
         let socket;
-        if (typeof data === 'string') {
-            info.options.headers['Content-Length'] = Buffer.byteLength(data, 'utf8');
+        if (typeof (data) === 'string') {
+            info.options.headers["Content-Length"] = Buffer.byteLength(data, 'utf8');
         }
         let callbackCalled = false;
         let handleResult = (err, res) => {
@@ -2298,7 +2297,7 @@ class HttpClient {
             let res = new HttpClientResponse(msg);
             handleResult(null, res);
         });
-        req.on('socket', sock => {
+        req.on('socket', (sock) => {
             socket = sock;
         });
         // If we ever get disconnected, we want the socket to timeout eventually
@@ -2313,10 +2312,10 @@ class HttpClient {
             // res should have headers
             handleResult(err, null);
         });
-        if (data && typeof data === 'string') {
+        if (data && typeof (data) === 'string') {
             req.write(data, 'utf8');
         }
-        if (data && typeof data !== 'string') {
+        if (data && typeof (data) !== 'string') {
             data.on('close', function () {
                 req.end();
             });
@@ -2343,34 +2342,31 @@ class HttpClient {
         const defaultPort = usingSsl ? 443 : 80;
         info.options = {};
         info.options.host = info.parsedUrl.hostname;
-        info.options.port = info.parsedUrl.port
-            ? parseInt(info.parsedUrl.port)
-            : defaultPort;
-        info.options.path =
-            (info.parsedUrl.pathname || '') + (info.parsedUrl.search || '');
+        info.options.port = info.parsedUrl.port ? parseInt(info.parsedUrl.port) : defaultPort;
+        info.options.path = (info.parsedUrl.pathname || '') + (info.parsedUrl.search || '');
         info.options.method = method;
         info.options.headers = this._mergeHeaders(headers);
         if (this.userAgent != null) {
-            info.options.headers['user-agent'] = this.userAgent;
+            info.options.headers["user-agent"] = this.userAgent;
         }
         info.options.agent = this._getAgent(info.parsedUrl);
         // gives handlers an opportunity to participate
         if (this.handlers) {
-            this.handlers.forEach(handler => {
+            this.handlers.forEach((handler) => {
                 handler.prepareRequest(info.options);
             });
         }
         return info;
     }
     _mergeHeaders(headers) {
-        const lowercaseKeys = obj => Object.keys(obj).reduce((c, k) => ((c[k.toLowerCase()] = obj[k]), c), {});
+        const lowercaseKeys = obj => Object.keys(obj).reduce((c, k) => (c[k.toLowerCase()] = obj[k], c), {});
         if (this.requestOptions && this.requestOptions.headers) {
             return Object.assign({}, lowercaseKeys(this.requestOptions.headers), lowercaseKeys(headers));
         }
         return lowercaseKeys(headers || {});
     }
     _getExistingOrDefaultHeader(additionalHeaders, header, _default) {
-        const lowercaseKeys = obj => Object.keys(obj).reduce((c, k) => ((c[k.toLowerCase()] = obj[k]), c), {});
+        const lowercaseKeys = obj => Object.keys(obj).reduce((c, k) => (c[k.toLowerCase()] = obj[k], c), {});
         let clientHeader;
         if (this.requestOptions && this.requestOptions.headers) {
             clientHeader = lowercaseKeys(this.requestOptions.headers)[header];
@@ -2408,7 +2404,7 @@ class HttpClient {
                     proxyAuth: proxyUrl.auth,
                     host: proxyUrl.hostname,
                     port: proxyUrl.port
-                }
+                },
             };
             let tunnelAgent;
             const overHttps = proxyUrl.protocol === 'https:';
@@ -2435,9 +2431,7 @@ class HttpClient {
             // we don't want to set NODE_TLS_REJECT_UNAUTHORIZED=0 since that will affect request for entire process
             // http.RequestOptions doesn't expose a way to modify RequestOptions.agent.options
             // we have to cast it to any and change it directly
-            agent.options = Object.assign(agent.options || {}, {
-                rejectUnauthorized: false
-            });
+            agent.options = Object.assign(agent.options || {}, { rejectUnauthorized: false });
         }
         return agent;
     }
@@ -2498,7 +2492,7 @@ class HttpClient {
                     msg = contents;
                 }
                 else {
-                    msg = 'Failed request: (' + statusCode + ')';
+                    msg = "Failed request: (" + statusCode + ")";
                 }
                 let err = new Error(msg);
                 // attach statusCode and body obj (if available) to the error object
@@ -3006,7 +3000,6 @@ const exec_1 = __webpack_require__(986);
 const io = __importStar(__webpack_require__(1));
 const fs_1 = __webpack_require__(747);
 const path = __importStar(__webpack_require__(622));
-const constants_1 = __webpack_require__(694);
 function isGnuTar() {
     return __awaiter(this, void 0, void 0, function* () {
         core.debug("Checking tar --version");
@@ -3033,7 +3026,7 @@ function getTarPath(args) {
             if (fs_1.existsSync(systemTar)) {
                 return systemTar;
             }
-            else if (isGnuTar()) {
+            else if (yield isGnuTar()) {
                 args.push("--force-local");
             }
         }
@@ -3041,10 +3034,10 @@ function getTarPath(args) {
     });
 }
 function execTar(args) {
-    var _a, _b;
+    var _a;
     return __awaiter(this, void 0, void 0, function* () {
         try {
-            yield exec_1.exec(`"${yield getTarPath()}"`, args);
+            yield exec_1.exec(`"${yield getTarPath(args)}"`, args);
         }
         catch (error) {
             throw new Error(`Tar failed with error: ${(_a = error) === null || _a === void 0 ? void 0 : _a.message}`);
@@ -3055,14 +3048,27 @@ function extractTar(archivePath, targetDirectory) {
     return __awaiter(this, void 0, void 0, function* () {
         // Create directory to extract tar into
         yield io.mkdirP(targetDirectory);
-        const args = ["-xz", "-f", archivePath, "-C", targetDirectory];
+        const args = [
+            "-xz",
+            "-f",
+            archivePath.replace(new RegExp("\\" + path.sep, "g"), "/"),
+            "-C",
+            targetDirectory.replace(new RegExp("\\" + path.sep, "g"), "/")
+        ];
         yield execTar(args);
     });
 }
 exports.extractTar = extractTar;
 function createTar(archivePath, sourceDirectory) {
     return __awaiter(this, void 0, void 0, function* () {
-        const args = ["-cz", "-f", archivePath, "-C", sourceDirectory, "."];
+        const args = [
+            "-cz",
+            "-f",
+            archivePath.replace(new RegExp("\\" + path.sep, "g"), "/"),
+            "-C",
+            sourceDirectory.replace(new RegExp("\\" + path.sep, "g"), "/"),
+            "."
+        ];
         yield execTar(args);
     });
 }
@@ -3086,10 +3092,12 @@ function getProxyUrl(reqUrl) {
     }
     let proxyVar;
     if (usingSsl) {
-        proxyVar = process.env['https_proxy'] || process.env['HTTPS_PROXY'];
+        proxyVar = process.env["https_proxy"] ||
+            process.env["HTTPS_PROXY"];
     }
     else {
-        proxyVar = process.env['http_proxy'] || process.env['HTTP_PROXY'];
+        proxyVar = process.env["http_proxy"] ||
+            process.env["HTTP_PROXY"];
     }
     if (proxyVar) {
         proxyUrl = url.parse(proxyVar);
@@ -3101,7 +3109,7 @@ function checkBypass(reqUrl) {
     if (!reqUrl.hostname) {
         return false;
     }
-    let noProxy = process.env['no_proxy'] || process.env['NO_PROXY'] || '';
+    let noProxy = process.env["no_proxy"] || process.env["NO_PROXY"] || '';
     if (!noProxy) {
         return false;
     }
@@ -3122,10 +3130,7 @@ function checkBypass(reqUrl) {
         upperReqHosts.push(`${upperReqHosts[0]}:${reqPort}`);
     }
     // Compare request host against noproxy
-    for (let upperNoProxyItem of noProxy
-        .split(',')
-        .map(x => x.trim().toUpperCase())
-        .filter(x => x)) {
+    for (let upperNoProxyItem of noProxy.split(',').map(x => x.trim().toUpperCase()).filter(x => x)) {
         if (upperReqHosts.some(x => x === upperNoProxyItem)) {
             return true;
         }

--- a/dist/restore/index.js
+++ b/dist/restore/index.js
@@ -1255,6 +1255,9 @@ const core = __importStar(__webpack_require__(470));
 const fs = __importStar(__webpack_require__(747));
 const auth_1 = __webpack_require__(226);
 const http_client_1 = __webpack_require__(539);
+const stream = __importStar(__webpack_require__(794));
+const util = __importStar(__webpack_require__(669));
+const constants_1 = __webpack_require__(694);
 const utils = __importStar(__webpack_require__(443));
 const constants_1 = __webpack_require__(694);
 function isSuccessStatusCode(statusCode) {
@@ -1326,13 +1329,10 @@ function getCacheEntry(keys) {
     });
 }
 exports.getCacheEntry = getCacheEntry;
-function pipeResponseToStream(response, stream) {
+function pipeResponseToStream(response, output) {
     return __awaiter(this, void 0, void 0, function* () {
-        return new Promise(resolve => {
-            response.message.pipe(stream).on("close", () => {
-                resolve();
-            });
-        });
+        const pipeline = util.promisify(stream.pipeline);
+        yield pipeline(response.message, output);
     });
 }
 function downloadCache(archiveLocation, archivePath) {
@@ -1665,10 +1665,6 @@ var __importStar = (this && this.__importStar) || function (mod) {
 };
 Object.defineProperty(exports, "__esModule", { value: true });
 const core = __importStar(__webpack_require__(470));
-<<<<<<< HEAD
-=======
-const glob = __importStar(__webpack_require__(281));
->>>>>>> 9bb13c7... Fix lint issue, build .js files
 const io = __importStar(__webpack_require__(1));
 const fs = __importStar(__webpack_require__(747));
 const os = __importStar(__webpack_require__(87));
@@ -2893,6 +2889,13 @@ function run() {
 run();
 exports.default = run;
 
+
+/***/ }),
+
+/***/ 794:
+/***/ (function(module) {
+
+module.exports = require("stream");
 
 /***/ }),
 

--- a/dist/restore/index.js
+++ b/dist/restore/index.js
@@ -3036,12 +3036,8 @@ function createTar(archiveFolder, sourceDirectories) {
         const args = [
             "-cz",
             "-f",
-<<<<<<< HEAD
-            constants_1.CacheFilename,
-            "-P",
-=======
             (_a = constants_1.CacheFilename) === null || _a === void 0 ? void 0 : _a.replace(/\\/g, "/"),
->>>>>>> Fallback to GNU tar if BSD tar is unavailable
+            "-P",
             "-C",
             (_b = workingDirectory) === null || _b === void 0 ? void 0 : _b.replace(/\\/g, "/"),
             "--files-from",

--- a/dist/restore/index.js
+++ b/dist/restore/index.js
@@ -2928,10 +2928,34 @@ var __importStar = (this && this.__importStar) || function (mod) {
     return result;
 };
 Object.defineProperty(exports, "__esModule", { value: true });
+const core = __importStar(__webpack_require__(470));
 const exec_1 = __webpack_require__(986);
 const io = __importStar(__webpack_require__(1));
 const fs_1 = __webpack_require__(747);
+<<<<<<< HEAD
 function getTarPath() {
+=======
+const path = __importStar(__webpack_require__(622));
+const constants_1 = __webpack_require__(694);
+function isGnuTar() {
+    return __awaiter(this, void 0, void 0, function* () {
+        core.debug("Checking tar --version");
+        let versionOutput = "";
+        yield exec_1.exec("tar --version", [], {
+            ignoreReturnCode: true,
+            silent: true,
+            listeners: {
+                stdout: (data) => (versionOutput += data.toString()),
+                stderr: (data) => (versionOutput += data.toString())
+            }
+        });
+        core.debug(versionOutput.trim());
+        return versionOutput.toUpperCase().includes("GNU TAR");
+    });
+}
+exports.isGnuTar = isGnuTar;
+function getTarPath(args) {
+>>>>>>> 4fa017f... Fallback to GNU tar if BSD tar is unavailable
     return __awaiter(this, void 0, void 0, function* () {
         // Explicitly use BSD Tar on Windows
         const IS_WINDOWS = process.platform === "win32";
@@ -2940,38 +2964,91 @@ function getTarPath() {
             if (fs_1.existsSync(systemTar)) {
                 return systemTar;
             }
+            else if (isGnuTar()) {
+                args.push("--force-local");
+            }
         }
         return yield io.which("tar", true);
     });
 }
+<<<<<<< HEAD
 function execTar(args) {
     var _a, _b;
     return __awaiter(this, void 0, void 0, function* () {
         try {
             yield exec_1.exec(`"${yield getTarPath()}"`, args);
+=======
+function execTar(args, cwd) {
+    var _a;
+    return __awaiter(this, void 0, void 0, function* () {
+        try {
+            yield exec_1.exec(`"${yield getTarPath(args)}"`, args, { cwd: cwd });
+>>>>>>> 4fa017f... Fallback to GNU tar if BSD tar is unavailable
         }
         catch (error) {
-            const IS_WINDOWS = process.platform === "win32";
-            if (IS_WINDOWS) {
-                throw new Error(`Tar failed with error: ${(_a = error) === null || _a === void 0 ? void 0 : _a.message}. Ensure BSD tar is installed and on the PATH.`);
-            }
-            throw new Error(`Tar failed with error: ${(_b = error) === null || _b === void 0 ? void 0 : _b.message}`);
+            throw new Error(`Tar failed with error: ${(_a = error) === null || _a === void 0 ? void 0 : _a.message}`);
         }
     });
 }
+<<<<<<< HEAD
 function extractTar(archivePath, targetDirectory) {
     return __awaiter(this, void 0, void 0, function* () {
         // Create directory to extract tar into
         yield io.mkdirP(targetDirectory);
         const args = ["-xz", "-f", archivePath, "-C", targetDirectory];
+=======
+function getWorkingDirectory() {
+    var _a;
+    return _a = process.env["GITHUB_WORKSPACE"], (_a !== null && _a !== void 0 ? _a : process.cwd());
+}
+function extractTar(archivePath) {
+    var _a, _b;
+    return __awaiter(this, void 0, void 0, function* () {
+        // Create directory to extract tar into
+        const workingDirectory = getWorkingDirectory();
+        yield io.mkdirP(workingDirectory);
+        const args = [
+            "-xz",
+            "-f",
+            (_a = archivePath) === null || _a === void 0 ? void 0 : _a.replace(/\\/g, "/"),
+            "-P",
+            "-C",
+            (_b = workingDirectory) === null || _b === void 0 ? void 0 : _b.replace(/\\/g, "/")
+        ];
+>>>>>>> 4fa017f... Fallback to GNU tar if BSD tar is unavailable
         yield execTar(args);
     });
 }
 exports.extractTar = extractTar;
+<<<<<<< HEAD
 function createTar(archivePath, sourceDirectory) {
     return __awaiter(this, void 0, void 0, function* () {
         const args = ["-cz", "-f", archivePath, "-C", sourceDirectory, "."];
         yield execTar(args);
+=======
+function createTar(archiveFolder, sourceDirectories) {
+    var _a, _b;
+    return __awaiter(this, void 0, void 0, function* () {
+        // Write source directories to manifest.txt to avoid command length limits
+        const manifestFilename = "manifest.txt";
+        fs_1.writeFileSync(path.join(archiveFolder, manifestFilename), sourceDirectories.join("\n"));
+        const workingDirectory = getWorkingDirectory();
+        const args = [
+            "-cz",
+            "-f",
+<<<<<<< HEAD
+            constants_1.CacheFilename,
+            "-P",
+=======
+            (_a = constants_1.CacheFilename) === null || _a === void 0 ? void 0 : _a.replace(/\\/g, "/"),
+>>>>>>> Fallback to GNU tar if BSD tar is unavailable
+            "-C",
+            (_b = workingDirectory) === null || _b === void 0 ? void 0 : _b.replace(/\\/g, "/"),
+            "--files-from",
+            manifestFilename
+        ];
+        yield execTar(args, archiveFolder);
+>>>>>>> 4fa017f... Fallback to GNU tar if BSD tar is unavailable
     });
 }
 exports.createTar = createTar;

--- a/dist/restore/index.js
+++ b/dist/restore/index.js
@@ -2932,9 +2932,6 @@ const core = __importStar(__webpack_require__(470));
 const exec_1 = __webpack_require__(986);
 const io = __importStar(__webpack_require__(1));
 const fs_1 = __webpack_require__(747);
-<<<<<<< HEAD
-function getTarPath() {
-=======
 const path = __importStar(__webpack_require__(622));
 const constants_1 = __webpack_require__(694);
 function isGnuTar() {
@@ -2955,7 +2952,6 @@ function isGnuTar() {
 }
 exports.isGnuTar = isGnuTar;
 function getTarPath(args) {
->>>>>>> 4fa017f... Fallback to GNU tar if BSD tar is unavailable
     return __awaiter(this, void 0, void 0, function* () {
         // Explicitly use BSD Tar on Windows
         const IS_WINDOWS = process.platform === "win32";
@@ -2971,80 +2967,30 @@ function getTarPath(args) {
         return yield io.which("tar", true);
     });
 }
-<<<<<<< HEAD
 function execTar(args) {
     var _a, _b;
     return __awaiter(this, void 0, void 0, function* () {
         try {
             yield exec_1.exec(`"${yield getTarPath()}"`, args);
-=======
-function execTar(args, cwd) {
-    var _a;
-    return __awaiter(this, void 0, void 0, function* () {
-        try {
-            yield exec_1.exec(`"${yield getTarPath(args)}"`, args, { cwd: cwd });
->>>>>>> 4fa017f... Fallback to GNU tar if BSD tar is unavailable
         }
         catch (error) {
             throw new Error(`Tar failed with error: ${(_a = error) === null || _a === void 0 ? void 0 : _a.message}`);
         }
     });
 }
-<<<<<<< HEAD
 function extractTar(archivePath, targetDirectory) {
     return __awaiter(this, void 0, void 0, function* () {
         // Create directory to extract tar into
         yield io.mkdirP(targetDirectory);
         const args = ["-xz", "-f", archivePath, "-C", targetDirectory];
-=======
-function getWorkingDirectory() {
-    var _a;
-    return _a = process.env["GITHUB_WORKSPACE"], (_a !== null && _a !== void 0 ? _a : process.cwd());
-}
-function extractTar(archivePath) {
-    var _a, _b;
-    return __awaiter(this, void 0, void 0, function* () {
-        // Create directory to extract tar into
-        const workingDirectory = getWorkingDirectory();
-        yield io.mkdirP(workingDirectory);
-        const args = [
-            "-xz",
-            "-f",
-            (_a = archivePath) === null || _a === void 0 ? void 0 : _a.replace(/\\/g, "/"),
-            "-P",
-            "-C",
-            (_b = workingDirectory) === null || _b === void 0 ? void 0 : _b.replace(/\\/g, "/")
-        ];
->>>>>>> 4fa017f... Fallback to GNU tar if BSD tar is unavailable
         yield execTar(args);
     });
 }
 exports.extractTar = extractTar;
-<<<<<<< HEAD
 function createTar(archivePath, sourceDirectory) {
     return __awaiter(this, void 0, void 0, function* () {
         const args = ["-cz", "-f", archivePath, "-C", sourceDirectory, "."];
         yield execTar(args);
-=======
-function createTar(archiveFolder, sourceDirectories) {
-    var _a, _b;
-    return __awaiter(this, void 0, void 0, function* () {
-        // Write source directories to manifest.txt to avoid command length limits
-        const manifestFilename = "manifest.txt";
-        fs_1.writeFileSync(path.join(archiveFolder, manifestFilename), sourceDirectories.join("\n"));
-        const workingDirectory = getWorkingDirectory();
-        const args = [
-            "-cz",
-            "-f",
-            (_a = constants_1.CacheFilename) === null || _a === void 0 ? void 0 : _a.replace(/\\/g, "/"),
-            "-P",
-            "-C",
-            (_b = workingDirectory) === null || _b === void 0 ? void 0 : _b.replace(/\\/g, "/"),
-            "--files-from",
-            manifestFilename
-        ];
-        yield execTar(args, archiveFolder);
->>>>>>> 4fa017f... Fallback to GNU tar if BSD tar is unavailable
     });
 }
 exports.createTar = createTar;

--- a/dist/restore/index.js
+++ b/dist/restore/index.js
@@ -1435,11 +1435,15 @@ function uploadFile(httpClient, cacheId, archivePath) {
                     const start = offset;
                     const end = offset + chunkSize - 1;
                     offset += MAX_CHUNK_SIZE;
-                    yield uploadChunk(httpClient, resourceUrl, () => fs.createReadStream(archivePath, {
+                    yield uploadChunk(httpClient, resourceUrl, () => fs
+                        .createReadStream(archivePath, {
                         fd,
                         start,
                         end,
                         autoClose: false
+                    })
+                        .on("error", error => {
+                        throw new Error(`Cache upload failed because file read failed with ${error.Message}`);
                     }), start, end);
                 }
             })));

--- a/dist/restore/index.js
+++ b/dist/restore/index.js
@@ -3000,6 +3000,7 @@ const exec_1 = __webpack_require__(986);
 const io = __importStar(__webpack_require__(1));
 const fs_1 = __webpack_require__(747);
 const path = __importStar(__webpack_require__(622));
+const tar = __importStar(__webpack_require__(943));
 function isGnuTar() {
     return __awaiter(this, void 0, void 0, function* () {
         core.debug("Checking tar --version");
@@ -3026,7 +3027,7 @@ function getTarPath(args) {
             if (fs_1.existsSync(systemTar)) {
                 return systemTar;
             }
-            else if (yield isGnuTar()) {
+            else if (yield tar.isGnuTar()) {
                 args.push("--force-local");
             }
         }

--- a/dist/restore/index.js
+++ b/dist/restore/index.js
@@ -1382,7 +1382,7 @@ function getContentRange(start, end) {
     // Content-Range: bytes 0-199/*
     return `bytes ${start}-${end}/*`;
 }
-function uploadChunk(httpClient, resourceUrl, data, start, end) {
+function uploadChunk(httpClient, resourceUrl, openStream, start, end) {
     return __awaiter(this, void 0, void 0, function* () {
         core.debug(`Uploading chunk of size ${end -
             start +
@@ -1392,7 +1392,7 @@ function uploadChunk(httpClient, resourceUrl, data, start, end) {
             "Content-Range": getContentRange(start, end)
         };
         const uploadChunkRequest = () => __awaiter(this, void 0, void 0, function* () {
-            return yield httpClient.sendStream("PATCH", resourceUrl, data, additionalHeaders);
+            return yield httpClient.sendStream("PATCH", resourceUrl, openStream(), additionalHeaders);
         });
         const response = yield uploadChunkRequest();
         if (isSuccessStatusCode(response.message.statusCode)) {
@@ -1435,13 +1435,12 @@ function uploadFile(httpClient, cacheId, archivePath) {
                     const start = offset;
                     const end = offset + chunkSize - 1;
                     offset += MAX_CHUNK_SIZE;
-                    const chunk = fs.createReadStream(archivePath, {
+                    yield uploadChunk(httpClient, resourceUrl, () => fs.createReadStream(archivePath, {
                         fd,
                         start,
                         end,
                         autoClose: false
-                    });
-                    yield uploadChunk(httpClient, resourceUrl, chunk, start, end);
+                    }), start, end);
                 }
             })));
         }
@@ -1496,7 +1495,9 @@ class BasicCredentialHandler {
         this.password = password;
     }
     prepareRequest(options) {
-        options.headers['Authorization'] = 'Basic ' + Buffer.from(this.username + ':' + this.password).toString('base64');
+        options.headers['Authorization'] =
+            'Basic ' +
+                Buffer.from(this.username + ':' + this.password).toString('base64');
     }
     // This handler cannot handle 401
     canHandleAuthentication(response) {
@@ -1532,7 +1533,8 @@ class PersonalAccessTokenCredentialHandler {
     // currently implements pre-authorization
     // TODO: support preAuth = false where it hooks on 401
     prepareRequest(options) {
-        options.headers['Authorization'] = 'Basic ' + Buffer.from('PAT:' + this.token).toString('base64');
+        options.headers['Authorization'] =
+            'Basic ' + Buffer.from('PAT:' + this.token).toString('base64');
     }
     // This handler cannot handle 401
     canHandleAuthentication(response) {
@@ -2001,6 +2003,7 @@ var HttpCodes;
     HttpCodes[HttpCodes["RequestTimeout"] = 408] = "RequestTimeout";
     HttpCodes[HttpCodes["Conflict"] = 409] = "Conflict";
     HttpCodes[HttpCodes["Gone"] = 410] = "Gone";
+    HttpCodes[HttpCodes["TooManyRequests"] = 429] = "TooManyRequests";
     HttpCodes[HttpCodes["InternalServerError"] = 500] = "InternalServerError";
     HttpCodes[HttpCodes["NotImplemented"] = 501] = "NotImplemented";
     HttpCodes[HttpCodes["BadGateway"] = 502] = "BadGateway";
@@ -2025,8 +2028,18 @@ function getProxyUrl(serverUrl) {
     return proxyUrl ? proxyUrl.href : '';
 }
 exports.getProxyUrl = getProxyUrl;
-const HttpRedirectCodes = [HttpCodes.MovedPermanently, HttpCodes.ResourceMoved, HttpCodes.SeeOther, HttpCodes.TemporaryRedirect, HttpCodes.PermanentRedirect];
-const HttpResponseRetryCodes = [HttpCodes.BadGateway, HttpCodes.ServiceUnavailable, HttpCodes.GatewayTimeout];
+const HttpRedirectCodes = [
+    HttpCodes.MovedPermanently,
+    HttpCodes.ResourceMoved,
+    HttpCodes.SeeOther,
+    HttpCodes.TemporaryRedirect,
+    HttpCodes.PermanentRedirect
+];
+const HttpResponseRetryCodes = [
+    HttpCodes.BadGateway,
+    HttpCodes.ServiceUnavailable,
+    HttpCodes.GatewayTimeout
+];
 const RetryableHttpVerbs = ['OPTIONS', 'GET', 'DELETE', 'HEAD'];
 const ExponentialBackoffCeiling = 10;
 const ExponentialBackoffTimeSlice = 5;
@@ -2157,19 +2170,23 @@ class HttpClient {
      */
     async request(verb, requestUrl, data, headers) {
         if (this._disposed) {
-            throw new Error("Client has already been disposed.");
+            throw new Error('Client has already been disposed.');
         }
         let parsedUrl = url.parse(requestUrl);
         let info = this._prepareRequest(verb, parsedUrl, headers);
         // Only perform retries on reads since writes may not be idempotent.
-        let maxTries = (this._allowRetries && RetryableHttpVerbs.indexOf(verb) != -1) ? this._maxRetries + 1 : 1;
+        let maxTries = this._allowRetries && RetryableHttpVerbs.indexOf(verb) != -1
+            ? this._maxRetries + 1
+            : 1;
         let numTries = 0;
         let response;
         while (numTries < maxTries) {
             response = await this.requestRaw(info, data);
 
             // Check if it's an authentication challenge
-            if (response && response.message && response.message.statusCode === HttpCodes.Unauthorized) {
+            if (response &&
+                response.message &&
+                response.message.statusCode === HttpCodes.Unauthorized) {
                 let authenticationHandler;
                 for (let i = 0; i < this.handlers.length; i++) {
                     if (this.handlers[i].canHandleAuthentication(response)) {
@@ -2187,21 +2204,32 @@ class HttpClient {
                 }
             }
             let redirectsRemaining = this._maxRedirects;
-            while (HttpRedirectCodes.indexOf(response.message.statusCode) != -1
-                && this._allowRedirects
-                && redirectsRemaining > 0) {
-                const redirectUrl = response.message.headers["location"];
+            while (HttpRedirectCodes.indexOf(response.message.statusCode) != -1 &&
+                this._allowRedirects &&
+                redirectsRemaining > 0) {
+                const redirectUrl = response.message.headers['location'];
                 if (!redirectUrl) {
                     // if there's no location to redirect to, we won't
                     break;
                 }
                 let parsedRedirectUrl = url.parse(redirectUrl);
-                if (parsedUrl.protocol == 'https:' && parsedUrl.protocol != parsedRedirectUrl.protocol && !this._allowRedirectDowngrade) {
-                    throw new Error("Redirect from HTTPS to HTTP protocol. This downgrade is not allowed for security reasons. If you want to allow this behavior, set the allowRedirectDowngrade option to true.");
+                if (parsedUrl.protocol == 'https:' &&
+                    parsedUrl.protocol != parsedRedirectUrl.protocol &&
+                    !this._allowRedirectDowngrade) {
+                    throw new Error('Redirect from HTTPS to HTTP protocol. This downgrade is not allowed for security reasons. If you want to allow this behavior, set the allowRedirectDowngrade option to true.');
                 }
                 // we need to finish reading the response before reassigning response
                 // which will leak the open socket.
                 await response.readBody();
+                // strip authorization header if redirected to a different hostname
+                if (parsedRedirectUrl.hostname !== parsedUrl.hostname) {
+                    for (let header in headers) {
+                        // header names are case insensitive
+                        if (header.toLowerCase() === 'authorization') {
+                            delete headers[header];
+                        }
+                    }
+                }
                 // let's make the request with the new redirectUrl
                 info = this._prepareRequest(verb, parsedRedirectUrl, headers);
                 response = await this.requestRaw(info, data);
@@ -2252,8 +2280,8 @@ class HttpClient {
      */
     requestRawWithCallback(info, data, onResult) {
         let socket;
-        if (typeof (data) === 'string') {
-            info.options.headers["Content-Length"] = Buffer.byteLength(data, 'utf8');
+        if (typeof data === 'string') {
+            info.options.headers['Content-Length'] = Buffer.byteLength(data, 'utf8');
         }
         let callbackCalled = false;
         let handleResult = (err, res) => {
@@ -2266,7 +2294,7 @@ class HttpClient {
             let res = new HttpClientResponse(msg);
             handleResult(null, res);
         });
-        req.on('socket', (sock) => {
+        req.on('socket', sock => {
             socket = sock;
         });
         // If we ever get disconnected, we want the socket to timeout eventually
@@ -2281,10 +2309,10 @@ class HttpClient {
             // res should have headers
             handleResult(err, null);
         });
-        if (data && typeof (data) === 'string') {
+        if (data && typeof data === 'string') {
             req.write(data, 'utf8');
         }
-        if (data && typeof (data) !== 'string') {
+        if (data && typeof data !== 'string') {
             data.on('close', function () {
                 req.end();
             });
@@ -2311,31 +2339,34 @@ class HttpClient {
         const defaultPort = usingSsl ? 443 : 80;
         info.options = {};
         info.options.host = info.parsedUrl.hostname;
-        info.options.port = info.parsedUrl.port ? parseInt(info.parsedUrl.port) : defaultPort;
-        info.options.path = (info.parsedUrl.pathname || '') + (info.parsedUrl.search || '');
+        info.options.port = info.parsedUrl.port
+            ? parseInt(info.parsedUrl.port)
+            : defaultPort;
+        info.options.path =
+            (info.parsedUrl.pathname || '') + (info.parsedUrl.search || '');
         info.options.method = method;
         info.options.headers = this._mergeHeaders(headers);
         if (this.userAgent != null) {
-            info.options.headers["user-agent"] = this.userAgent;
+            info.options.headers['user-agent'] = this.userAgent;
         }
         info.options.agent = this._getAgent(info.parsedUrl);
         // gives handlers an opportunity to participate
         if (this.handlers) {
-            this.handlers.forEach((handler) => {
+            this.handlers.forEach(handler => {
                 handler.prepareRequest(info.options);
             });
         }
         return info;
     }
     _mergeHeaders(headers) {
-        const lowercaseKeys = obj => Object.keys(obj).reduce((c, k) => (c[k.toLowerCase()] = obj[k], c), {});
+        const lowercaseKeys = obj => Object.keys(obj).reduce((c, k) => ((c[k.toLowerCase()] = obj[k]), c), {});
         if (this.requestOptions && this.requestOptions.headers) {
             return Object.assign({}, lowercaseKeys(this.requestOptions.headers), lowercaseKeys(headers));
         }
         return lowercaseKeys(headers || {});
     }
     _getExistingOrDefaultHeader(additionalHeaders, header, _default) {
-        const lowercaseKeys = obj => Object.keys(obj).reduce((c, k) => (c[k.toLowerCase()] = obj[k], c), {});
+        const lowercaseKeys = obj => Object.keys(obj).reduce((c, k) => ((c[k.toLowerCase()] = obj[k]), c), {});
         let clientHeader;
         if (this.requestOptions && this.requestOptions.headers) {
             clientHeader = lowercaseKeys(this.requestOptions.headers)[header];
@@ -2373,7 +2404,7 @@ class HttpClient {
                     proxyAuth: proxyUrl.auth,
                     host: proxyUrl.hostname,
                     port: proxyUrl.port
-                },
+                }
             };
             let tunnelAgent;
             const overHttps = proxyUrl.protocol === 'https:';
@@ -2400,7 +2431,9 @@ class HttpClient {
             // we don't want to set NODE_TLS_REJECT_UNAUTHORIZED=0 since that will affect request for entire process
             // http.RequestOptions doesn't expose a way to modify RequestOptions.agent.options
             // we have to cast it to any and change it directly
-            agent.options = Object.assign(agent.options || {}, { rejectUnauthorized: false });
+            agent.options = Object.assign(agent.options || {}, {
+                rejectUnauthorized: false
+            });
         }
         return agent;
     }
@@ -2461,7 +2494,7 @@ class HttpClient {
                     msg = contents;
                 }
                 else {
-                    msg = "Failed request: (" + statusCode + ")";
+                    msg = 'Failed request: (' + statusCode + ')';
                 }
                 let err = new Error(msg);
                 // attach statusCode and body obj (if available) to the error object
@@ -3049,12 +3082,10 @@ function getProxyUrl(reqUrl) {
     }
     let proxyVar;
     if (usingSsl) {
-        proxyVar = process.env["https_proxy"] ||
-            process.env["HTTPS_PROXY"];
+        proxyVar = process.env['https_proxy'] || process.env['HTTPS_PROXY'];
     }
     else {
-        proxyVar = process.env["http_proxy"] ||
-            process.env["HTTP_PROXY"];
+        proxyVar = process.env['http_proxy'] || process.env['HTTP_PROXY'];
     }
     if (proxyVar) {
         proxyUrl = url.parse(proxyVar);
@@ -3066,7 +3097,7 @@ function checkBypass(reqUrl) {
     if (!reqUrl.hostname) {
         return false;
     }
-    let noProxy = process.env["no_proxy"] || process.env["NO_PROXY"] || '';
+    let noProxy = process.env['no_proxy'] || process.env['NO_PROXY'] || '';
     if (!noProxy) {
         return false;
     }
@@ -3087,7 +3118,10 @@ function checkBypass(reqUrl) {
         upperReqHosts.push(`${upperReqHosts[0]}:${reqPort}`);
     }
     // Compare request host against noproxy
-    for (let upperNoProxyItem of noProxy.split(',').map(x => x.trim().toUpperCase()).filter(x => x)) {
+    for (let upperNoProxyItem of noProxy
+        .split(',')
+        .map(x => x.trim().toUpperCase())
+        .filter(x => x)) {
         if (upperReqHosts.some(x => x === upperNoProxyItem)) {
             return true;
         }

--- a/dist/save/index.js
+++ b/dist/save/index.js
@@ -2913,30 +2913,7 @@ const core = __importStar(__webpack_require__(470));
 const exec_1 = __webpack_require__(986);
 const io = __importStar(__webpack_require__(1));
 const fs_1 = __webpack_require__(747);
-<<<<<<< HEAD
 function getTarPath() {
-=======
-const path = __importStar(__webpack_require__(622));
-const constants_1 = __webpack_require__(694);
-function isGnuTar() {
-    return __awaiter(this, void 0, void 0, function* () {
-        core.debug("Checking tar --version");
-        let versionOutput = "";
-        yield exec_1.exec("tar --version", [], {
-            ignoreReturnCode: true,
-            silent: true,
-            listeners: {
-                stdout: (data) => (versionOutput += data.toString()),
-                stderr: (data) => (versionOutput += data.toString())
-            }
-        });
-        core.debug(versionOutput.trim());
-        return versionOutput.toUpperCase().includes("GNU TAR");
-    });
-}
-exports.isGnuTar = isGnuTar;
-function getTarPath(args) {
->>>>>>> 4fa017f... Fallback to GNU tar if BSD tar is unavailable
     return __awaiter(this, void 0, void 0, function* () {
         // Explicitly use BSD Tar on Windows
         const IS_WINDOWS = process.platform === "win32";
@@ -2952,80 +2929,30 @@ function getTarPath(args) {
         return yield io.which("tar", true);
     });
 }
-<<<<<<< HEAD
 function execTar(args) {
     var _a, _b;
     return __awaiter(this, void 0, void 0, function* () {
         try {
             yield exec_1.exec(`"${yield getTarPath()}"`, args);
-=======
-function execTar(args, cwd) {
-    var _a;
-    return __awaiter(this, void 0, void 0, function* () {
-        try {
-            yield exec_1.exec(`"${yield getTarPath(args)}"`, args, { cwd: cwd });
->>>>>>> 4fa017f... Fallback to GNU tar if BSD tar is unavailable
         }
         catch (error) {
             throw new Error(`Tar failed with error: ${(_a = error) === null || _a === void 0 ? void 0 : _a.message}`);
         }
     });
 }
-<<<<<<< HEAD
 function extractTar(archivePath, targetDirectory) {
     return __awaiter(this, void 0, void 0, function* () {
         // Create directory to extract tar into
         yield io.mkdirP(targetDirectory);
         const args = ["-xz", "-f", archivePath, "-C", targetDirectory];
-=======
-function getWorkingDirectory() {
-    var _a;
-    return _a = process.env["GITHUB_WORKSPACE"], (_a !== null && _a !== void 0 ? _a : process.cwd());
-}
-function extractTar(archivePath) {
-    var _a, _b;
-    return __awaiter(this, void 0, void 0, function* () {
-        // Create directory to extract tar into
-        const workingDirectory = getWorkingDirectory();
-        yield io.mkdirP(workingDirectory);
-        const args = [
-            "-xz",
-            "-f",
-            (_a = archivePath) === null || _a === void 0 ? void 0 : _a.replace(/\\/g, "/"),
-            "-P",
-            "-C",
-            (_b = workingDirectory) === null || _b === void 0 ? void 0 : _b.replace(/\\/g, "/")
-        ];
->>>>>>> 4fa017f... Fallback to GNU tar if BSD tar is unavailable
         yield execTar(args);
     });
 }
 exports.extractTar = extractTar;
-<<<<<<< HEAD
 function createTar(archivePath, sourceDirectory) {
     return __awaiter(this, void 0, void 0, function* () {
         const args = ["-cz", "-f", archivePath, "-C", sourceDirectory, "."];
         yield execTar(args);
-=======
-function createTar(archiveFolder, sourceDirectories) {
-    var _a, _b;
-    return __awaiter(this, void 0, void 0, function* () {
-        // Write source directories to manifest.txt to avoid command length limits
-        const manifestFilename = "manifest.txt";
-        fs_1.writeFileSync(path.join(archiveFolder, manifestFilename), sourceDirectories.join("\n"));
-        const workingDirectory = getWorkingDirectory();
-        const args = [
-            "-cz",
-            "-f",
-            (_a = constants_1.CacheFilename) === null || _a === void 0 ? void 0 : _a.replace(/\\/g, "/"),
-            "-P",
-            "-C",
-            (_b = workingDirectory) === null || _b === void 0 ? void 0 : _b.replace(/\\/g, "/"),
-            "--files-from",
-            manifestFilename
-        ];
-        yield execTar(args, archiveFolder);
->>>>>>> 4fa017f... Fallback to GNU tar if BSD tar is unavailable
     });
 }
 exports.createTar = createTar;

--- a/dist/save/index.js
+++ b/dist/save/index.js
@@ -2830,6 +2830,9 @@ var Events;
     Events["Push"] = "push";
     Events["PullRequest"] = "pull_request";
 })(Events = exports.Events || (exports.Events = {}));
+// Socket timeout in milliseconds during download.  If no traffic is received
+// over the socket during this period, the socket is destroyed and the download
+// is aborted.
 exports.SocketTimeout = 5000;
 
 

--- a/dist/save/index.js
+++ b/dist/save/index.js
@@ -1252,9 +1252,9 @@ var __importStar = (this && this.__importStar) || function (mod) {
 };
 Object.defineProperty(exports, "__esModule", { value: true });
 const core = __importStar(__webpack_require__(470));
-const fs = __importStar(__webpack_require__(747));
-const auth_1 = __webpack_require__(226);
 const http_client_1 = __webpack_require__(539);
+const auth_1 = __webpack_require__(226);
+const fs = __importStar(__webpack_require__(747));
 const stream = __importStar(__webpack_require__(794));
 const util = __importStar(__webpack_require__(669));
 const constants_1 = __webpack_require__(694);
@@ -1264,6 +1264,12 @@ function isSuccessStatusCode(statusCode) {
         return false;
     }
     return statusCode >= 200 && statusCode < 300;
+}
+function isServerErrorStatusCode(statusCode) {
+    if (!statusCode) {
+        return true;
+    }
+    return statusCode >= 500;
 }
 function isRetryableStatusCode(statusCode) {
     if (!statusCode) {
@@ -1304,12 +1310,56 @@ function createHttpClient() {
     const bearerCredentialHandler = new auth_1.BearerCredentialHandler(token);
     return new http_client_1.HttpClient("actions/cache", [bearerCredentialHandler], getRequestOptions());
 }
+function retry(name, method, getStatusCode, maxAttempts = 2) {
+    return __awaiter(this, void 0, void 0, function* () {
+        let response = undefined;
+        let statusCode = undefined;
+        let isRetryable = false;
+        let errorMessage = "";
+        let attempt = 1;
+        while (attempt <= maxAttempts) {
+            try {
+                response = yield method();
+                statusCode = getStatusCode(response);
+                if (!isServerErrorStatusCode(statusCode)) {
+                    return response;
+                }
+                isRetryable = isRetryableStatusCode(statusCode);
+                errorMessage = `Cache service responded with ${statusCode}`;
+            }
+            catch (error) {
+                isRetryable = true;
+                errorMessage = error.message;
+            }
+            core.debug(`${name} - Attempt ${attempt} of ${maxAttempts} failed with error: ${errorMessage}`);
+            if (!isRetryable) {
+                core.debug(`${name} - Error is not retryable`);
+                break;
+            }
+            attempt++;
+        }
+        throw Error(`${name} failed: ${errorMessage}`);
+    });
+}
+exports.retry = retry;
+function retryTypedResponse(name, method, maxAttempts = 2) {
+    return __awaiter(this, void 0, void 0, function* () {
+        return yield retry(name, method, (response) => response.statusCode, maxAttempts);
+    });
+}
+exports.retryTypedResponse = retryTypedResponse;
+function retryHttpClientResponse(name, method, maxAttempts = 2) {
+    return __awaiter(this, void 0, void 0, function* () {
+        return yield retry(name, method, (response) => response.message.statusCode, maxAttempts);
+    });
+}
+exports.retryHttpClientResponse = retryHttpClientResponse;
 function getCacheEntry(keys) {
     var _a;
     return __awaiter(this, void 0, void 0, function* () {
         const httpClient = createHttpClient();
         const resource = `cache?keys=${encodeURIComponent(keys.join(","))}`;
-        const response = yield httpClient.getJson(getCacheApiUrl(resource));
+        const response = yield retryTypedResponse("getCacheEntry", () => httpClient.getJson(getCacheApiUrl(resource)));
         if (response.statusCode === 204) {
             return null;
         }
@@ -1338,7 +1388,7 @@ function downloadCache(archiveLocation, archivePath) {
     return __awaiter(this, void 0, void 0, function* () {
         const stream = fs.createWriteStream(archivePath);
         const httpClient = new http_client_1.HttpClient("actions/cache");
-        const downloadResponse = yield httpClient.get(archiveLocation);
+        const downloadResponse = yield retryHttpClientResponse("downloadCache", () => httpClient.get(archiveLocation));
         // Abort download if no traffic received over the socket.
         downloadResponse.message.socket.setTimeout(constants_1.SocketTimeout, () => {
             downloadResponse.message.destroy();
@@ -1368,7 +1418,7 @@ function reserveCache(key) {
         const reserveCacheRequest = {
             key
         };
-        const response = yield httpClient.postJson(getCacheApiUrl("caches"), reserveCacheRequest);
+        const response = yield retryTypedResponse("reserveCache", () => httpClient.postJson(getCacheApiUrl("caches"), reserveCacheRequest));
         return _c = (_b = (_a = response) === null || _a === void 0 ? void 0 : _a.result) === null || _b === void 0 ? void 0 : _b.cacheId, (_c !== null && _c !== void 0 ? _c : -1);
     });
 }
@@ -1390,21 +1440,7 @@ function uploadChunk(httpClient, resourceUrl, openStream, start, end) {
             "Content-Type": "application/octet-stream",
             "Content-Range": getContentRange(start, end)
         };
-        const uploadChunkRequest = () => __awaiter(this, void 0, void 0, function* () {
-            return yield httpClient.sendStream("PATCH", resourceUrl, openStream(), additionalHeaders);
-        });
-        const response = yield uploadChunkRequest();
-        if (isSuccessStatusCode(response.message.statusCode)) {
-            return;
-        }
-        if (isRetryableStatusCode(response.message.statusCode)) {
-            core.debug(`Received ${response.message.statusCode}, retrying chunk at offset ${start}.`);
-            const retryResponse = yield uploadChunkRequest();
-            if (isSuccessStatusCode(retryResponse.message.statusCode)) {
-                return;
-            }
-        }
-        throw new Error(`Cache service responded with ${response.message.statusCode} during chunk upload.`);
+        yield retryHttpClientResponse(`uploadChunk (start: ${start}, end: ${end})`, () => httpClient.sendStream("PATCH", resourceUrl, openStream(), additionalHeaders));
     });
 }
 function parseEnvNumber(key) {
@@ -1456,7 +1492,7 @@ function uploadFile(httpClient, cacheId, archivePath) {
 function commitCache(httpClient, cacheId, filesize) {
     return __awaiter(this, void 0, void 0, function* () {
         const commitCacheRequest = { size: filesize };
-        return yield httpClient.postJson(getCacheApiUrl(`caches/${cacheId.toString()}`), commitCacheRequest);
+        return yield retryTypedResponse("commitCache", () => httpClient.postJson(getCacheApiUrl(`caches/${cacheId.toString()}`), commitCacheRequest));
     });
 }
 function saveCache(cacheId, archivePath) {
@@ -1498,9 +1534,7 @@ class BasicCredentialHandler {
         this.password = password;
     }
     prepareRequest(options) {
-        options.headers['Authorization'] =
-            'Basic ' +
-                Buffer.from(this.username + ':' + this.password).toString('base64');
+        options.headers['Authorization'] = 'Basic ' + Buffer.from(this.username + ':' + this.password).toString('base64');
     }
     // This handler cannot handle 401
     canHandleAuthentication(response) {
@@ -1536,8 +1570,7 @@ class PersonalAccessTokenCredentialHandler {
     // currently implements pre-authorization
     // TODO: support preAuth = false where it hooks on 401
     prepareRequest(options) {
-        options.headers['Authorization'] =
-            'Basic ' + Buffer.from('PAT:' + this.token).toString('base64');
+        options.headers['Authorization'] = 'Basic ' + Buffer.from('PAT:' + this.token).toString('base64');
     }
     // This handler cannot handle 401
     canHandleAuthentication(response) {
@@ -2006,7 +2039,6 @@ var HttpCodes;
     HttpCodes[HttpCodes["RequestTimeout"] = 408] = "RequestTimeout";
     HttpCodes[HttpCodes["Conflict"] = 409] = "Conflict";
     HttpCodes[HttpCodes["Gone"] = 410] = "Gone";
-    HttpCodes[HttpCodes["TooManyRequests"] = 429] = "TooManyRequests";
     HttpCodes[HttpCodes["InternalServerError"] = 500] = "InternalServerError";
     HttpCodes[HttpCodes["NotImplemented"] = 501] = "NotImplemented";
     HttpCodes[HttpCodes["BadGateway"] = 502] = "BadGateway";
@@ -2031,18 +2063,8 @@ function getProxyUrl(serverUrl) {
     return proxyUrl ? proxyUrl.href : '';
 }
 exports.getProxyUrl = getProxyUrl;
-const HttpRedirectCodes = [
-    HttpCodes.MovedPermanently,
-    HttpCodes.ResourceMoved,
-    HttpCodes.SeeOther,
-    HttpCodes.TemporaryRedirect,
-    HttpCodes.PermanentRedirect
-];
-const HttpResponseRetryCodes = [
-    HttpCodes.BadGateway,
-    HttpCodes.ServiceUnavailable,
-    HttpCodes.GatewayTimeout
-];
+const HttpRedirectCodes = [HttpCodes.MovedPermanently, HttpCodes.ResourceMoved, HttpCodes.SeeOther, HttpCodes.TemporaryRedirect, HttpCodes.PermanentRedirect];
+const HttpResponseRetryCodes = [HttpCodes.BadGateway, HttpCodes.ServiceUnavailable, HttpCodes.GatewayTimeout];
 const RetryableHttpVerbs = ['OPTIONS', 'GET', 'DELETE', 'HEAD'];
 const ExponentialBackoffCeiling = 10;
 const ExponentialBackoffTimeSlice = 5;
@@ -2055,12 +2077,6 @@ class HttpClientResponse {
             let output = Buffer.alloc(0);
             this.message.on('data', (chunk) => {
                 output = Buffer.concat([output, chunk]);
-            });
-            this.message.on('aborted', () => {
-                reject("Request was aborted or closed prematurely");
-            });
-            this.message.on('timeout', (socket) => {
-                reject("Request timed out");
             });
             this.message.on('end', () => {
                 resolve(output.toString());
@@ -2173,23 +2189,18 @@ class HttpClient {
      */
     async request(verb, requestUrl, data, headers) {
         if (this._disposed) {
-            throw new Error('Client has already been disposed.');
+            throw new Error("Client has already been disposed.");
         }
         let parsedUrl = url.parse(requestUrl);
         let info = this._prepareRequest(verb, parsedUrl, headers);
         // Only perform retries on reads since writes may not be idempotent.
-        let maxTries = this._allowRetries && RetryableHttpVerbs.indexOf(verb) != -1
-            ? this._maxRetries + 1
-            : 1;
+        let maxTries = (this._allowRetries && RetryableHttpVerbs.indexOf(verb) != -1) ? this._maxRetries + 1 : 1;
         let numTries = 0;
         let response;
         while (numTries < maxTries) {
             response = await this.requestRaw(info, data);
-
             // Check if it's an authentication challenge
-            if (response &&
-                response.message &&
-                response.message.statusCode === HttpCodes.Unauthorized) {
+            if (response && response.message && response.message.statusCode === HttpCodes.Unauthorized) {
                 let authenticationHandler;
                 for (let i = 0; i < this.handlers.length; i++) {
                     if (this.handlers[i].canHandleAuthentication(response)) {
@@ -2207,32 +2218,21 @@ class HttpClient {
                 }
             }
             let redirectsRemaining = this._maxRedirects;
-            while (HttpRedirectCodes.indexOf(response.message.statusCode) != -1 &&
-                this._allowRedirects &&
-                redirectsRemaining > 0) {
-                const redirectUrl = response.message.headers['location'];
+            while (HttpRedirectCodes.indexOf(response.message.statusCode) != -1
+                && this._allowRedirects
+                && redirectsRemaining > 0) {
+                const redirectUrl = response.message.headers["location"];
                 if (!redirectUrl) {
                     // if there's no location to redirect to, we won't
                     break;
                 }
                 let parsedRedirectUrl = url.parse(redirectUrl);
-                if (parsedUrl.protocol == 'https:' &&
-                    parsedUrl.protocol != parsedRedirectUrl.protocol &&
-                    !this._allowRedirectDowngrade) {
-                    throw new Error('Redirect from HTTPS to HTTP protocol. This downgrade is not allowed for security reasons. If you want to allow this behavior, set the allowRedirectDowngrade option to true.');
+                if (parsedUrl.protocol == 'https:' && parsedUrl.protocol != parsedRedirectUrl.protocol && !this._allowRedirectDowngrade) {
+                    throw new Error("Redirect from HTTPS to HTTP protocol. This downgrade is not allowed for security reasons. If you want to allow this behavior, set the allowRedirectDowngrade option to true.");
                 }
                 // we need to finish reading the response before reassigning response
                 // which will leak the open socket.
                 await response.readBody();
-                // strip authorization header if redirected to a different hostname
-                if (parsedRedirectUrl.hostname !== parsedUrl.hostname) {
-                    for (let header in headers) {
-                        // header names are case insensitive
-                        if (header.toLowerCase() === 'authorization') {
-                            delete headers[header];
-                        }
-                    }
-                }
                 // let's make the request with the new redirectUrl
                 info = this._prepareRequest(verb, parsedRedirectUrl, headers);
                 response = await this.requestRaw(info, data);
@@ -2283,8 +2283,8 @@ class HttpClient {
      */
     requestRawWithCallback(info, data, onResult) {
         let socket;
-        if (typeof data === 'string') {
-            info.options.headers['Content-Length'] = Buffer.byteLength(data, 'utf8');
+        if (typeof (data) === 'string') {
+            info.options.headers["Content-Length"] = Buffer.byteLength(data, 'utf8');
         }
         let callbackCalled = false;
         let handleResult = (err, res) => {
@@ -2297,7 +2297,7 @@ class HttpClient {
             let res = new HttpClientResponse(msg);
             handleResult(null, res);
         });
-        req.on('socket', sock => {
+        req.on('socket', (sock) => {
             socket = sock;
         });
         // If we ever get disconnected, we want the socket to timeout eventually
@@ -2312,10 +2312,10 @@ class HttpClient {
             // res should have headers
             handleResult(err, null);
         });
-        if (data && typeof data === 'string') {
+        if (data && typeof (data) === 'string') {
             req.write(data, 'utf8');
         }
-        if (data && typeof data !== 'string') {
+        if (data && typeof (data) !== 'string') {
             data.on('close', function () {
                 req.end();
             });
@@ -2342,34 +2342,31 @@ class HttpClient {
         const defaultPort = usingSsl ? 443 : 80;
         info.options = {};
         info.options.host = info.parsedUrl.hostname;
-        info.options.port = info.parsedUrl.port
-            ? parseInt(info.parsedUrl.port)
-            : defaultPort;
-        info.options.path =
-            (info.parsedUrl.pathname || '') + (info.parsedUrl.search || '');
+        info.options.port = info.parsedUrl.port ? parseInt(info.parsedUrl.port) : defaultPort;
+        info.options.path = (info.parsedUrl.pathname || '') + (info.parsedUrl.search || '');
         info.options.method = method;
         info.options.headers = this._mergeHeaders(headers);
         if (this.userAgent != null) {
-            info.options.headers['user-agent'] = this.userAgent;
+            info.options.headers["user-agent"] = this.userAgent;
         }
         info.options.agent = this._getAgent(info.parsedUrl);
         // gives handlers an opportunity to participate
         if (this.handlers) {
-            this.handlers.forEach(handler => {
+            this.handlers.forEach((handler) => {
                 handler.prepareRequest(info.options);
             });
         }
         return info;
     }
     _mergeHeaders(headers) {
-        const lowercaseKeys = obj => Object.keys(obj).reduce((c, k) => ((c[k.toLowerCase()] = obj[k]), c), {});
+        const lowercaseKeys = obj => Object.keys(obj).reduce((c, k) => (c[k.toLowerCase()] = obj[k], c), {});
         if (this.requestOptions && this.requestOptions.headers) {
             return Object.assign({}, lowercaseKeys(this.requestOptions.headers), lowercaseKeys(headers));
         }
         return lowercaseKeys(headers || {});
     }
     _getExistingOrDefaultHeader(additionalHeaders, header, _default) {
-        const lowercaseKeys = obj => Object.keys(obj).reduce((c, k) => ((c[k.toLowerCase()] = obj[k]), c), {});
+        const lowercaseKeys = obj => Object.keys(obj).reduce((c, k) => (c[k.toLowerCase()] = obj[k], c), {});
         let clientHeader;
         if (this.requestOptions && this.requestOptions.headers) {
             clientHeader = lowercaseKeys(this.requestOptions.headers)[header];
@@ -2407,7 +2404,7 @@ class HttpClient {
                     proxyAuth: proxyUrl.auth,
                     host: proxyUrl.hostname,
                     port: proxyUrl.port
-                }
+                },
             };
             let tunnelAgent;
             const overHttps = proxyUrl.protocol === 'https:';
@@ -2434,9 +2431,7 @@ class HttpClient {
             // we don't want to set NODE_TLS_REJECT_UNAUTHORIZED=0 since that will affect request for entire process
             // http.RequestOptions doesn't expose a way to modify RequestOptions.agent.options
             // we have to cast it to any and change it directly
-            agent.options = Object.assign(agent.options || {}, {
-                rejectUnauthorized: false
-            });
+            agent.options = Object.assign(agent.options || {}, { rejectUnauthorized: false });
         }
         return agent;
     }
@@ -2497,7 +2492,7 @@ class HttpClient {
                     msg = contents;
                 }
                 else {
-                    msg = 'Failed request: (' + statusCode + ')';
+                    msg = "Failed request: (" + statusCode + ")";
                 }
                 let err = new Error(msg);
                 // attach statusCode and body obj (if available) to the error object
@@ -2985,7 +2980,25 @@ const core = __importStar(__webpack_require__(470));
 const exec_1 = __webpack_require__(986);
 const io = __importStar(__webpack_require__(1));
 const fs_1 = __webpack_require__(747);
-function getTarPath() {
+const path = __importStar(__webpack_require__(622));
+function isGnuTar() {
+    return __awaiter(this, void 0, void 0, function* () {
+        core.debug("Checking tar --version");
+        let versionOutput = "";
+        yield exec_1.exec("tar --version", [], {
+            ignoreReturnCode: true,
+            silent: true,
+            listeners: {
+                stdout: (data) => (versionOutput += data.toString()),
+                stderr: (data) => (versionOutput += data.toString())
+            }
+        });
+        core.debug(versionOutput.trim());
+        return versionOutput.toUpperCase().includes("GNU TAR");
+    });
+}
+exports.isGnuTar = isGnuTar;
+function getTarPath(args) {
     return __awaiter(this, void 0, void 0, function* () {
         // Explicitly use BSD Tar on Windows
         const IS_WINDOWS = process.platform === "win32";
@@ -2994,7 +3007,7 @@ function getTarPath() {
             if (fs_1.existsSync(systemTar)) {
                 return systemTar;
             }
-            else if (isGnuTar()) {
+            else if (yield isGnuTar()) {
                 args.push("--force-local");
             }
         }
@@ -3002,10 +3015,10 @@ function getTarPath() {
     });
 }
 function execTar(args) {
-    var _a, _b;
+    var _a;
     return __awaiter(this, void 0, void 0, function* () {
         try {
-            yield exec_1.exec(`"${yield getTarPath()}"`, args);
+            yield exec_1.exec(`"${yield getTarPath(args)}"`, args);
         }
         catch (error) {
             throw new Error(`Tar failed with error: ${(_a = error) === null || _a === void 0 ? void 0 : _a.message}`);
@@ -3016,14 +3029,27 @@ function extractTar(archivePath, targetDirectory) {
     return __awaiter(this, void 0, void 0, function* () {
         // Create directory to extract tar into
         yield io.mkdirP(targetDirectory);
-        const args = ["-xz", "-f", archivePath, "-C", targetDirectory];
+        const args = [
+            "-xz",
+            "-f",
+            archivePath.replace(new RegExp("\\" + path.sep, "g"), "/"),
+            "-C",
+            targetDirectory.replace(new RegExp("\\" + path.sep, "g"), "/")
+        ];
         yield execTar(args);
     });
 }
 exports.extractTar = extractTar;
 function createTar(archivePath, sourceDirectory) {
     return __awaiter(this, void 0, void 0, function* () {
-        const args = ["-cz", "-f", archivePath, "-C", sourceDirectory, "."];
+        const args = [
+            "-cz",
+            "-f",
+            archivePath.replace(new RegExp("\\" + path.sep, "g"), "/"),
+            "-C",
+            sourceDirectory.replace(new RegExp("\\" + path.sep, "g"), "/"),
+            "."
+        ];
         yield execTar(args);
     });
 }
@@ -3047,10 +3073,12 @@ function getProxyUrl(reqUrl) {
     }
     let proxyVar;
     if (usingSsl) {
-        proxyVar = process.env['https_proxy'] || process.env['HTTPS_PROXY'];
+        proxyVar = process.env["https_proxy"] ||
+            process.env["HTTPS_PROXY"];
     }
     else {
-        proxyVar = process.env['http_proxy'] || process.env['HTTP_PROXY'];
+        proxyVar = process.env["http_proxy"] ||
+            process.env["HTTP_PROXY"];
     }
     if (proxyVar) {
         proxyUrl = url.parse(proxyVar);
@@ -3062,7 +3090,7 @@ function checkBypass(reqUrl) {
     if (!reqUrl.hostname) {
         return false;
     }
-    let noProxy = process.env['no_proxy'] || process.env['NO_PROXY'] || '';
+    let noProxy = process.env["no_proxy"] || process.env["NO_PROXY"] || '';
     if (!noProxy) {
         return false;
     }
@@ -3083,10 +3111,7 @@ function checkBypass(reqUrl) {
         upperReqHosts.push(`${upperReqHosts[0]}:${reqPort}`);
     }
     // Compare request host against noproxy
-    for (let upperNoProxyItem of noProxy
-        .split(',')
-        .map(x => x.trim().toUpperCase())
-        .filter(x => x)) {
+    for (let upperNoProxyItem of noProxy.split(',').map(x => x.trim().toUpperCase()).filter(x => x)) {
         if (upperReqHosts.some(x => x === upperNoProxyItem)) {
             return true;
         }

--- a/dist/save/index.js
+++ b/dist/save/index.js
@@ -3017,12 +3017,8 @@ function createTar(archiveFolder, sourceDirectories) {
         const args = [
             "-cz",
             "-f",
-<<<<<<< HEAD
-            constants_1.CacheFilename,
-            "-P",
-=======
             (_a = constants_1.CacheFilename) === null || _a === void 0 ? void 0 : _a.replace(/\\/g, "/"),
->>>>>>> Fallback to GNU tar if BSD tar is unavailable
+            "-P",
             "-C",
             (_b = workingDirectory) === null || _b === void 0 ? void 0 : _b.replace(/\\/g, "/"),
             "--files-from",

--- a/dist/save/index.js
+++ b/dist/save/index.js
@@ -2909,10 +2909,34 @@ var __importStar = (this && this.__importStar) || function (mod) {
     return result;
 };
 Object.defineProperty(exports, "__esModule", { value: true });
+const core = __importStar(__webpack_require__(470));
 const exec_1 = __webpack_require__(986);
 const io = __importStar(__webpack_require__(1));
 const fs_1 = __webpack_require__(747);
+<<<<<<< HEAD
 function getTarPath() {
+=======
+const path = __importStar(__webpack_require__(622));
+const constants_1 = __webpack_require__(694);
+function isGnuTar() {
+    return __awaiter(this, void 0, void 0, function* () {
+        core.debug("Checking tar --version");
+        let versionOutput = "";
+        yield exec_1.exec("tar --version", [], {
+            ignoreReturnCode: true,
+            silent: true,
+            listeners: {
+                stdout: (data) => (versionOutput += data.toString()),
+                stderr: (data) => (versionOutput += data.toString())
+            }
+        });
+        core.debug(versionOutput.trim());
+        return versionOutput.toUpperCase().includes("GNU TAR");
+    });
+}
+exports.isGnuTar = isGnuTar;
+function getTarPath(args) {
+>>>>>>> 4fa017f... Fallback to GNU tar if BSD tar is unavailable
     return __awaiter(this, void 0, void 0, function* () {
         // Explicitly use BSD Tar on Windows
         const IS_WINDOWS = process.platform === "win32";
@@ -2921,38 +2945,91 @@ function getTarPath() {
             if (fs_1.existsSync(systemTar)) {
                 return systemTar;
             }
+            else if (isGnuTar()) {
+                args.push("--force-local");
+            }
         }
         return yield io.which("tar", true);
     });
 }
+<<<<<<< HEAD
 function execTar(args) {
     var _a, _b;
     return __awaiter(this, void 0, void 0, function* () {
         try {
             yield exec_1.exec(`"${yield getTarPath()}"`, args);
+=======
+function execTar(args, cwd) {
+    var _a;
+    return __awaiter(this, void 0, void 0, function* () {
+        try {
+            yield exec_1.exec(`"${yield getTarPath(args)}"`, args, { cwd: cwd });
+>>>>>>> 4fa017f... Fallback to GNU tar if BSD tar is unavailable
         }
         catch (error) {
-            const IS_WINDOWS = process.platform === "win32";
-            if (IS_WINDOWS) {
-                throw new Error(`Tar failed with error: ${(_a = error) === null || _a === void 0 ? void 0 : _a.message}. Ensure BSD tar is installed and on the PATH.`);
-            }
-            throw new Error(`Tar failed with error: ${(_b = error) === null || _b === void 0 ? void 0 : _b.message}`);
+            throw new Error(`Tar failed with error: ${(_a = error) === null || _a === void 0 ? void 0 : _a.message}`);
         }
     });
 }
+<<<<<<< HEAD
 function extractTar(archivePath, targetDirectory) {
     return __awaiter(this, void 0, void 0, function* () {
         // Create directory to extract tar into
         yield io.mkdirP(targetDirectory);
         const args = ["-xz", "-f", archivePath, "-C", targetDirectory];
+=======
+function getWorkingDirectory() {
+    var _a;
+    return _a = process.env["GITHUB_WORKSPACE"], (_a !== null && _a !== void 0 ? _a : process.cwd());
+}
+function extractTar(archivePath) {
+    var _a, _b;
+    return __awaiter(this, void 0, void 0, function* () {
+        // Create directory to extract tar into
+        const workingDirectory = getWorkingDirectory();
+        yield io.mkdirP(workingDirectory);
+        const args = [
+            "-xz",
+            "-f",
+            (_a = archivePath) === null || _a === void 0 ? void 0 : _a.replace(/\\/g, "/"),
+            "-P",
+            "-C",
+            (_b = workingDirectory) === null || _b === void 0 ? void 0 : _b.replace(/\\/g, "/")
+        ];
+>>>>>>> 4fa017f... Fallback to GNU tar if BSD tar is unavailable
         yield execTar(args);
     });
 }
 exports.extractTar = extractTar;
+<<<<<<< HEAD
 function createTar(archivePath, sourceDirectory) {
     return __awaiter(this, void 0, void 0, function* () {
         const args = ["-cz", "-f", archivePath, "-C", sourceDirectory, "."];
         yield execTar(args);
+=======
+function createTar(archiveFolder, sourceDirectories) {
+    var _a, _b;
+    return __awaiter(this, void 0, void 0, function* () {
+        // Write source directories to manifest.txt to avoid command length limits
+        const manifestFilename = "manifest.txt";
+        fs_1.writeFileSync(path.join(archiveFolder, manifestFilename), sourceDirectories.join("\n"));
+        const workingDirectory = getWorkingDirectory();
+        const args = [
+            "-cz",
+            "-f",
+<<<<<<< HEAD
+            constants_1.CacheFilename,
+            "-P",
+=======
+            (_a = constants_1.CacheFilename) === null || _a === void 0 ? void 0 : _a.replace(/\\/g, "/"),
+>>>>>>> Fallback to GNU tar if BSD tar is unavailable
+            "-C",
+            (_b = workingDirectory) === null || _b === void 0 ? void 0 : _b.replace(/\\/g, "/"),
+            "--files-from",
+            manifestFilename
+        ];
+        yield execTar(args, archiveFolder);
+>>>>>>> 4fa017f... Fallback to GNU tar if BSD tar is unavailable
     });
 }
 exports.createTar = createTar;

--- a/dist/save/index.js
+++ b/dist/save/index.js
@@ -1255,6 +1255,9 @@ const core = __importStar(__webpack_require__(470));
 const fs = __importStar(__webpack_require__(747));
 const auth_1 = __webpack_require__(226);
 const http_client_1 = __webpack_require__(539);
+const stream = __importStar(__webpack_require__(794));
+const util = __importStar(__webpack_require__(669));
+const constants_1 = __webpack_require__(694);
 const utils = __importStar(__webpack_require__(443));
 function isSuccessStatusCode(statusCode) {
     if (!statusCode) {
@@ -1325,13 +1328,10 @@ function getCacheEntry(keys) {
     });
 }
 exports.getCacheEntry = getCacheEntry;
-function pipeResponseToStream(response, stream) {
+function pipeResponseToStream(response, output) {
     return __awaiter(this, void 0, void 0, function* () {
-        return new Promise(resolve => {
-            response.message.pipe(stream).on("close", () => {
-                resolve();
-            });
-        });
+        const pipeline = util.promisify(stream.pipeline);
+        yield pipeline(response.message, output);
     });
 }
 function downloadCache(archiveLocation, archivePath) {
@@ -1664,10 +1664,6 @@ var __importStar = (this && this.__importStar) || function (mod) {
 };
 Object.defineProperty(exports, "__esModule", { value: true });
 const core = __importStar(__webpack_require__(470));
-<<<<<<< HEAD
-=======
-const glob = __importStar(__webpack_require__(281));
->>>>>>> 9bb13c7... Fix lint issue, build .js files
 const io = __importStar(__webpack_require__(1));
 const fs = __importStar(__webpack_require__(747));
 const os = __importStar(__webpack_require__(87));
@@ -2873,6 +2869,13 @@ module.exports = bytesToUuid;
 /***/ (function(module) {
 
 module.exports = require("fs");
+
+/***/ }),
+
+/***/ 794:
+/***/ (function(module) {
+
+module.exports = require("stream");
 
 /***/ }),
 

--- a/dist/save/index.js
+++ b/dist/save/index.js
@@ -1381,7 +1381,7 @@ function getContentRange(start, end) {
     // Content-Range: bytes 0-199/*
     return `bytes ${start}-${end}/*`;
 }
-function uploadChunk(httpClient, resourceUrl, data, start, end) {
+function uploadChunk(httpClient, resourceUrl, openStream, start, end) {
     return __awaiter(this, void 0, void 0, function* () {
         core.debug(`Uploading chunk of size ${end -
             start +
@@ -1391,7 +1391,7 @@ function uploadChunk(httpClient, resourceUrl, data, start, end) {
             "Content-Range": getContentRange(start, end)
         };
         const uploadChunkRequest = () => __awaiter(this, void 0, void 0, function* () {
-            return yield httpClient.sendStream("PATCH", resourceUrl, data, additionalHeaders);
+            return yield httpClient.sendStream("PATCH", resourceUrl, openStream(), additionalHeaders);
         });
         const response = yield uploadChunkRequest();
         if (isSuccessStatusCode(response.message.statusCode)) {
@@ -1434,13 +1434,12 @@ function uploadFile(httpClient, cacheId, archivePath) {
                     const start = offset;
                     const end = offset + chunkSize - 1;
                     offset += MAX_CHUNK_SIZE;
-                    const chunk = fs.createReadStream(archivePath, {
+                    yield uploadChunk(httpClient, resourceUrl, () => fs.createReadStream(archivePath, {
                         fd,
                         start,
                         end,
                         autoClose: false
-                    });
-                    yield uploadChunk(httpClient, resourceUrl, chunk, start, end);
+                    }), start, end);
                 }
             })));
         }
@@ -1495,7 +1494,9 @@ class BasicCredentialHandler {
         this.password = password;
     }
     prepareRequest(options) {
-        options.headers['Authorization'] = 'Basic ' + Buffer.from(this.username + ':' + this.password).toString('base64');
+        options.headers['Authorization'] =
+            'Basic ' +
+                Buffer.from(this.username + ':' + this.password).toString('base64');
     }
     // This handler cannot handle 401
     canHandleAuthentication(response) {
@@ -1531,7 +1532,8 @@ class PersonalAccessTokenCredentialHandler {
     // currently implements pre-authorization
     // TODO: support preAuth = false where it hooks on 401
     prepareRequest(options) {
-        options.headers['Authorization'] = 'Basic ' + Buffer.from('PAT:' + this.token).toString('base64');
+        options.headers['Authorization'] =
+            'Basic ' + Buffer.from('PAT:' + this.token).toString('base64');
     }
     // This handler cannot handle 401
     canHandleAuthentication(response) {
@@ -2000,6 +2002,7 @@ var HttpCodes;
     HttpCodes[HttpCodes["RequestTimeout"] = 408] = "RequestTimeout";
     HttpCodes[HttpCodes["Conflict"] = 409] = "Conflict";
     HttpCodes[HttpCodes["Gone"] = 410] = "Gone";
+    HttpCodes[HttpCodes["TooManyRequests"] = 429] = "TooManyRequests";
     HttpCodes[HttpCodes["InternalServerError"] = 500] = "InternalServerError";
     HttpCodes[HttpCodes["NotImplemented"] = 501] = "NotImplemented";
     HttpCodes[HttpCodes["BadGateway"] = 502] = "BadGateway";
@@ -2024,8 +2027,18 @@ function getProxyUrl(serverUrl) {
     return proxyUrl ? proxyUrl.href : '';
 }
 exports.getProxyUrl = getProxyUrl;
-const HttpRedirectCodes = [HttpCodes.MovedPermanently, HttpCodes.ResourceMoved, HttpCodes.SeeOther, HttpCodes.TemporaryRedirect, HttpCodes.PermanentRedirect];
-const HttpResponseRetryCodes = [HttpCodes.BadGateway, HttpCodes.ServiceUnavailable, HttpCodes.GatewayTimeout];
+const HttpRedirectCodes = [
+    HttpCodes.MovedPermanently,
+    HttpCodes.ResourceMoved,
+    HttpCodes.SeeOther,
+    HttpCodes.TemporaryRedirect,
+    HttpCodes.PermanentRedirect
+];
+const HttpResponseRetryCodes = [
+    HttpCodes.BadGateway,
+    HttpCodes.ServiceUnavailable,
+    HttpCodes.GatewayTimeout
+];
 const RetryableHttpVerbs = ['OPTIONS', 'GET', 'DELETE', 'HEAD'];
 const ExponentialBackoffCeiling = 10;
 const ExponentialBackoffTimeSlice = 5;
@@ -2156,19 +2169,23 @@ class HttpClient {
      */
     async request(verb, requestUrl, data, headers) {
         if (this._disposed) {
-            throw new Error("Client has already been disposed.");
+            throw new Error('Client has already been disposed.');
         }
         let parsedUrl = url.parse(requestUrl);
         let info = this._prepareRequest(verb, parsedUrl, headers);
         // Only perform retries on reads since writes may not be idempotent.
-        let maxTries = (this._allowRetries && RetryableHttpVerbs.indexOf(verb) != -1) ? this._maxRetries + 1 : 1;
+        let maxTries = this._allowRetries && RetryableHttpVerbs.indexOf(verb) != -1
+            ? this._maxRetries + 1
+            : 1;
         let numTries = 0;
         let response;
         while (numTries < maxTries) {
             response = await this.requestRaw(info, data);
 
             // Check if it's an authentication challenge
-            if (response && response.message && response.message.statusCode === HttpCodes.Unauthorized) {
+            if (response &&
+                response.message &&
+                response.message.statusCode === HttpCodes.Unauthorized) {
                 let authenticationHandler;
                 for (let i = 0; i < this.handlers.length; i++) {
                     if (this.handlers[i].canHandleAuthentication(response)) {
@@ -2186,21 +2203,32 @@ class HttpClient {
                 }
             }
             let redirectsRemaining = this._maxRedirects;
-            while (HttpRedirectCodes.indexOf(response.message.statusCode) != -1
-                && this._allowRedirects
-                && redirectsRemaining > 0) {
-                const redirectUrl = response.message.headers["location"];
+            while (HttpRedirectCodes.indexOf(response.message.statusCode) != -1 &&
+                this._allowRedirects &&
+                redirectsRemaining > 0) {
+                const redirectUrl = response.message.headers['location'];
                 if (!redirectUrl) {
                     // if there's no location to redirect to, we won't
                     break;
                 }
                 let parsedRedirectUrl = url.parse(redirectUrl);
-                if (parsedUrl.protocol == 'https:' && parsedUrl.protocol != parsedRedirectUrl.protocol && !this._allowRedirectDowngrade) {
-                    throw new Error("Redirect from HTTPS to HTTP protocol. This downgrade is not allowed for security reasons. If you want to allow this behavior, set the allowRedirectDowngrade option to true.");
+                if (parsedUrl.protocol == 'https:' &&
+                    parsedUrl.protocol != parsedRedirectUrl.protocol &&
+                    !this._allowRedirectDowngrade) {
+                    throw new Error('Redirect from HTTPS to HTTP protocol. This downgrade is not allowed for security reasons. If you want to allow this behavior, set the allowRedirectDowngrade option to true.');
                 }
                 // we need to finish reading the response before reassigning response
                 // which will leak the open socket.
                 await response.readBody();
+                // strip authorization header if redirected to a different hostname
+                if (parsedRedirectUrl.hostname !== parsedUrl.hostname) {
+                    for (let header in headers) {
+                        // header names are case insensitive
+                        if (header.toLowerCase() === 'authorization') {
+                            delete headers[header];
+                        }
+                    }
+                }
                 // let's make the request with the new redirectUrl
                 info = this._prepareRequest(verb, parsedRedirectUrl, headers);
                 response = await this.requestRaw(info, data);
@@ -2251,8 +2279,8 @@ class HttpClient {
      */
     requestRawWithCallback(info, data, onResult) {
         let socket;
-        if (typeof (data) === 'string') {
-            info.options.headers["Content-Length"] = Buffer.byteLength(data, 'utf8');
+        if (typeof data === 'string') {
+            info.options.headers['Content-Length'] = Buffer.byteLength(data, 'utf8');
         }
         let callbackCalled = false;
         let handleResult = (err, res) => {
@@ -2265,7 +2293,7 @@ class HttpClient {
             let res = new HttpClientResponse(msg);
             handleResult(null, res);
         });
-        req.on('socket', (sock) => {
+        req.on('socket', sock => {
             socket = sock;
         });
         // If we ever get disconnected, we want the socket to timeout eventually
@@ -2280,10 +2308,10 @@ class HttpClient {
             // res should have headers
             handleResult(err, null);
         });
-        if (data && typeof (data) === 'string') {
+        if (data && typeof data === 'string') {
             req.write(data, 'utf8');
         }
-        if (data && typeof (data) !== 'string') {
+        if (data && typeof data !== 'string') {
             data.on('close', function () {
                 req.end();
             });
@@ -2310,31 +2338,34 @@ class HttpClient {
         const defaultPort = usingSsl ? 443 : 80;
         info.options = {};
         info.options.host = info.parsedUrl.hostname;
-        info.options.port = info.parsedUrl.port ? parseInt(info.parsedUrl.port) : defaultPort;
-        info.options.path = (info.parsedUrl.pathname || '') + (info.parsedUrl.search || '');
+        info.options.port = info.parsedUrl.port
+            ? parseInt(info.parsedUrl.port)
+            : defaultPort;
+        info.options.path =
+            (info.parsedUrl.pathname || '') + (info.parsedUrl.search || '');
         info.options.method = method;
         info.options.headers = this._mergeHeaders(headers);
         if (this.userAgent != null) {
-            info.options.headers["user-agent"] = this.userAgent;
+            info.options.headers['user-agent'] = this.userAgent;
         }
         info.options.agent = this._getAgent(info.parsedUrl);
         // gives handlers an opportunity to participate
         if (this.handlers) {
-            this.handlers.forEach((handler) => {
+            this.handlers.forEach(handler => {
                 handler.prepareRequest(info.options);
             });
         }
         return info;
     }
     _mergeHeaders(headers) {
-        const lowercaseKeys = obj => Object.keys(obj).reduce((c, k) => (c[k.toLowerCase()] = obj[k], c), {});
+        const lowercaseKeys = obj => Object.keys(obj).reduce((c, k) => ((c[k.toLowerCase()] = obj[k]), c), {});
         if (this.requestOptions && this.requestOptions.headers) {
             return Object.assign({}, lowercaseKeys(this.requestOptions.headers), lowercaseKeys(headers));
         }
         return lowercaseKeys(headers || {});
     }
     _getExistingOrDefaultHeader(additionalHeaders, header, _default) {
-        const lowercaseKeys = obj => Object.keys(obj).reduce((c, k) => (c[k.toLowerCase()] = obj[k], c), {});
+        const lowercaseKeys = obj => Object.keys(obj).reduce((c, k) => ((c[k.toLowerCase()] = obj[k]), c), {});
         let clientHeader;
         if (this.requestOptions && this.requestOptions.headers) {
             clientHeader = lowercaseKeys(this.requestOptions.headers)[header];
@@ -2372,7 +2403,7 @@ class HttpClient {
                     proxyAuth: proxyUrl.auth,
                     host: proxyUrl.hostname,
                     port: proxyUrl.port
-                },
+                }
             };
             let tunnelAgent;
             const overHttps = proxyUrl.protocol === 'https:';
@@ -2399,7 +2430,9 @@ class HttpClient {
             // we don't want to set NODE_TLS_REJECT_UNAUTHORIZED=0 since that will affect request for entire process
             // http.RequestOptions doesn't expose a way to modify RequestOptions.agent.options
             // we have to cast it to any and change it directly
-            agent.options = Object.assign(agent.options || {}, { rejectUnauthorized: false });
+            agent.options = Object.assign(agent.options || {}, {
+                rejectUnauthorized: false
+            });
         }
         return agent;
     }
@@ -2460,7 +2493,7 @@ class HttpClient {
                     msg = contents;
                 }
                 else {
-                    msg = "Failed request: (" + statusCode + ")";
+                    msg = 'Failed request: (' + statusCode + ')';
                 }
                 let err = new Error(msg);
                 // attach statusCode and body obj (if available) to the error object
@@ -3010,12 +3043,10 @@ function getProxyUrl(reqUrl) {
     }
     let proxyVar;
     if (usingSsl) {
-        proxyVar = process.env["https_proxy"] ||
-            process.env["HTTPS_PROXY"];
+        proxyVar = process.env['https_proxy'] || process.env['HTTPS_PROXY'];
     }
     else {
-        proxyVar = process.env["http_proxy"] ||
-            process.env["HTTP_PROXY"];
+        proxyVar = process.env['http_proxy'] || process.env['HTTP_PROXY'];
     }
     if (proxyVar) {
         proxyUrl = url.parse(proxyVar);
@@ -3027,7 +3058,7 @@ function checkBypass(reqUrl) {
     if (!reqUrl.hostname) {
         return false;
     }
-    let noProxy = process.env["no_proxy"] || process.env["NO_PROXY"] || '';
+    let noProxy = process.env['no_proxy'] || process.env['NO_PROXY'] || '';
     if (!noProxy) {
         return false;
     }
@@ -3048,7 +3079,10 @@ function checkBypass(reqUrl) {
         upperReqHosts.push(`${upperReqHosts[0]}:${reqPort}`);
     }
     // Compare request host against noproxy
-    for (let upperNoProxyItem of noProxy.split(',').map(x => x.trim().toUpperCase()).filter(x => x)) {
+    for (let upperNoProxyItem of noProxy
+        .split(',')
+        .map(x => x.trim().toUpperCase())
+        .filter(x => x)) {
         if (upperReqHosts.some(x => x === upperNoProxyItem)) {
             return true;
         }

--- a/dist/save/index.js
+++ b/dist/save/index.js
@@ -2981,6 +2981,7 @@ const exec_1 = __webpack_require__(986);
 const io = __importStar(__webpack_require__(1));
 const fs_1 = __webpack_require__(747);
 const path = __importStar(__webpack_require__(622));
+const tar = __importStar(__webpack_require__(943));
 function isGnuTar() {
     return __awaiter(this, void 0, void 0, function* () {
         core.debug("Checking tar --version");
@@ -3007,7 +3008,7 @@ function getTarPath(args) {
             if (fs_1.existsSync(systemTar)) {
                 return systemTar;
             }
-            else if (yield isGnuTar()) {
+            else if (yield tar.isGnuTar()) {
                 args.push("--force-local");
             }
         }

--- a/dist/save/index.js
+++ b/dist/save/index.js
@@ -1434,11 +1434,15 @@ function uploadFile(httpClient, cacheId, archivePath) {
                     const start = offset;
                     const end = offset + chunkSize - 1;
                     offset += MAX_CHUNK_SIZE;
-                    yield uploadChunk(httpClient, resourceUrl, () => fs.createReadStream(archivePath, {
+                    yield uploadChunk(httpClient, resourceUrl, () => fs
+                        .createReadStream(archivePath, {
                         fd,
                         start,
                         end,
                         autoClose: false
+                    })
+                        .on("error", error => {
+                        throw new Error(`Cache upload failed because file read failed with ${error.Message}`);
                     }), start, end);
                 }
             })));

--- a/dist/save/index.js
+++ b/dist/save/index.js
@@ -1339,7 +1339,24 @@ function downloadCache(archiveLocation, archivePath) {
         const stream = fs.createWriteStream(archivePath);
         const httpClient = new http_client_1.HttpClient("actions/cache");
         const downloadResponse = yield httpClient.get(archiveLocation);
+        // Abort download if no traffic received over the socket.
+        downloadResponse.message.socket.setTimeout(constants_1.SocketTimeout, () => {
+            downloadResponse.message.destroy();
+            core.debug(`Aborting download, socket timed out after ${constants_1.SocketTimeout} ms`);
+        });
         yield pipeResponseToStream(downloadResponse, stream);
+        // Validate download size.
+        const contentLengthHeader = downloadResponse.message.headers["content-length"];
+        if (contentLengthHeader) {
+            const expectedLength = parseInt(contentLengthHeader);
+            const actualLength = utils.getArchiveFileSize(archivePath);
+            if (actualLength != expectedLength) {
+                throw new Error(`Incomplete download. Expected file size: ${expectedLength}, actual file size: ${actualLength}`);
+            }
+        }
+        else {
+            core.debug("Unable to validate download, no Content-Length header");
+        }
     });
 }
 exports.downloadCache = downloadCache;
@@ -1647,6 +1664,10 @@ var __importStar = (this && this.__importStar) || function (mod) {
 };
 Object.defineProperty(exports, "__esModule", { value: true });
 const core = __importStar(__webpack_require__(470));
+<<<<<<< HEAD
+=======
+const glob = __importStar(__webpack_require__(281));
+>>>>>>> 9bb13c7... Fix lint issue, build .js files
 const io = __importStar(__webpack_require__(1));
 const fs = __importStar(__webpack_require__(747));
 const os = __importStar(__webpack_require__(87));
@@ -2022,6 +2043,12 @@ class HttpClientResponse {
             this.message.on('data', (chunk) => {
                 output = Buffer.concat([output, chunk]);
             });
+            this.message.on('aborted', () => {
+                reject("Request was aborted or closed prematurely");
+            });
+            this.message.on('timeout', (socket) => {
+                reject("Request timed out");
+            });
             this.message.on('end', () => {
                 resolve(output.toString());
             });
@@ -2143,6 +2170,7 @@ class HttpClient {
         let response;
         while (numTries < maxTries) {
             response = await this.requestRaw(info, data);
+
             // Check if it's an authentication challenge
             if (response && response.message && response.message.statusCode === HttpCodes.Unauthorized) {
                 let authenticationHandler;
@@ -2802,6 +2830,7 @@ var Events;
     Events["Push"] = "push";
     Events["PullRequest"] = "pull_request";
 })(Events = exports.Events || (exports.Events = {}));
+exports.SocketTimeout = 5000;
 
 
 /***/ }),

--- a/src/cacheHttpClient.ts
+++ b/src/cacheHttpClient.ts
@@ -179,7 +179,7 @@ function getContentRange(start: number, end: number): string {
 async function uploadChunk(
     httpClient: HttpClient,
     resourceUrl: string,
-    data: NodeJS.ReadableStream,
+    openStream: () => NodeJS.ReadableStream,
     start: number,
     end: number
 ): Promise<void> {
@@ -200,7 +200,7 @@ async function uploadChunk(
         return await httpClient.sendStream(
             "PATCH",
             resourceUrl,
-            data,
+            openStream(),
             additionalHeaders
         );
     };
@@ -263,17 +263,17 @@ async function uploadFile(
                     const start = offset;
                     const end = offset + chunkSize - 1;
                     offset += MAX_CHUNK_SIZE;
-                    const chunk = fs.createReadStream(archivePath, {
-                        fd,
-                        start,
-                        end,
-                        autoClose: false
-                    });
 
                     await uploadChunk(
                         httpClient,
                         resourceUrl,
-                        chunk,
+                        () =>
+                            fs.createReadStream(archivePath, {
+                                fd,
+                                start,
+                                end,
+                                autoClose: false
+                            }),
                         start,
                         end
                     );

--- a/src/cacheHttpClient.ts
+++ b/src/cacheHttpClient.ts
@@ -1,12 +1,14 @@
 import * as core from "@actions/core";
-import * as fs from "fs";
-import { BearerCredentialHandler } from "@actions/http-client/auth";
 import { HttpClient, HttpCodes } from "@actions/http-client";
+import { BearerCredentialHandler } from "@actions/http-client/auth";
 import {
     IHttpClientResponse,
     IRequestOptions,
     ITypedResponse
 } from "@actions/http-client/interfaces";
+import * as fs from "fs";
+import * as stream from "stream";
+import * as util from "util";
 
 import { SocketTimeout } from "./constants";
 import {
@@ -109,13 +111,10 @@ export async function getCacheEntry(
 
 async function pipeResponseToStream(
     response: IHttpClientResponse,
-    stream: NodeJS.WritableStream
+    output: NodeJS.WritableStream
 ): Promise<void> {
-    return new Promise(resolve => {
-        response.message.pipe(stream).on("close", () => {
-            resolve();
-        });
-    });
+    const pipeline = util.promisify(stream.pipeline);
+    await pipeline(response.message, output);
 }
 
 export async function downloadCache(

--- a/src/cacheHttpClient.ts
+++ b/src/cacheHttpClient.ts
@@ -137,7 +137,7 @@ export async function downloadCache(
     await pipeResponseToStream(downloadResponse, stream);
 
     // Validate download size.
-    var contentLengthHeader =
+    const contentLengthHeader =
         downloadResponse.message.headers["content-length"];
 
     if (contentLengthHeader) {

--- a/src/cacheHttpClient.ts
+++ b/src/cacheHttpClient.ts
@@ -268,12 +268,18 @@ async function uploadFile(
                         httpClient,
                         resourceUrl,
                         () =>
-                            fs.createReadStream(archivePath, {
-                                fd,
-                                start,
-                                end,
-                                autoClose: false
-                            }),
+                            fs
+                                .createReadStream(archivePath, {
+                                    fd,
+                                    start,
+                                    end,
+                                    autoClose: false
+                                })
+                                .on("error", error => {
+                                    throw new Error(
+                                        `Cache upload failed because file read failed with ${error.Message}`
+                                    );
+                                }),
                         start,
                         end
                     );

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -19,4 +19,7 @@ export enum Events {
     PullRequest = "pull_request"
 }
 
+// Socket timeout in milliseconds during download.  If no traffic is received
+// over the socket during this period, the socket is destroyed and the download
+// is aborted.
 export const SocketTimeout = 5000;

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -18,3 +18,5 @@ export enum Events {
     Push = "push",
     PullRequest = "pull_request"
 }
+
+export const SocketTimeout = 5000;

--- a/src/tar.ts
+++ b/src/tar.ts
@@ -3,6 +3,7 @@ import { exec } from "@actions/exec";
 import * as io from "@actions/io";
 import { existsSync } from "fs";
 import * as path from "path";
+import * as tar from "./tar";
 
 export async function isGnuTar(): Promise<boolean> {
     core.debug("Checking tar --version");
@@ -28,7 +29,7 @@ async function getTarPath(args: string[]): Promise<string> {
         const systemTar = `${process.env["windir"]}\\System32\\tar.exe`;
         if (existsSync(systemTar)) {
             return systemTar;
-        } else if (await isGnuTar()) {
+        } else if (await tar.isGnuTar()) {
             args.push("--force-local");
         }
     }

--- a/src/tar.ts
+++ b/src/tar.ts
@@ -28,7 +28,7 @@ async function getTarPath(args: string[]): Promise<string> {
         const systemTar = `${process.env["windir"]}\\System32\\tar.exe`;
         if (existsSync(systemTar)) {
             return systemTar;
-        } else if (isGnuTar()) {
+        } else if (await isGnuTar()) {
             args.push("--force-local");
         }
     }
@@ -52,9 +52,9 @@ export async function extractTar(
     const args = [
         "-xz",
         "-f",
-        archivePath?.replace(/\\/g, "/"),
+        archivePath.replace(new RegExp("\\" + path.sep, "g"), "/"),
         "-C",
-        targetDirectory?.replace(/\\/g, "/")
+        targetDirectory.replace(new RegExp("\\" + path.sep, "g"), "/")
     ];
     await execTar(args);
 }
@@ -66,9 +66,9 @@ export async function createTar(
     const args = [
         "-cz",
         "-f",
-        archivePath?.replace(/\\/g, "/"),
+        archivePath.replace(new RegExp("\\" + path.sep, "g"), "/"),
         "-C",
-        sourceDirectory?.replace(/\\/g, "/"),
+        sourceDirectory.replace(new RegExp("\\" + path.sep, "g"), "/"),
         "."
     ];
     await execTar(args);

--- a/src/tar.ts
+++ b/src/tar.ts
@@ -1,14 +1,35 @@
+import * as core from "@actions/core";
 import { exec } from "@actions/exec";
 import * as io from "@actions/io";
 import { existsSync } from "fs";
+import * as path from "path";
 
-async function getTarPath(): Promise<string> {
+export async function isGnuTar(): Promise<boolean> {
+    core.debug("Checking tar --version");
+    let versionOutput = "";
+    await exec("tar --version", [], {
+        ignoreReturnCode: true,
+        silent: true,
+        listeners: {
+            stdout: (data: Buffer): string =>
+                (versionOutput += data.toString()),
+            stderr: (data: Buffer): string => (versionOutput += data.toString())
+        }
+    });
+
+    core.debug(versionOutput.trim());
+    return versionOutput.toUpperCase().includes("GNU TAR");
+}
+
+async function getTarPath(args: string[]): Promise<string> {
     // Explicitly use BSD Tar on Windows
     const IS_WINDOWS = process.platform === "win32";
     if (IS_WINDOWS) {
         const systemTar = `${process.env["windir"]}\\System32\\tar.exe`;
         if (existsSync(systemTar)) {
             return systemTar;
+        } else if (isGnuTar()) {
+            args.push("--force-local");
         }
     }
     return await io.which("tar", true);
@@ -16,14 +37,8 @@ async function getTarPath(): Promise<string> {
 
 async function execTar(args: string[]): Promise<void> {
     try {
-        await exec(`"${await getTarPath()}"`, args);
+        await exec(`"${await getTarPath(args)}"`, args);
     } catch (error) {
-        const IS_WINDOWS = process.platform === "win32";
-        if (IS_WINDOWS) {
-            throw new Error(
-                `Tar failed with error: ${error?.message}. Ensure BSD tar is installed and on the PATH.`
-            );
-        }
         throw new Error(`Tar failed with error: ${error?.message}`);
     }
 }
@@ -34,7 +49,13 @@ export async function extractTar(
 ): Promise<void> {
     // Create directory to extract tar into
     await io.mkdirP(targetDirectory);
-    const args = ["-xz", "-f", archivePath, "-C", targetDirectory];
+    const args = [
+        "-xz",
+        "-f",
+        archivePath?.replace(/\\/g, "/"),
+        "-C",
+        targetDirectory?.replace(/\\/g, "/")
+    ];
     await execTar(args);
 }
 
@@ -42,6 +63,13 @@ export async function createTar(
     archivePath: string,
     sourceDirectory: string
 ): Promise<void> {
-    const args = ["-cz", "-f", archivePath, "-C", sourceDirectory, "."];
+    const args = [
+        "-cz",
+        "-f",
+        archivePath?.replace(/\\/g, "/"),
+        "-C",
+        sourceDirectory?.replace(/\\/g, "/"),
+        "."
+    ];
     await execTar(args);
 }


### PR DESCRIPTION
Cherry-pick commits for v1.2.0 release

Includes the following commits:

Fall back to gnu tar:
PR: https://github.com/actions/cache/pull/252
git cherry-pick 78809b91d73d12e094c66654de7b65727733dcc6..52046d14091e303ed4799d5c3ec3b96b9302023c

Adds socket timeout and validate file size
PR: https://github.com/actions/cache/pull/269
git cherry-pick f00dedfa6c708c51f4e4296f092458a4a891bddd..48b62c1c529d0cb84897a268c7c9a992f441b406

Better error handling during download 
PR: https://github.com/actions/cache/pull/284
git cherry-pick 1ed0c23029e0785d1732d054dc4aafb7cd760f23

Fix upload chunk retries
PR: https://github.com/actions/cache/pull/305
git cherry-pick 354f70a56cbf010d865e8bc8c5b6fb9d8e4f483c

Error handling for stream
PR: https://github.com/actions/cache/pull/300
git cherry-pick 4967c8e6c50fdd9eca6ebcc587a8fb80f4a169b3

Retries to all API
PR: https://github.com/actions/cache/pull/306
git cherry-pick 05b13411a0663afe7850fb8d87c8927b0bbb5f8e

Tested locally using `pipecli` and also ported Eric's e2e workflow change to get more coverage. 
