### PR TITLE
Fix typo of cache path in Lerna example

### DIFF
--- a/examples.md
+++ b/examples.md
@@ -215,7 +215,7 @@ If using `npm config` to retrieve the cache directory, ensure you run [actions/s
 - name: restore lerna
   uses: actions/cache@v2
   with:
-    path: **/*/node_modules
+    path: **/node_modules
     key: ${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
 ```
 

--- a/examples.md
+++ b/examples.md
@@ -215,9 +215,7 @@ If using `npm config` to retrieve the cache directory, ensure you run [actions/s
 - name: restore lerna
   uses: actions/cache@v2
   with:
-    path: |
-      node_modules
-      **/*/node_modules
+    path: **/*/node_modules
     key: ${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
 ```
 

--- a/examples.md
+++ b/examples.md
@@ -217,7 +217,7 @@ If using `npm config` to retrieve the cache directory, ensure you run [actions/s
   with:
     path: |
       node_modules
-      */*/node_modules
+      **/*/node_modules
     key: ${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
 ```
 


### PR DESCRIPTION
Hello, there!

I think I found a typo in the Lerna example.

If my understanding is correct, you want to recursively search for `node_modules` in child directories, so `**` is the one to use, no 🤔  ?