### PR TITLE
Update Scala - SBT example to include Coursier cache

### DIFF
--- a/examples.md
+++ b/examples.md
@@ -443,12 +443,16 @@ SBT 1.2
   uses: actions/cache@v2
   with:
     path: ~/.ivy2/cache
-    key: ${{ runner.os }}-sbt-ivy-cache-${{ hashFiles('**/build.sbt') }}
+    key: ${{ runner.os }}-sbt-ivy-cache-${{ github.run_id }}
+    restore-keys: |
+      ${{ runner.os }}-sbt-ivy-cache-
 - name: Cache SBT
   uses: actions/cache@v2
   with:
     path: ~/.sbt
-    key: ${{ runner.os }}-sbt-${{ hashFiles('**/build.sbt') }}
+    key: ${{ runner.os }}-sbt-${{ github.run_id }}
+    restore-keys: |
+      ${{ runner.os }}-sbt-
 ```
 
 SBT 1.3.0-1.3.10
@@ -457,17 +461,23 @@ SBT 1.3.0-1.3.10
   uses: actions/cache@v2
   with:
     path: ~/.ivy2/cache
-    key: ${{ runner.os }}-sbt-ivy-cache-${{ hashFiles('**/build.sbt') }}
+    key: ${{ runner.os }}-sbt-ivy-cache-${{ github.run_id }}
+    restore-keys: |
+      ${{ runner.os }}-sbt-ivy-cache-
 - name: Cache SBT coursier cache
   uses: actions/cache@v2
   with:
     path: ~/.coursier/cache
-    key: ${{ runner.os }}-sbt-coursier-cache-${{ hashFiles('**/build.sbt') }}
+    key: ${{ runner.os }}-sbt-coursier-cache-${{ github.run_id }}
+    restore-keys: |
+      ${{ runner.os }}-sbt-coursier-cache-
 - name: Cache SBT
   uses: actions/cache@v2
   with:
     path: ~/.sbt
-    key: ${{ runner.os }}-sbt-${{ hashFiles('**/build.sbt') }}
+    key: ${{ runner.os }}-sbt-${{ github.run_id }}
+    restore-keys: |
+      ${{ runner.os }}-sbt-
 ```
 
 SBT 1.3.11+
@@ -476,30 +486,40 @@ SBT 1.3.11+
   uses: actions/cache@v2
   with:
     path: ~/.ivy2/cache
-    key: ${{ runner.os }}-sbt-ivy-cache-${{ hashFiles('**/build.sbt') }}
+    key: ${{ runner.os }}-sbt-ivy-cache-${{ github.run_id }}
+    restore-keys: |
+      ${{ runner.os }}-sbt-ivy-cache-
 - name: Cache SBT coursier cache (Linux)
   uses: actions/cache@v2
   if: startsWith(runner.os, 'Linux')
   with:
     path: ~/.cache/coursier/v1
-    key: ${{ runner.os }}-sbt-coursier-cache-${{ hashFiles('**/build.sbt') }}
+    key: ${{ runner.os }}-sbt-coursier-cache-${{ github.run_id }}
+    restore-keys: |
+      ${{ runner.os }}-sbt-coursier-cache-
 - name: Cache SBT coursier cache (macOS)
   uses: actions/cache@v2
   if: startsWith(runner.os, 'macOS')
   with:
     path: ~/Library/Caches/Coursier/v1
-    key: ${{ runner.os }}-sbt-coursier-cache-${{ hashFiles('**/build.sbt') }}
+    key: ${{ runner.os }}-sbt-coursier-cache-${{ github.run_id }}
+    restore-keys: |
+      ${{ runner.os }}-sbt-coursier-cache-
 - name: Cache SBT coursier cache (Windows)
   uses: actions/cache@v2
   if: startsWith(runner.os, 'Windows')
   with:
     path: ~\AppData\Local\Coursier\Cache\v1
