### PR TITLE
Update yarn example

### DIFF
--- a/examples.md
+++ b/examples.md
@@ -225,11 +225,18 @@ The yarn cache directory will depend on your operating system and version of `ya
   id: yarn-cache-dir-path
   run: echo "::set-output name=dir::$(yarn cache dir)"
 
+# Use week number for automatically purging the cache every week. This is
+# useful because caching yarn-cache would otherwise lead it to grow
+# indefinitely since old dependencies are never purged.
+- name: Get week number
+  id: week-number
+  run: echo "::set-output name=value::$(date +%W)"
+
 - uses: actions/cache@v2
   id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
   with:
     path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
-    key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+    key: ${{ runner.os }}-${{ steps.week-number.outputs.value }}-yarn-${{ hashFiles('**/yarn.lock') }}
     restore-keys: |
       ${{ runner.os }}-yarn-
 ```


### PR DESCRIPTION
The yarn-cache directory will grow infinitely big if it is restored every run and never cleared. A large cache will slow down builds, and might lead to increased storage costs. GitHub also offers no way to manually purge the cache, so there is no manual workaround either.

I choose weekly since I figured it's long enough have cache hits for most builds, but not too long for the cache to grow gigantic.