### PR TITLE
Allow to skip the save post-step

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,8 +83,6 @@ jobs:
       run: /generate-primes.sh -d prime-numbers
 
     - name: Use Prime Numbers
-      env:
-        CACHE_SKIP_SAVE: true
       run: /primes.sh -d prime-numbers
 ```
 

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Create a workflow `.yml` file in your repositories `.github/workflows` directory
 * `restore-keys` - An ordered list of keys to use for restoring the cache if no cache hit occurred for key
 
 ### Environment Variables
-* `CACHE_SKIP_SAVE` - [optinal] When set on step, any modifications made to the restored cache will not be persisted back at the end of the step.  
+* `CACHE_SKIP_SAVE` - [optional] When set to `true`, any modifications made to the restored cache will not be persisted back at the end of the step.  This environment variable can be set at any time using `echo "CACHE_SKIP_SAVE=true" >> $GITHUB_ENV`
 
 ### Outputs
 

--- a/README.md
+++ b/README.md
@@ -70,6 +70,8 @@ jobs:
     - uses: actions/checkout@v2
 
     - name: Cache Primes
+      env:
+        CACHE_SKIP_SAVE: true
       id: cache-primes
       uses: actions/cache@v2
       with:

--- a/README.md
+++ b/README.md
@@ -41,6 +41,9 @@ Create a workflow `.yml` file in your repositories `.github/workflows` directory
 * `key` - An explicit key for restoring and saving the cache
 * `restore-keys` - An ordered list of keys to use for restoring the cache if no cache hit occurred for key
 
+### Environment Variables
+* `CACHE_SKIP_SAVE` - [optinal] When set on step, any modifications made to the restored cache will not be persisted back at the end of the step.  
+
 ### Outputs
 
 * `cache-hit` - A boolean value to indicate an exact match was found for the key
@@ -78,6 +81,8 @@ jobs:
       run: /generate-primes.sh -d prime-numbers
 
     - name: Use Prime Numbers
+      env:
+        CACHE_SKIP_SAVE: true
       run: /primes.sh -d prime-numbers
 ```
 

--- a/action.yml
+++ b/action.yml
@@ -21,7 +21,7 @@ runs:
   using: 'node12'
   main: 'dist/restore/index.js'
   post: 'dist/save/index.js'
-  post-if: 'success()'
+  post-if: 'success() && !env.CACHE_SKIP_SAVE'
 branding:
   icon: 'archive'
   color: 'gray-dark'

--- a/action.yml
+++ b/action.yml
@@ -21,7 +21,7 @@ runs:
   using: 'node12'
   main: 'dist/restore/index.js'
   post: 'dist/save/index.js'
-  post-if: 'success() && env.CACHE_SKIP_SAVE !== "true"'
+  post-if: 'success() && env.CACHE_SKIP_SAVE != "true"'
 branding:
   icon: 'archive'
   color: 'gray-dark'

--- a/action.yml
+++ b/action.yml
@@ -21,7 +21,7 @@ runs:
   using: 'node12'
   main: 'dist/restore/index.js'
   post: 'dist/save/index.js'
-  post-if: 'success() && env.CACHE_SKIP_SAVE != "true"'
+  post-if: success() && env.CACHE_SKIP_SAVE != 'true'
 branding:
   icon: 'archive'
   color: 'gray-dark'

--- a/action.yml
+++ b/action.yml
@@ -21,7 +21,7 @@ runs:
   using: 'node12'
   main: 'dist/restore/index.js'
   post: 'dist/save/index.js'
-  post-if: 'success() && !env.CACHE_SKIP_SAVE'
+  post-if: 'success() && env.CACHE_SKIP_SAVE !== "true"'
 branding:
   icon: 'archive'
   color: 'gray-dark'


### PR DESCRIPTION
This is similar to #474 - but improves on that by skipping the `post` (save) step entirely, saving tens of seconds on each run.  

Fixes #350 
Fixes #334