### PR TITLE
Drop the example based on using pip's internals

### DIFF
--- a/examples.md
+++ b/examples.md
@@ -389,23 +389,6 @@ jobs:
       ${{ runner.os }}-pip-
 ```
 
-### Using a script to get cache location
-
-> Note: This uses an internal pip API and may not always work
-```yaml
-- name: Get pip cache dir
-  id: pip-cache
-  run: |
-    python -c "from pip._internal.locations import USER_CACHE_DIR; print('::set-output name=dir::' + USER_CACHE_DIR)"
-
-- uses: actions/cache@v2
-  with:
-    path: ${{ steps.pip-cache.outputs.dir }}
-    key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
-    restore-keys: |
-      ${{ runner.os }}-pip-
-```
-
 ## Python - pipenv
 
 ```yaml


### PR DESCRIPTION
pip's documentation explicitly states to not use `import pip`:

> While it is implemented in Python, and so is available from your Python code via
> `import pip`, you must not use pip’s internal APIs in this way.

(from https://pip.pypa.io/en/stable/user_guide/#using-pip-from-your-program)

This example is in direct contradiction with the documentation's guidance and, thus, I'd like to see it removed.

_(puts on pip maintainer hat)_ Recommending/suggesting this adds additional support burden for us, since we've spent a bunch of effort to communicate to our users that the code in pip's namespace is not meant-to-be-reused code via `import pip.<whatever>`. _(takes off hat)_