### PR TITLE
Add example for python pipenv

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ See [Examples](examples.md) for a list of `actions/cache` implementations for us
 - [OCaml/Reason - esy](./examples.md#ocamlreason---esy)
 - [PHP - Composer](./examples.md#php---composer)
 - [Python - pip](./examples.md#python---pip)
+- [Python - pipenv](./examples.md#python---pipenv)
 - [R - renv](./examples.md#r---renv)
 - [Ruby - Bundler](./examples.md#ruby---bundler)
 - [Rust - Cargo](./examples.md#rust---cargo)

--- a/examples.md
+++ b/examples.md
@@ -22,6 +22,7 @@
     - [Multiple OSes in a workflow](#multiple-oss-in-a-workflow)
     - [Using pip to get cache location](#using-pip-to-get-cache-location)
     - [Using a script to get cache location](#using-a-script-to-get-cache-location)
+  - [Python - pipenv](#python---pipenv)
   - [R - renv](#r---renv)
     - [Simple example](#simple-example-1)
     - [Multiple OSes in a workflow](#multiple-oss-in-a-workflow-1)
@@ -377,6 +378,17 @@ Replace `~/.cache/pip` with the correct `path` if not using Ubuntu.
     key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
     restore-keys: |
       ${{ runner.os }}-pip-
+```
+
+## Python - pipenv
+
+```yaml
+- uses: actions/cache@v2
+  with:
+    path: ~/.local/share/virtualenvs
+    key: ${{ runner.os }}-pipenv-${{ hashFiles('Pipfile.lock') }}
+    restore-keys: |
+      ${{ runner.os }}-pipenv-
 ```
 
 ## R - renv


### PR DESCRIPTION
Following the conversation in [this issue](https://github.com/actions/cache/issues/152) I added an example for Pipenv using a `path` that makes the cache work.