### PR TITLE
Use existing check-dist implementation

### DIFF
--- a/.github/workflows/check-dist.yml
+++ b/.github/workflows/check-dist.yml
@@ -32,14 +32,16 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Move the committed index.js file
-        run: mv dist/ /tmp/
-
-      - name: Rebuild the index.js file
+      - name: Rebuild the dist/ directory
         run: npm run build
 
-      - name: Compare the expected and actual index.js files
-        run: git diff --ignore-all-space dist/ /tmp/dist
+      - name: Compare the expected and actual dist/ directories
+        run: |
+          if [ "$(git diff --ignore-space-at-eol dist/ | wc -l)" -gt "0" ]; then
+            echo "Detected uncommitted changes after build.  See status below:"
+            git diff
+            exit 1
+          fi
         id: diff
 
       # If index.js was different than expected, upload the expected version as an artifact

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -47,17 +47,6 @@ jobs:
       run: npm run lint
     - name: Build & Test
       run: npm run test
-    - name: Ensure dist/ folder is up-to-date
-      if: ${{ runner.os == 'Linux' }}
-      shell: bash
-      run: |
-        npm run build
-        if [ "$(git diff --ignore-space-at-eol | wc -l)" -gt "0" ]; then
-          echo "Detected uncommitted changes after build.  See status below:"
-          git diff
-          exit 1
-        fi
-        
 
   # End to end save and restore
   test-save:

--- a/dist/save/index.js
+++ b/dist/save/index.js
@@ -56,7 +56,6 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
         function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
         step((generator = generator.apply(thisArg, _arguments || [])).next());
     });
-console.log("fail on purp")
 };
 var __importStar = (this && this.__importStar) || function (mod) {
     if (mod && mod.__esModule) return mod;

--- a/dist/save/index.js
+++ b/dist/save/index.js
@@ -56,6 +56,7 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
         function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
         step((generator = generator.apply(thisArg, _arguments || [])).next());
     });
+console.log("fail on purp")
 };
 var __importStar = (this && this.__importStar) || function (mod) {
     if (mod && mod.__esModule) return mod;


### PR DESCRIPTION
Follow-up to #604.  Using the simpler (existing) implementation in a separate workflow.

Example failed run: https://github.com/actions/cache/pull/618/checks?check_run_id=3255542092