-    key: ${{ runner.os }}-sbt-coursier-cache-${{ hashFiles('**/build.sbt') }}
+    key: ${{ runner.os }}-sbt-coursier-cache-${{ github.run_id }}
+    restore-keys: |
+      ${{ runner.os }}-sbt-coursier-cache-
 - name: Cache SBT
   uses: actions/cache@v2
   with:
     path: ~/.sbt
-    key: ${{ runner.os }}-sbt-${{ hashFiles('**/build.sbt') }}
+    key: ${{ runner.os }}-sbt-${{ github.run_id }}
+    restore-keys: |
+      ${{ runner.os }}-sbt-
 ```
 
 ## Swift, Objective-C - Carthage

--- a/examples.md
+++ b/examples.md
@@ -437,13 +437,68 @@ When dependencies are installed later in the workflow, we must specify the same 
 
 ## Scala - SBT
 
+SBT 1.2
 ```yaml
+- name: Cache SBT ivy cache
+  uses: actions/cache@v2
+  with:
+    path: ~/.ivy2/cache
+    key: ${{ runner.os }}-sbt-ivy-cache-${{ hashFiles('**/build.sbt') }}
 - name: Cache SBT
   uses: actions/cache@v2
   with:
-    path: | 
-      ~/.ivy2/cache
-      ~/.sbt
+    path: ~/.sbt
+    key: ${{ runner.os }}-sbt-${{ hashFiles('**/build.sbt') }}
+```
+
+SBT 1.3.0-1.3.10
+```yaml
+- name: Cache SBT ivy cache
+  uses: actions/cache@v2
+  with:
+    path: ~/.ivy2/cache
+    key: ${{ runner.os }}-sbt-ivy-cache-${{ hashFiles('**/build.sbt') }}
+- name: Cache SBT coursier cache
+  uses: actions/cache@v2
+  with:
+    path: ~/.coursier/cache
+    key: ${{ runner.os }}-sbt-coursier-cache-${{ hashFiles('**/build.sbt') }}
+- name: Cache SBT
+  uses: actions/cache@v2
+  with:
+    path: ~/.sbt
+    key: ${{ runner.os }}-sbt-${{ hashFiles('**/build.sbt') }}
+```
+
+SBT 1.3.11+
+```yaml
+- name: Cache SBT ivy cache
+  uses: actions/cache@v2
+  with:
+    path: ~/.ivy2/cache
+    key: ${{ runner.os }}-sbt-ivy-cache-${{ hashFiles('**/build.sbt') }}
+- name: Cache SBT coursier cache (Linux)
+  uses: actions/cache@v2
+  if: startsWith(runner.os, 'Linux')
+  with:
+    path: ~/.cache/coursier/v1
+    key: ${{ runner.os }}-sbt-coursier-cache-${{ hashFiles('**/build.sbt') }}
+- name: Cache SBT coursier cache (macOS)
+  uses: actions/cache@v2
+  if: startsWith(runner.os, 'macOS')
+  with:
+    path: ~/Library/Caches/Coursier/v1
+    key: ${{ runner.os }}-sbt-coursier-cache-${{ hashFiles('**/build.sbt') }}
+- name: Cache SBT coursier cache (Windows)
+  uses: actions/cache@v2
+  if: startsWith(runner.os, 'Windows')
+  with:
+    path: ~\AppData\Local\Coursier\Cache\v1
+    key: ${{ runner.os }}-sbt-coursier-cache-${{ hashFiles('**/build.sbt') }}
+- name: Cache SBT
+  uses: actions/cache@v2
+  with:
+    path: ~/.sbt
     key: ${{ runner.os }}-sbt-${{ hashFiles('**/build.sbt') }}
 ```
 


### PR DESCRIPTION
Previously I didn't include an example for SBT 1.3+ in #134 since the cache size limit was too small for Coursier (SBT 1.3 uses Coursier instead of Ivy, see https://github.com/actions/cache/issues/59#issuecomment-552846834). Since the cache size limit has been increased in [v1.1.1](https://github.com/actions/cache/releases/tag/v1.1.1), this PR adds an example for SBT 1.3.