### PR TITLE
Update Rust directories recommended for caching

### DIFF
--- a/examples.md
+++ b/examples.md
@@ -453,9 +453,11 @@ When dependencies are installed later in the workflow, we must specify the same 
 - uses: actions/cache@v2
   with:
     path: |
-      ~/.cargo/registry
-      ~/.cargo/git
-      target
+      ~/.cargo/bin/
+      ~/.cargo/registry/index/
+      ~/.cargo/registry/cache/
+      ~/.cargo/git/db/
+      target/
     key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
 ```
 


### PR DESCRIPTION
This commit applies the suggestion from The Cargo Book:
https://doc.rust-lang.org/cargo/guide/cargo-home.html#caching-the-cargo-home-in-ci