### PR TITLE
Fix CODEOWNER team name

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @artifacts-actions
+* @actions/artifacts-actions


### PR DESCRIPTION
A GitHub team needs to reference the org name in CODEOWNERs, see https://docs.github.com/en/free-pro-team@latest/github/creating-cloning-and-archiving-repositories/about-code-owners#codeowners-syntax