### PR TITLE
Extend Gradle example with note to stop any running Daemons

### DIFF
--- a/examples.md
+++ b/examples.md
@@ -137,6 +137,8 @@ We cache the elements of the Cabal store separately, as the entirety of `~/.caba
 
 ## Java - Gradle
 
+>Note: Ensure no Gradle daemons are running anymore when your workflow completes. Creating the cache package might fail due to locks being held by Gradle. Refer to the [Gradle Daemon documentation](https://docs.gradle.org/current/userguide/gradle_daemon.html) on how to disable or stop the Gradle Daemons.
+
 ```yaml
 - uses: actions/cache@v2
   with:


### PR DESCRIPTION
This PR adds a small note to the Gradle example mentioning that devs should ensure that no Daemons are running anymore. Running Daemons can hold locks on the file system which makes the `tar.exe` fail to create the package. See #454 for details. 

**Daemons holding locks cause this error**
![image](https://user-images.githubusercontent.com/674916/118119907-5e904180-b3ef-11eb-8308-8de8febd0b4c.png)

**Ensuring Daemons are stopped**
![image](https://user-images.githubusercontent.com/674916/118119991-7d8ed380-b3ef-11eb-9551-81556d4d543b.png)
