### PR TITLE
(R renv) Fix Renv package cache location in examples

### DIFF
--- a/examples.md
+++ b/examples.md
@@ -454,22 +454,22 @@ For renv, the cache directory will vary by OS. Look at https://rstudio.github.io
 
 Locations:
 
-- Ubuntu: `~/.local/share/renv`
-- macOS: `~/Library/Application Support/renv`
-- Windows: `%LOCALAPPDATA%/renv`
+- Ubuntu: `~/.cache/R/renv`
+- macOS: `~/Library/Caches/org.R-project.R/R/renv`
+- Windows: `%LOCALAPPDATA%/R/cache/R/renv`
 
 ### Simple example
 
 ```yaml
 - uses: actions/cache@v2
   with:
-    path: ~/.local/share/renv
+    path: ~/.cache/R/renv
     key: ${{ runner.os }}-renv-${{ hashFiles('**/renv.lock') }}
     restore-keys: |
       ${{ runner.os }}-renv-
 ```
 
-Replace `~/.local/share/renv` with the correct `path` if not using Ubuntu.
+Replace `~/.cache/R/renv` with the correct `path` if not using Ubuntu.
 
 ### Multiple OS's in a workflow
 
@@ -477,7 +477,7 @@ Replace `~/.local/share/renv` with the correct `path` if not using Ubuntu.
 - uses: actions/cache@v2
   if: startsWith(runner.os, 'Linux')
   with:
-    path: ~/.local/share/renv
+    path: ~/.cache/R/renv
     key: ${{ runner.os }}-renv-${{ hashFiles('**/renv.lock') }}
     restore-keys: |
       ${{ runner.os }}-renv-


### PR DESCRIPTION
Hi all,
This PR changes the Renv package cache location in `examples.md`. In the latest update of renv v0.14.0 the default path to the global renv cache has changed from `~/.local/share/renv` to `~/.cache/R/renv` on Linux. See [the renv release notes](https://github.com/rstudio/renv/blob/master/NEWS.md#renv-0140) and [commit for more details](https://github.com/rstudio/renv/commit/758e9fd4be8aed72220388ea27b562bcef249710#diff-eb1ccebc1cc8dc359bd2cbc7e7ca5d19eb2abd37519f5368437457228df03705R252). Updating the cache location fixed the problem for me.

Kind regards,
Manuel