### PR TITLE
Add Coursier cache to recommended Scala setup

### DIFF
--- a/examples.md
+++ b/examples.md
@@ -444,6 +444,7 @@ When dependencies are installed later in the workflow, we must specify the same 
     path: | 
       ~/.ivy2/cache
       ~/.sbt
+      ~/.cache/coursier/v1
     key: ${{ runner.os }}-sbt-${{ hashFiles('**/build.sbt') }}
 ```
 


### PR DESCRIPTION
As of [sbt 1.3.0](https://www.scala-sbt.org/1.x/docs/sbt-1.3-Release-Notes.html#Library+management+with+Coursier) any dependencies are now resolved by coursier. The [default cache location](https://get-coursier.io/docs/cache.html#location) of Coursier is different than the one from Ivy so this should be added as well.