### PR TITLE
Update cache key for Elixir

### DIFF
--- a/examples.md
+++ b/examples.md
@@ -97,13 +97,14 @@ steps:
 ```
 
 ## Elixir - Mix
+
 ```yaml
 - uses: actions/cache@v2
   with:
     path: |
       deps
       _build
-    key: ${{ runner.os }}-mix-${{ hashFiles(format('{0}{1}', github.workspace, '/mix.lock')) }}
+    key: ${{ runner.os }}-mix-${{ hashFiles('**/mix.lock')) }}
     restore-keys: |
       ${{ runner.os }}-mix-
 ```


### PR DESCRIPTION
This makes the key similar to other environments.

Notably, this prevents a situation where the cache key is wrong (the hash is empty) in such setups:

```
./
  frontend/
  backend/mix.lock
```

cc @jclem 