### PR TITLE
elixir typo - stray parenthesis

### DIFF
--- a/examples.md
+++ b/examples.md
@@ -104,7 +104,7 @@ steps:
     path: |
       deps
       _build
-    key: ${{ runner.os }}-mix-${{ hashFiles('**/mix.lock')) }}
+    key: ${{ runner.os }}-mix-${{ hashFiles('**/mix.lock') }}
     restore-keys: |
       ${{ runner.os }}-mix-
 ```


### PR DESCRIPTION
This fixes a documentation typo in PR #568 