### PR TITLE
Fix: Remove event validation

### DIFF
--- a/__tests__/actionUtils.test.ts
+++ b/__tests__/actionUtils.test.ts
@@ -4,7 +4,7 @@ import { promises as fs } from "fs";
 import * as os from "os";
 import * as path from "path";
 
-import { Events, Outputs, RefKey, State } from "../src/constants";
+import { Events, Outputs, State } from "../src/constants";
 import { ArtifactCacheEntry } from "../src/contracts";
 import * as actionUtils from "../src/utils/actionUtils";
 
@@ -19,7 +19,6 @@ function getTempDir(): string {
 
 afterEach(() => {
     delete process.env[Events.Key];
-    delete process.env[RefKey];
 });
 
 afterAll(async () => {
@@ -186,15 +185,6 @@ test("logWarning logs a message with a warning prefix", () => {
     expect(infoMock).toHaveBeenCalledWith(`[warning]${message}`);
 });
 
-test("isValidEvent returns false for event that does not have a branch or tag", () => {
-    const event = "foo";
-    process.env[Events.Key] = event;
-
-    const isValidEvent = actionUtils.isValidEvent();
-
-    expect(isValidEvent).toBe(false);
-});
-
 test("resolvePaths with no ~ in path", async () => {
     const filePath = ".cache";
 
@@ -324,16 +314,6 @@ test("resolvePaths exclusion pattern returns not found", async () => {
     } finally {
         process.chdir(originalCwd);
     }
-});
-
-test("isValidEvent returns true for event that has a ref", () => {
-    const event = Events.Push;
-    process.env[Events.Key] = event;
-    process.env[RefKey] = "ref/heads/feature";
-
-    const isValidEvent = actionUtils.isValidEvent();
-
-    expect(isValidEvent).toBe(true);
 });
 
 test("unlinkFile unlinks file", async () => {

--- a/__tests__/restore.test.ts
+++ b/__tests__/restore.test.ts
@@ -6,8 +6,7 @@ import {
     CacheFilename,
     CompressionMethod,
     Events,
-    Inputs,
-    RefKey
+    Inputs
 } from "../src/constants";
 import { ArtifactCacheEntry } from "../src/contracts";
 import run from "../src/restore";
@@ -27,11 +26,6 @@ beforeAll(() => {
         }
     );
 
-    jest.spyOn(actionUtils, "isValidEvent").mockImplementation(() => {
-        const actualUtils = jest.requireActual("../src/utils/actionUtils");
-        return actualUtils.isValidEvent();
-    });
-
     jest.spyOn(actionUtils, "getCacheFileName").mockImplementation(cm => {
         const actualUtils = jest.requireActual("../src/utils/actionUtils");
         return actualUtils.getCacheFileName(cm);
@@ -40,26 +34,11 @@ beforeAll(() => {
 
 beforeEach(() => {
     process.env[Events.Key] = Events.Push;
-    process.env[RefKey] = "refs/heads/feature-branch";
 });
 
 afterEach(() => {
     testUtils.clearInputs();
     delete process.env[Events.Key];
-    delete process.env[RefKey];
-});
-
-test("restore with invalid event outputs warning", async () => {
-    const logWarningMock = jest.spyOn(actionUtils, "logWarning");
-    const failedMock = jest.spyOn(core, "setFailed");
-    const invalidEvent = "commit_comment";
-    process.env[Events.Key] = invalidEvent;
-    delete process.env[RefKey];
-    await run();
-    expect(logWarningMock).toHaveBeenCalledWith(
-        `Event Validation Error: The event type ${invalidEvent} is not supported because it's not tied to a branch or tag ref.`
-    );
-    expect(failedMock).toHaveBeenCalledTimes(0);
 });
 
 test("restore with no path should fail", async () => {

--- a/__tests__/save.test.ts
+++ b/__tests__/save.test.ts
@@ -6,8 +6,7 @@ import {
     CacheFilename,
     CompressionMethod,
     Events,
-    Inputs,
-    RefKey
+    Inputs
 } from "../src/constants";
 import { ArtifactCacheEntry } from "../src/contracts";
 import run from "../src/save";
@@ -37,11 +36,6 @@ beforeAll(() => {
         }
     );
 
-    jest.spyOn(actionUtils, "isValidEvent").mockImplementation(() => {
-        const actualUtils = jest.requireActual("../src/utils/actionUtils");
-        return actualUtils.isValidEvent();
-    });
-
     jest.spyOn(actionUtils, "resolvePaths").mockImplementation(
         async filePaths => {
             return filePaths.map(x => path.resolve(x));
@@ -60,26 +54,11 @@ beforeAll(() => {
 
 beforeEach(() => {
     process.env[Events.Key] = Events.Push;
-    process.env[RefKey] = "refs/heads/feature-branch";
 });
 
 afterEach(() => {
     testUtils.clearInputs();
     delete process.env[Events.Key];
-    delete process.env[RefKey];
-});
-
-test("save with invalid event outputs warning", async () => {
-    const logWarningMock = jest.spyOn(actionUtils, "logWarning");
-    const failedMock = jest.spyOn(core, "setFailed");
-    const invalidEvent = "commit_comment";
-    process.env[Events.Key] = invalidEvent;
-    delete process.env[RefKey];
-    await run();
-    expect(logWarningMock).toHaveBeenCalledWith(
-        `Event Validation Error: The event type ${invalidEvent} is not supported because it's not tied to a branch or tag ref.`
-    );
-    expect(failedMock).toHaveBeenCalledTimes(0);
 });
 
 test("save with no primary key in state outputs warning", async () => {

--- a/dist/restore/index.js
+++ b/dist/restore/index.js
@@ -3345,12 +3345,6 @@ function resolvePaths(patterns) {
     });
 }
 exports.resolvePaths = resolvePaths;
-// Cache token authorized for all events that are tied to a ref
-// See GitHub Context https://help.github.com/actions/automating-your-workflow-with-github-actions/contexts-and-expression-syntax-for-github-actions#github-context
-function isValidEvent() {
-    return constants_1.RefKey in process.env && Boolean(process.env[constants_1.RefKey]);
-}
-exports.isValidEvent = isValidEvent;
 function unlinkFile(path) {
     return util.promisify(fs.unlink)(path);
 }
@@ -4607,7 +4601,6 @@ var CompressionMethod;
 // over the socket during this period, the socket is destroyed and the download
 // is aborted.
 exports.SocketTimeout = 5000;
-exports.RefKey = "GITHUB_REF";
 
 
 /***/ }),
@@ -4699,11 +4692,6 @@ function run() {
     var _a;
     return __awaiter(this, void 0, void 0, function* () {
         try {
-            // Validate inputs, this can cause task failure
-            if (!utils.isValidEvent()) {
-                utils.logWarning(`Event Validation Error: The event type ${process.env[constants_1.Events.Key]} is not supported because it's not tied to a branch or tag ref.`);
-                return;
-            }
             const primaryKey = core.getInput(constants_1.Inputs.Key, { required: true });
             core.saveState(constants_1.State.CacheKey, primaryKey);
             const restoreKeys = core

--- a/dist/save/index.js
+++ b/dist/save/index.js
@@ -3345,12 +3345,6 @@ function resolvePaths(patterns) {
     });
 }
 exports.resolvePaths = resolvePaths;
-// Cache token authorized for all events that are tied to a ref
-// See GitHub Context https://help.github.com/actions/automating-your-workflow-with-github-actions/contexts-and-expression-syntax-for-github-actions#github-context
-function isValidEvent() {
-    return constants_1.RefKey in process.env && Boolean(process.env[constants_1.RefKey]);
-}
-exports.isValidEvent = isValidEvent;
 function unlinkFile(path) {
     return util.promisify(fs.unlink)(path);
 }
@@ -4597,10 +4591,6 @@ const utils = __importStar(__webpack_require__(443));
 function run() {
     return __awaiter(this, void 0, void 0, function* () {
         try {
-            if (!utils.isValidEvent()) {
-                utils.logWarning(`Event Validation Error: The event type ${process.env[constants_1.Events.Key]} is not supported because it's not tied to a branch or tag ref.`);
-                return;
-            }
             const state = utils.getCacheState();
             // Inputs are re-evaluted before the post action, so we want the original key used for restore
             const primaryKey = core.getState(constants_1.State.CacheKey);
@@ -4694,7 +4684,6 @@ var CompressionMethod;
 // over the socket during this period, the socket is destroyed and the download
 // is aborted.
 exports.SocketTimeout = 5000;
-exports.RefKey = "GITHUB_REF";
 
 
 /***/ }),

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -33,5 +33,3 @@ export enum CompressionMethod {
 // over the socket during this period, the socket is destroyed and the download
 // is aborted.
 export const SocketTimeout = 5000;
-
-export const RefKey = "GITHUB_REF";

--- a/src/restore.ts
+++ b/src/restore.ts
@@ -8,16 +8,6 @@ import * as utils from "./utils/actionUtils";
 
 async function run(): Promise<void> {
     try {
-        // Validate inputs, this can cause task failure
-        if (!utils.isValidEvent()) {
-            utils.logWarning(
-                `Event Validation Error: The event type ${
-                    process.env[Events.Key]
-                } is not supported because it's not tied to a branch or tag ref.`
-            );
-            return;
-        }
-
         const primaryKey = core.getInput(Inputs.Key, { required: true });
         core.saveState(State.CacheKey, primaryKey);
 

--- a/src/save.ts
+++ b/src/save.ts
@@ -8,15 +8,6 @@ import * as utils from "./utils/actionUtils";
 
 async function run(): Promise<void> {
     try {
-        if (!utils.isValidEvent()) {
-            utils.logWarning(
-                `Event Validation Error: The event type ${
-                    process.env[Events.Key]
-                } is not supported because it's not tied to a branch or tag ref.`
-            );
-            return;
-        }
-
         const state = utils.getCacheState();
 
         // Inputs are re-evaluted before the post action, so we want the original key used for restore

--- a/src/utils/actionUtils.ts
+++ b/src/utils/actionUtils.ts
@@ -11,7 +11,6 @@ import {
     CacheFilename,
     CompressionMethod,
     Outputs,
-    RefKey,
     State
 } from "../constants";
 import { ArtifactCacheEntry } from "../contracts";
@@ -106,12 +105,6 @@ export async function resolvePaths(patterns: string[]): Promise<string[]> {
     }
 
     return paths;
-}
-
-// Cache token authorized for all events that are tied to a ref
-// See GitHub Context https://help.github.com/actions/automating-your-workflow-with-github-actions/contexts-and-expression-syntax-for-github-actions#github-context
-export function isValidEvent(): boolean {
-    return RefKey in process.env && Boolean(process.env[RefKey]);
 }
 
 export function unlinkFile(path: fs.PathLike): Promise<void> {


### PR DESCRIPTION
This PR

* [x] removes the event validation entirely

💁‍♂️ This is an alternative to #317 - I have tried using this action with the `deployment` event, and as far as I understand, the event validation currently serves no real purpose. The action currently verifies that the `GITHUB_REF` environment variable is set, but never uses its value. 