### PR TITLE
Improved gradle cache key calculation example

### DIFF
--- a/examples.md
+++ b/examples.md
@@ -140,7 +140,7 @@ We cache the elements of the Cabal store separately, as the entirety of `~/.caba
     path: |
       ~/.gradle/caches
       ~/.gradle/wrapper
-    key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*') }}
+    key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
     restore-keys: |
       ${{ runner.os }}-gradle-
 ```


### PR DESCRIPTION
## Context
Without taking into account the `gradle-wrapper.properties` for the cache key, whenever the gradle version gets updated in that file, GH cache will still use the cache generated for the previous version.

That will make subsequent builds to regenerate the `gradle-api-XX.jar` artifact every single time, and that operation is very expensive, **25 seconds** in the build I detected this on a GH Actions runner.

Example log indicating that expensive operation being executed:
```
Generating /home/runner/.gradle/caches/6.8/generated-gradle-jars/gradle-api-6.8.jar
```

## Proposed change
Provide an example that actually takes the `gradle-wrapper.properties` into account for the cache key generation, so if the gradle version gets updated the cache will be regenerated, making subsequent builds much faster.

Also, it would be nice that the example provided in the [webiste docs](https://docs.github.com/en/free-pro-team@latest/actions/guides/building-and-testing-java-with-gradle#caching-dependencies) is aligned with these ones, currently the one in the web doesn't match with the one here for gradle.