### PR TITLE
(R renv) Remove unused renv-cache-path variable

### DIFF
--- a/examples.md
+++ b/examples.md
@@ -468,11 +468,6 @@ For renv, the cache directory will vary by OS. The `RENV_PATHS_ROOT` environment
     cat("##[set-output name=os-version;]", sessionInfo()$running, "\n", sep = "")
     cat("##[set-output name=r-version;]", R.Version()$version.string, sep = "")
   shell: Rscript {0}
-- name: Get renv cache path
-  id: get-renv-cache-path
-  run: |
-    cat("##[set-output name=renv-cache-path;]", renv::paths$cache(), sep = "")
-  shell: Rscript {0}
 - name: Restore Renv package cache
   uses: actions/cache@v2
   with:


### PR DESCRIPTION
This is a follow up PR after https://github.com/actions/cache/pull/660, which removes the unused `renv-cache-path` variable. Now that the cache location is set by `RENV_PATHS_ROOT` the `renv-cache-path` is not used anymore.