### PR TITLE
doc(python-pipenv): Add run example

### DIFF
--- a/examples.md
+++ b/examples.md
@@ -417,6 +417,15 @@ jobs:
       ${{ runner.os }}-pipenv-
 ```
 
+To use the cache effectively:
+```yaml
+- name: Install packages
+  run: |
+    pipenv --venv && \
+      (pipenv lock -r |cat - ci-requirements.txt|pipenv run pip install -r /dev/stdin) || \
+      (pipenv install --python ${{ matrix.python-version }} --deploy)
+```
+
 ## R - renv
 
 For renv, the cache directory will vary by OS. Look at https://rstudio.github.io/renv/articles/renv.html#cache


### PR DESCRIPTION
Using the cache is only effective when not using install as it will run
`pipenv --rm` if it detects an old environment. On top of that, pip is a
lot faster at detecting satisfied requirements.