### PR TITLE
Add read-only feature

### DIFF
--- a/__tests__/restore.test.ts
+++ b/__tests__/restore.test.ts
@@ -27,6 +27,13 @@ beforeAll(() => {
             return actualUtils.getInputAsArray(name, options);
         }
     );
+
+    jest.spyOn(actionUtils, "getInputAsBoolean").mockImplementation(
+        (name, options) => {
+            const actualUtils = jest.requireActual("../src/utils/actionUtils");
+            return actualUtils.getInputAsBoolean(name, options);
+        }
+    );
 });
 
 beforeEach(() => {

--- a/__tests__/restore.test.ts
+++ b/__tests__/restore.test.ts
@@ -308,3 +308,35 @@ test("restore with cache found for restore key", async () => {
     );
     expect(failedMock).toHaveBeenCalledTimes(0);
 });
+
+test("restore with read-only with cache found for key", async () => {
+    const path = "node_modules";
+    const key = "node-test";
+    testUtils.setInputs({
+        path: path,
+        key,
+        readOnly: true
+    });
+
+    const infoMock = jest.spyOn(core, "info");
+    const failedMock = jest.spyOn(core, "setFailed");
+    const stateMock = jest.spyOn(core, "saveState");
+    const setCacheHitOutputMock = jest.spyOn(actionUtils, "setCacheHitOutput");
+    const restoreCacheMock = jest
+        .spyOn(cache, "restoreCache")
+        .mockImplementationOnce(() => {
+            return Promise.resolve(key);
+        });
+
+    await run();
+
+    expect(restoreCacheMock).toHaveBeenCalledTimes(1);
+    expect(restoreCacheMock).toHaveBeenCalledWith([path], key, []);
+
+    expect(stateMock).toHaveBeenCalledWith("CACHE_KEY", key);
+    expect(setCacheHitOutputMock).toHaveBeenCalledTimes(1);
+    expect(setCacheHitOutputMock).toHaveBeenCalledWith(true);
+
+    expect(infoMock).toHaveBeenCalledWith(`Cache restored from key: ${key}`);
+    expect(failedMock).toHaveBeenCalledTimes(0);
+});

--- a/action.yml
+++ b/action.yml
@@ -14,6 +14,9 @@ inputs:
   upload-chunk-size:
     description: 'The chunk size used to split up large files during upload, in bytes'
     required: false
+  read-only:
+    description: 'Set to true to never save the cache'
+    required: false
 outputs:
   cache-hit:
     description: 'A boolean value to indicate an exact match was found for the primary key'

--- a/dist/restore/index.js
+++ b/dist/restore/index.js
@@ -4595,6 +4595,7 @@ var Inputs;
     Inputs["Path"] = "path";
     Inputs["RestoreKeys"] = "restore-keys";
     Inputs["UploadChunkSize"] = "upload-chunk-size";
+    Inputs["ReadOnly"] = "read-only";
 })(Inputs = exports.Inputs || (exports.Inputs = {}));
 var Outputs;
 (function (Outputs) {
@@ -36910,7 +36911,7 @@ var __importStar = (this && this.__importStar) || function (mod) {
     return result;
 };
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.getInputAsInt = exports.getInputAsArray = exports.isValidEvent = exports.logWarning = exports.getCacheState = exports.setOutputAndState = exports.setCacheHitOutput = exports.setCacheState = exports.isExactKeyMatch = exports.isGhes = void 0;
+exports.getInputAsBoolean = exports.getInputAsInt = exports.getInputAsArray = exports.isValidEvent = exports.logWarning = exports.getCacheState = exports.setOutputAndState = exports.setCacheHitOutput = exports.setCacheState = exports.isExactKeyMatch = exports.isGhes = void 0;
 const core = __importStar(__webpack_require__(470));
 const constants_1 = __webpack_require__(196);
 function isGhes() {
@@ -36975,6 +36976,10 @@ function getInputAsInt(name, options) {
     return value;
 }
 exports.getInputAsInt = getInputAsInt;
+function getInputAsBoolean(name, options) {
+    return core.getInput(name, options) === "true";
+}
+exports.getInputAsBoolean = getInputAsBoolean;
 
 
 /***/ }),

--- a/dist/save/index.js
+++ b/dist/save/index.js
@@ -4595,6 +4595,7 @@ var Inputs;
     Inputs["Path"] = "path";
     Inputs["RestoreKeys"] = "restore-keys";
     Inputs["UploadChunkSize"] = "upload-chunk-size";
+    Inputs["ReadOnly"] = "read-only";
 })(Inputs = exports.Inputs || (exports.Inputs = {}));
 var Outputs;
 (function (Outputs) {
@@ -36910,7 +36911,7 @@ var __importStar = (this && this.__importStar) || function (mod) {
     return result;
 };
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.getInputAsInt = exports.getInputAsArray = exports.isValidEvent = exports.logWarning = exports.getCacheState = exports.setOutputAndState = exports.setCacheHitOutput = exports.setCacheState = exports.isExactKeyMatch = exports.isGhes = void 0;
+exports.getInputAsBoolean = exports.getInputAsInt = exports.getInputAsArray = exports.isValidEvent = exports.logWarning = exports.getCacheState = exports.setOutputAndState = exports.setCacheHitOutput = exports.setCacheState = exports.isExactKeyMatch = exports.isGhes = void 0;
 const core = __importStar(__webpack_require__(470));
 const constants_1 = __webpack_require__(196);
 function isGhes() {
@@ -36975,6 +36976,10 @@ function getInputAsInt(name, options) {
     return value;
 }
 exports.getInputAsInt = getInputAsInt;
+function getInputAsBoolean(name, options) {
+    return core.getInput(name, options) === "true";
+}
+exports.getInputAsBoolean = getInputAsBoolean;
 
 
 /***/ }),
@@ -44209,6 +44214,10 @@ function run() {
         try {
             if (utils.isGhes()) {
                 utils.logWarning("Cache action is not supported on GHES");
+                return;
+            }
+            if (utils.getInputAsBoolean(constants_1.Inputs.ReadOnly)) {
+                core.info("Cache running in read-only mode, not saving cache.");
                 return;
             }
             if (!utils.isValidEvent()) {

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -2,7 +2,8 @@ export enum Inputs {
     Key = "key",
     Path = "path",
     RestoreKeys = "restore-keys",
-    UploadChunkSize = "upload-chunk-size"
+    UploadChunkSize = "upload-chunk-size",
+    ReadOnly = "read-only"
 }
 
 export enum Outputs {

--- a/src/save.ts
+++ b/src/save.ts
@@ -11,6 +11,11 @@ async function run(): Promise<void> {
             return;
         }
 
+        if (utils.getInputAsBoolean(Inputs.ReadOnly)) {
+            core.info("Cache running in read-only mode, not saving cache.");
+            return;
+        }
+
         if (!utils.isValidEvent()) {
             utils.logWarning(
                 `Event Validation Error: The event type ${

--- a/src/utils/actionUtils.ts
+++ b/src/utils/actionUtils.ts
@@ -74,3 +74,10 @@ export function getInputAsInt(
     }
     return value;
 }
+
+export function getInputAsBoolean(
+    name: string,
+    options?: core.InputOptions
+): boolean {
+    return core.getInput(name, options) === "true";
+}

--- a/src/utils/testUtils.ts
+++ b/src/utils/testUtils.ts
@@ -13,6 +13,7 @@ interface CacheInput {
     path: string;
     key: string;
     restoreKeys?: string[];
+    readOnly?: boolean;
 }
 
 export function setInputs(input: CacheInput): void {
@@ -20,6 +21,7 @@ export function setInputs(input: CacheInput): void {
     setInput(Inputs.Key, input.key);
     input.restoreKeys &&
         setInput(Inputs.RestoreKeys, input.restoreKeys.join("\n"));
+    setInput(Inputs.ReadOnly, input.readOnly ? "true" : "false");
 }
 
 export function clearInputs(): void {
@@ -27,4 +29,5 @@ export function clearInputs(): void {
     delete process.env[getInputName(Inputs.Key)];
     delete process.env[getInputName(Inputs.RestoreKeys)];
     delete process.env[getInputName(Inputs.UploadChunkSize)];
+    delete process.env[getInputName(Inputs.ReadOnly)];
 }


### PR DESCRIPTION
When `read-only` is `true`, the cache is only restored and not saved. This allows for sharing the cache with multiple steps even if these steps may change them. I tried to use `inputs.read-only` in the `post-if` since just starting the post-job takes precious seconds, but that always seems to be `null`.

Available as `martijnhols/cache@read-only`

Fixes #350, #334 and maybe #210 