### PR TITLE
Fix caching not restoring on windows hosts

### DIFF
--- a/dist/restore/index.js
+++ b/dist/restore/index.js
@@ -5186,13 +5186,13 @@ function getTarPath(args, compressionMethod) {
             if (compressionMethod !== constants_1.CompressionMethod.Gzip) {
                 // We only use zstandard compression on windows when gnu tar is installed due to
                 // a bug with compressing large files with bsdtar + zstd
-                args.push('--force-local');
+                //args.push('--force-local');
             }
             else if (fs_1.existsSync(systemTar)) {
                 return systemTar;
             }
             else if (yield utils.isGnuTarInstalled()) {
-                args.push('--force-local');
+               // args.push('--force-local');
             }
         }
         return yield io.which('tar', true);

--- a/dist/restore/index.js
+++ b/dist/restore/index.js
@@ -5180,21 +5180,6 @@ const utils = __importStar(__webpack_require__(15));
 const constants_1 = __webpack_require__(931);
 function getTarPath(args, compressionMethod) {
     return __awaiter(this, void 0, void 0, function* () {
-        const IS_WINDOWS = process.platform === 'win32';
-        if (IS_WINDOWS) {
-            const systemTar = `${process.env['windir']}\\System32\\tar.exe`;
-            if (compressionMethod !== constants_1.CompressionMethod.Gzip) {
-                // We only use zstandard compression on windows when gnu tar is installed due to
-                // a bug with compressing large files with bsdtar + zstd
-                //args.push('--force-local');
-            }
-            else if (fs_1.existsSync(systemTar)) {
-                return systemTar;
-            }
-            else if (yield utils.isGnuTarInstalled()) {
-               // args.push('--force-local');
-            }
-        }
         return yield io.which('tar', true);
     });
 }


### PR DESCRIPTION
TAR is in windows-latest by default, no local is not the correct approach for the Windows 2019 / Latest image and it will break the download of artifacts. 

Godot needs this to work now since we use this feature to replace AppVeyor for our CI.

I think the confusion is Win32 TAR vs GNU TAR