### PR TITLE
Improve string split to handle whitespace

### DIFF
--- a/__tests__/restore.test.ts
+++ b/__tests__/restore.test.ts
@@ -20,6 +20,13 @@ beforeAll(() => {
         const actualUtils = jest.requireActual("../src/utils/actionUtils");
         return actualUtils.isValidEvent();
     });
+
+    jest.spyOn(actionUtils, "getInputAsArray").mockImplementation(
+        (name, options) => {
+            const actualUtils = jest.requireActual("../src/utils/actionUtils");
+            return actualUtils.getInputAsArray(name, options);
+        }
+    );
 });
 
 beforeEach(() => {

--- a/__tests__/save.test.ts
+++ b/__tests__/save.test.ts
@@ -19,6 +19,14 @@ beforeAll(() => {
         return jest.requireActual("../src/utils/actionUtils").getCacheState();
     });
 
+    jest.spyOn(actionUtils, "getInputAsArray").mockImplementation(
+        (name, options) => {
+            return jest
+                .requireActual("../src/utils/actionUtils")
+                .getInputAsArray(name, options);
+        }
+    );
+
     jest.spyOn(actionUtils, "isExactKeyMatch").mockImplementation(
         (key, cacheResult) => {
             return jest

--- a/dist/restore/index.js
+++ b/dist/restore/index.js
@@ -5306,7 +5306,7 @@ var __importStar = (this && this.__importStar) || function (mod) {
     return result;
 };
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.isValidEvent = exports.logWarning = exports.getCacheState = exports.setOutputAndState = exports.setCacheHitOutput = exports.setCacheState = exports.isExactKeyMatch = void 0;
+exports.getInputAsArray = exports.isValidEvent = exports.logWarning = exports.getCacheState = exports.setOutputAndState = exports.setCacheHitOutput = exports.setCacheState = exports.isExactKeyMatch = void 0;
 const core = __importStar(__webpack_require__(470));
 const constants_1 = __webpack_require__(694);
 function isExactKeyMatch(key, cacheKey) {
@@ -5350,6 +5350,14 @@ function isValidEvent() {
     return constants_1.RefKey in process.env && Boolean(process.env[constants_1.RefKey]);
 }
 exports.isValidEvent = isValidEvent;
+function getInputAsArray(name, options) {
+    return core
+        .getInput(name, options)
+        .split("\n")
+        .map(s => s.trim())
+        .filter(x => x !== "");
+}
+exports.getInputAsArray = getInputAsArray;
 
 
 /***/ }),
@@ -6835,14 +6843,10 @@ function run() {
             }
             const primaryKey = core.getInput(constants_1.Inputs.Key, { required: true });
             core.saveState(constants_1.State.CachePrimaryKey, primaryKey);
-            const restoreKeys = core
-                .getInput(constants_1.Inputs.RestoreKeys)
-                .split("\n")
-                .filter(x => x !== "");
-            const cachePaths = core
-                .getInput(constants_1.Inputs.Path, { required: true })
-                .split("\n")
-                .filter(x => x !== "");
+            const restoreKeys = utils.getInputAsArray(constants_1.Inputs.RestoreKeys);
+            const cachePaths = utils.getInputAsArray(constants_1.Inputs.Path, {
+                required: true
+            });
             try {
                 const cacheKey = yield cache.restoreCache(cachePaths, primaryKey, restoreKeys);
                 if (!cacheKey) {

--- a/dist/save/index.js
+++ b/dist/save/index.js
@@ -5306,7 +5306,7 @@ var __importStar = (this && this.__importStar) || function (mod) {
     return result;
 };
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.isValidEvent = exports.logWarning = exports.getCacheState = exports.setOutputAndState = exports.setCacheHitOutput = exports.setCacheState = exports.isExactKeyMatch = void 0;
+exports.getInputAsArray = exports.isValidEvent = exports.logWarning = exports.getCacheState = exports.setOutputAndState = exports.setCacheHitOutput = exports.setCacheState = exports.isExactKeyMatch = void 0;
 const core = __importStar(__webpack_require__(470));
 const constants_1 = __webpack_require__(694);
 function isExactKeyMatch(key, cacheKey) {
@@ -5350,6 +5350,14 @@ function isValidEvent() {
     return constants_1.RefKey in process.env && Boolean(process.env[constants_1.RefKey]);
 }
 exports.isValidEvent = isValidEvent;
+function getInputAsArray(name, options) {
+    return core
+        .getInput(name, options)
+        .split("\n")
+        .map(s => s.trim())
+        .filter(x => x !== "");
+}
+exports.getInputAsArray = getInputAsArray;
 
 
 /***/ }),
@@ -6600,10 +6608,9 @@ function run() {
                 core.info(`Cache hit occurred on the primary key ${primaryKey}, not saving cache.`);
                 return;
             }
-            const cachePaths = core
-                .getInput(constants_1.Inputs.Path, { required: true })
-                .split("\n")
-                .filter(x => x !== "");
+            const cachePaths = utils.getInputAsArray(constants_1.Inputs.Path, {
+                required: true
+            });
             try {
                 yield cache.saveCache(cachePaths, primaryKey);
             }

--- a/src/restore.ts
+++ b/src/restore.ts
@@ -19,15 +19,10 @@ async function run(): Promise<void> {
         const primaryKey = core.getInput(Inputs.Key, { required: true });
         core.saveState(State.CachePrimaryKey, primaryKey);
 
-        const restoreKeys = core
-            .getInput(Inputs.RestoreKeys)
-            .split("\n")
-            .filter(x => x !== "");
-
-        const cachePaths = core
-            .getInput(Inputs.Path, { required: true })
-            .split("\n")
-            .filter(x => x !== "");
+        const restoreKeys = utils.getInputAsArray(Inputs.RestoreKeys);
+        const cachePaths = utils.getInputAsArray(Inputs.Path, {
+            required: true
+        });
 
         try {
             const cacheKey = await cache.restoreCache(

--- a/src/save.ts
+++ b/src/save.ts
@@ -31,10 +31,9 @@ async function run(): Promise<void> {
             return;
         }
 
-        const cachePaths = core
-            .getInput(Inputs.Path, { required: true })
-            .split("\n")
-            .filter(x => x !== "");
+        const cachePaths = utils.getInputAsArray(Inputs.Path, {
+            required: true
+        });
 
         try {
             await cache.saveCache(cachePaths, primaryKey);

--- a/src/utils/actionUtils.ts
+++ b/src/utils/actionUtils.ts
@@ -45,3 +45,14 @@ export function logWarning(message: string): void {
 export function isValidEvent(): boolean {
     return RefKey in process.env && Boolean(process.env[RefKey]);
 }
+
+export function getInputAsArray(
+    name: string,
+    options?: core.InputOptions
+): string[] {
+    return core
+        .getInput(name, options)
+        .split("\n")
+        .map(s => s.trim())
+        .filter(x => x !== "");
+}


### PR DESCRIPTION
Currently, the following two cache definitions result in two separate caches:

```
- uses: actions/cache@v2
  with:
    path: |
      ~/cache
      !~/cache/exclude
    key: ${{ runner.os }}-${{ hashFiles('**/lockfiles') }}
```

```
- uses: actions/cache@v2
  with:
    path: |
      ~/cache 
      !~/cache/exclude
    key: ${{ runner.os }}-${{ hashFiles('**/lockfiles') }}
```

Don't see any difference? There's an extra whitespace in one.  This results in different version hashes, which ends up creating two different caches.

This PR calls `trim()` on each entry in the `path` and `restore-keys` to remove any leading and trailing whitespace.  Additionally, this moves the split logic to a separate method and adds unit test coverage.