### PR TITLE
Document that no cache is saved on an exact match and thus file hashes should be included in keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Create a workflow `.yml` file in your repositories `.github/workflows` directory
 ### Inputs
 
 * `path` - A list of files, directories, and wildcard patterns to cache and restore. See [`@actions/glob`](https://github.com/actions/toolkit/tree/main/packages/glob) for supported patterns. 
-* `key` - An explicit key for restoring and saving the cache
+* `key` - An explicit key for restoring and saving the cache.  When an exact match is found for this key, the cache will not be saved at the end of the workflow, and so it is recommended to make the key uniquely correspond to the set of files present in the cache, e.g., by including a file hash of exact-version dependencies.
 * `restore-keys` - An ordered list of keys to use for restoring the cache if no cache hit occurred for key
 
 ### Outputs


### PR DESCRIPTION
The (unexpected, to me) fact that the cache isn't updated on an exact match seems to be an important point worthy of being documented, and it helps to explain exactly *why* hash expressions should be included in keys.