### PR TITLE
Add name for Maven example

### DIFF
--- a/examples.md
+++ b/examples.md
@@ -120,8 +120,8 @@ steps:
 We cache the elements of the Cabal store separately, as the entirety of `~/.cabal` can grow very large for projects with many dependencies.
 
 ```yaml
-- uses: actions/cache@v2
-  name: Cache ~/.cabal/packages, ~/.cabal/store and dist-newstyle
+- name: Cache ~/.cabal/packages, ~/.cabal/store and dist-newstyle
+  uses: actions/cache@v2
   with:
     path: |
       ~/.cabal/packages
@@ -144,7 +144,8 @@ We cache the elements of the Cabal store separately, as the entirety of `~/.caba
 ## Java - Maven
 
 ```yaml
-- uses: actions/cache@v2
+- name: Cache local Maven repository
+  uses: actions/cache@v2
   with:
     path: ~/.m2/repository
     key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}


### PR DESCRIPTION
- Adds a name for the Maven example so the step does not appear with the generic name in the log
- Specify `name` before `uses` for Haskell to be consistent with other examples