### PR TITLE
Add a reference to gradle-cache-action to Java-Gradle configuration

### DIFF
--- a/examples.md
+++ b/examples.md
@@ -133,6 +133,9 @@ We cache the elements of the Cabal store separately, as the entirety of `~/.caba
 
 ## Java - Gradle
 
+Consider using [gradle-cache-action](https://github.com/burrunan/gradle-cache-action) as it provides fine-grained
+[@actions/cache](https://github.com/actions/toolkit/tree/main/packages/cache)-based caching for Gradle builds.
+
 ```yaml
 - uses: actions/cache@v2
   with:


### PR DESCRIPTION
https://github.com/burrunan/gradle-cache-action is [@actions/cache](https://github.com/actions/toolkit/tree/main/packages/cache)-based action for better caching when Gradle is used.

It comes with defaults, so there's no need to configure paths.

PS. I add the exclusion of `!~/.gradle/wrapper/dists/**/gradle*.zip` to the default configuration, as the file (100-150MiB) is used one time only (see https://github.com/gradle/gradle/issues/3605), however, I include the change into the single PR to avoid unexpected merge conflicts between the two