### PR TITLE
ci(workflow): add cache to workflows using actions/setup-node

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -6,13 +6,13 @@ on:
       - main
       - releases/**
     paths-ignore:
-      - '**.md'
+      - "**.md"
   push:
     branches:
       - main
       - releases/**
     paths-ignore:
-      - '**.md'
+      - "**.md"
 
 jobs:
   # Build and unit test
@@ -23,41 +23,41 @@ jobs:
       fail-fast: false
     runs-on: ${{ matrix.os }}
     steps:
-    - name: Checkout
-      uses: actions/checkout@v2
-    - name: Setup Node.js
-      uses: actions/setup-node@v1
-      with:
-        node-version: '12.x'
-    - name: Determine npm cache directory
-      id: npm-cache
-      run: |
-        echo "::set-output name=dir::$(npm config get cache)"
-    - name: Restore npm cache
-      uses: actions/cache@v2
-      with:
-        path: ${{ steps.npm-cache.outputs.dir }}
-        key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
-        restore-keys: |
-          ${{ runner.os }}-node-
-    - run: npm ci
-    - name: Prettier Format Check
-      run: npm run format-check
-    - name: ESLint Check
-      run: npm run lint
-    - name: Build & Test
-      run: npm run test
-    - name: Ensure dist/ folder is up-to-date
-      if: ${{ runner.os == 'Linux' }}
-      shell: bash
-      run: |
-        npm run build
-        if [ "$(git diff --ignore-space-at-eol | wc -l)" -gt "0" ]; then
-          echo "Detected uncommitted changes after build.  See status below:"
-          git diff
-          exit 1
-        fi
-        
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Setup Node.js
+        uses: actions/setup-node@v2
+        with:
+          node-version: "12.x"
+          cache: npm
+      - name: Determine npm cache directory
+        id: npm-cache
+        run: |
+          echo "::set-output name=dir::$(npm config get cache)"
+      - name: Restore npm cache
+        uses: actions/cache@v2
+        with:
+          path: ${{ steps.npm-cache.outputs.dir }}
+          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-node-
+      - run: npm ci
+      - name: Prettier Format Check
+        run: npm run format-check
+      - name: ESLint Check
+        run: npm run lint
+      - name: Build & Test
+        run: npm run test
+      - name: Ensure dist/ folder is up-to-date
+        if: ${{ runner.os == 'Linux' }}
+        shell: bash
+        run: |
+          npm run build
+          if [ "$(git diff --ignore-space-at-eol | wc -l)" -gt "0" ]; then
+            echo "Detected uncommitted changes after build.  See status below:"
+            git diff
+            exit 1
+          fi
 
   # End to end save and restore
   test-save:
@@ -67,21 +67,21 @@ jobs:
       fail-fast: false
     runs-on: ${{ matrix.os }}
     steps:
-    - name: Checkout
-      uses: actions/checkout@v2
-    - name: Generate files in working directory
-      shell: bash
-      run: __tests__/create-cache-files.sh ${{ runner.os }} test-cache
-    - name: Generate files outside working directory
-      shell: bash
-      run: __tests__/create-cache-files.sh ${{ runner.os }} ~/test-cache
-    - name: Save cache
-      uses: ./
-      with:
-        key: test-${{ runner.os }}-${{ github.run_id }}
-        path: |
-          test-cache
-          ~/test-cache
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Generate files in working directory
+        shell: bash
+        run: __tests__/create-cache-files.sh ${{ runner.os }} test-cache
+      - name: Generate files outside working directory
+        shell: bash
+        run: __tests__/create-cache-files.sh ${{ runner.os }} ~/test-cache
+      - name: Save cache
+        uses: ./
+        with:
+          key: test-${{ runner.os }}-${{ github.run_id }}
+          path: |
+            test-cache
+            ~/test-cache
   test-restore:
     needs: test-save
     strategy:
@@ -90,21 +90,21 @@ jobs:
       fail-fast: false
     runs-on: ${{ matrix.os }}
     steps:
-    - name: Checkout
-      uses: actions/checkout@v2
-    - name: Restore cache
-      uses: ./
-      with:
-        key: test-${{ runner.os }}-${{ github.run_id }}
-        path: |
-          test-cache
-          ~/test-cache
-    - name: Verify cache files in working directory
-      shell: bash
-      run: __tests__/verify-cache-files.sh ${{ runner.os }} test-cache
-    - name: Verify cache files outside working directory
-      shell: bash
-      run: __tests__/verify-cache-files.sh ${{ runner.os }} ~/test-cache
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Restore cache
+        uses: ./
+        with:
+          key: test-${{ runner.os }}-${{ github.run_id }}
+          path: |
+            test-cache
+            ~/test-cache
+      - name: Verify cache files in working directory
+        shell: bash
+        run: __tests__/verify-cache-files.sh ${{ runner.os }} test-cache
+      - name: Verify cache files outside working directory
+        shell: bash
+        run: __tests__/verify-cache-files.sh ${{ runner.os }} ~/test-cache
 
   # End to end with proxy
   test-proxy-save:
@@ -120,15 +120,15 @@ jobs:
     env:
       https_proxy: http://squid-proxy:3128
     steps:
-    - name: Checkout
-      uses: actions/checkout@v2
-    - name: Generate files
-      run: __tests__/create-cache-files.sh proxy test-cache
-    - name: Save cache
-      uses: ./
-      with:
-        key: test-proxy-${{ github.run_id }}
-        path: test-cache
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Generate files
+        run: __tests__/create-cache-files.sh proxy test-cache
+      - name: Save cache
+        uses: ./
+        with:
+          key: test-proxy-${{ github.run_id }}
+          path: test-cache
   test-proxy-restore:
     needs: test-proxy-save
     runs-on: ubuntu-latest
@@ -143,12 +143,12 @@ jobs:
     env:
       https_proxy: http://squid-proxy:3128
     steps:
-    - name: Checkout
-      uses: actions/checkout@v2
-    - name: Restore cache
-      uses: ./
-      with:
-        key: test-proxy-${{ github.run_id }}
-        path: test-cache
-    - name: Verify cache
-      run: __tests__/verify-cache-files.sh proxy test-cache
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Restore cache
+        uses: ./
+        with:
+          key: test-proxy-${{ github.run_id }}
+          path: test-cache
+      - name: Verify cache
+        run: __tests__/verify-cache-files.sh proxy test-cache

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -6,13 +6,13 @@ on:
       - main
       - releases/**
     paths-ignore:
-      - "**.md"
+      - '**.md'
   push:
     branches:
       - main
       - releases/**
     paths-ignore:
-      - "**.md"
+      - '**.md'
 
 jobs:
   # Build and unit test


### PR DESCRIPTION
## Description

Add `cache` to workflows using `actions/setup-node`

## Context

`setup-node` GitHub Action just released a new option to add cache to steps using it.

You can find the details here: https://github.blog/changelog/2021-07-02-github-actions-setup-node-now-supports-dependency-caching/

---

🤖 This PR has been generated automatically by [this octoherd script](https://github.com/oscard0m/octoherd-script-add-cache-to-node-github-action), feel free to run it in your GitHub user/org repositories! 💪🏾
