### PR TITLE
Add "see more" link to GHE-not-supported warning

### DIFF
--- a/__tests__/restore.test.ts
+++ b/__tests__/restore.test.ts
@@ -68,7 +68,7 @@ test("restore on GHES should no-op", async () => {
     expect(setCacheHitOutputMock).toHaveBeenCalledTimes(1);
     expect(setCacheHitOutputMock).toHaveBeenCalledWith(false);
     expect(logWarningMock).toHaveBeenCalledWith(
-        "Cache action is not supported on GHES"
+        "Cache action is not supported on GHES. See https://github.com/actions/cache/issues/505 for more details"
     );
 });
 

--- a/__tests__/save.test.ts
+++ b/__tests__/save.test.ts
@@ -111,7 +111,7 @@ test("save on GHES should no-op", async () => {
 
     expect(saveCacheMock).toHaveBeenCalledTimes(0);
     expect(logWarningMock).toHaveBeenCalledWith(
-        "Cache action is not supported on GHES"
+        "Cache action is not supported on GHES. See https://github.com/actions/cache/issues/505 for more details"
     );
 });
 

--- a/dist/restore/index.js
+++ b/dist/restore/index.js
@@ -49218,7 +49218,7 @@ function run() {
     return __awaiter(this, void 0, void 0, function* () {
         try {
             if (utils.isGhes()) {
-                utils.logWarning("Cache action is not supported on GHES");
+                utils.logWarning("Cache action is not supported on GHES. See https://github.com/actions/cache/issues/505 for more details");
                 utils.setCacheHitOutput(false);
                 return;
             }

--- a/dist/save/index.js
+++ b/dist/save/index.js
@@ -47162,7 +47162,7 @@ function run() {
     return __awaiter(this, void 0, void 0, function* () {
         try {
             if (utils.isGhes()) {
-                utils.logWarning("Cache action is not supported on GHES");
+                utils.logWarning("Cache action is not supported on GHES. See https://github.com/actions/cache/issues/505 for more details");
                 return;
             }
             if (!utils.isValidEvent()) {

--- a/src/restore.ts
+++ b/src/restore.ts
@@ -7,7 +7,9 @@ import * as utils from "./utils/actionUtils";
 async function run(): Promise<void> {
     try {
         if (utils.isGhes()) {
-            utils.logWarning("Cache action is not supported on GHES");
+            utils.logWarning(
+                "Cache action is not supported on GHES. See https://github.com/actions/cache/issues/505 for more details"
+            );
             utils.setCacheHitOutput(false);
             return;
         }

--- a/src/save.ts
+++ b/src/save.ts
@@ -12,7 +12,9 @@ process.on("uncaughtException", e => utils.logWarning(e.message));
 async function run(): Promise<void> {
     try {
         if (utils.isGhes()) {
-            utils.logWarning("Cache action is not supported on GHES");
+            utils.logWarning(
+                "Cache action is not supported on GHES. See https://github.com/actions/cache/issues/505 for more details"
+            );
             return;
         }
 


### PR DESCRIPTION
I lived for several months thinking that support for caching action on GHE is just a matter of time, because it's such an important thing to have. Only today, I discovered that originally it was not planned at all. And that people already created some workarounds. So I hope that linking the issue from the warning message will save other people from what happened to me :-)