### PR TITLE
Upgrade to cache 1.0.1

### DIFF
--- a/dist/restore/index.js
+++ b/dist/restore/index.js
@@ -1022,7 +1022,7 @@ const semver = __importStar(__webpack_require__(280));
 const util = __importStar(__webpack_require__(669));
 const uuid_1 = __webpack_require__(898);
 const constants_1 = __webpack_require__(931);
-// From https://github.com/actions/toolkit/blob/master/packages/tool-cache/src/tool-cache.ts#L23
+// From https://github.com/actions/toolkit/blob/main/packages/tool-cache/src/tool-cache.ts#L23
 function createTempDirectory() {
     return __awaiter(this, void 0, void 0, function* () {
         const IS_WINDOWS = process.platform === 'win32';
@@ -4444,9 +4444,10 @@ function downloadCacheStorageSDK(archiveLocation, archivePath, options) {
             try {
                 downloadProgress.startDisplayTimer();
                 while (!downloadProgress.isDone()) {
-                    const segmentSize = Math.min(maxSegmentSize, contentLength - downloadProgress.segmentOffset);
+                    const segmentStart = downloadProgress.segmentOffset + downloadProgress.segmentSize;
+                    const segmentSize = Math.min(maxSegmentSize, contentLength - segmentStart);
                     downloadProgress.nextSegment(segmentSize);
-                    const result = yield client.downloadToBuffer(downloadProgress.segmentOffset, segmentSize, {
+                    const result = yield client.downloadToBuffer(segmentStart, segmentSize, {
                         concurrency: options.downloadConcurrency,
                         onProgress: downloadProgress.onProgress()
                     });

--- a/dist/save/index.js
+++ b/dist/save/index.js
@@ -1022,7 +1022,7 @@ const semver = __importStar(__webpack_require__(280));
 const util = __importStar(__webpack_require__(669));
 const uuid_1 = __webpack_require__(898);
 const constants_1 = __webpack_require__(931);
-// From https://github.com/actions/toolkit/blob/master/packages/tool-cache/src/tool-cache.ts#L23
+// From https://github.com/actions/toolkit/blob/main/packages/tool-cache/src/tool-cache.ts#L23
 function createTempDirectory() {
     return __awaiter(this, void 0, void 0, function* () {
         const IS_WINDOWS = process.platform === 'win32';
@@ -4444,9 +4444,10 @@ function downloadCacheStorageSDK(archiveLocation, archivePath, options) {
             try {
                 downloadProgress.startDisplayTimer();
                 while (!downloadProgress.isDone()) {
-                    const segmentSize = Math.min(maxSegmentSize, contentLength - downloadProgress.segmentOffset);
+                    const segmentStart = downloadProgress.segmentOffset + downloadProgress.segmentSize;
+                    const segmentSize = Math.min(maxSegmentSize, contentLength - segmentStart);
                     downloadProgress.nextSegment(segmentSize);
-                    const result = yield client.downloadToBuffer(downloadProgress.segmentOffset, segmentSize, {
+                    const result = yield client.downloadToBuffer(segmentStart, segmentSize, {
                         concurrency: options.downloadConcurrency,
                         onProgress: downloadProgress.onProgress()
                     });

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,9 +5,9 @@
   "requires": true,
   "dependencies": {
     "@actions/cache": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@actions/cache/-/cache-1.0.0.tgz",
-      "integrity": "sha512-4gF8XNRhZpFNZJL/rzlnZ2H63P+3USLamvhkhIv5v2JKkEkRvgGVnaQ3kY0LAwYXai82U1wVQhn9cegIUxgRQg==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@actions/cache/-/cache-1.0.1.tgz",
+      "integrity": "sha512-QyMKGZTVB6bRBIMNEoW74LeqYtbY7cSaWNvaT1uqhzjredaW+vNFxv9XF/cyipzwZBVZgizOF2zpdVYnP0UVYg==",
       "requires": {
         "@actions/core": "^1.2.4",
         "@actions/exec": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "@actions/core": "^1.2.0",
     "@actions/exec": "^1.0.1",
     "@actions/io": "^1.0.1",
-    "@actions/cache": "^1.0.0"
+    "@actions/cache": "^1.0.1"
   },
   "devDependencies": {
     "@types/jest": "^24.0.13",


### PR DESCRIPTION
Upgrade to @actions/cache v1.0.1 to pull in a bug fix when downloading multi-segment files (> 2 GBs in size) using the Azure Storage SDK.