### PR TITLE
Add option to specify a custom cache server

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,10 @@ steps:
 
 > Note: The `id` defined in `actions/cache` must match the `id` in the `if` statement (i.e. `steps.[ID].outputs.cache-hit`)
 
+## Custom cache server
+
+To use a custom cache server, set the environment variable `GITHUB_ACTIONS_CACHE_URL` or use the input `cache-url`.
+
 ## Known limitation
 
 - `action/cache` is currently not supported on GitHub Enterprise Server. <https://github.com/github/roadmap/issues/273> is tracking this.

--- a/action.yml
+++ b/action.yml
@@ -14,6 +14,9 @@ inputs:
   upload-chunk-size:
     description: 'The chunk size used to split up large files during upload, in bytes'
     required: false
+  cache-url:
+    description: 'The URL of the cache server'
+    required: false
 outputs:
   cache-hit:
     description: 'A boolean value to indicate an exact match was found for the primary key'

--- a/dist/restore/index.js
+++ b/dist/restore/index.js
@@ -36348,6 +36348,9 @@ function setActionsCacheUrl() {
     if (requestedCacheUrl) {
         process.env.ACTIONS_CACHE_URL = requestedCacheUrl;
     }
+    else if (process.env.GITHUB_ACTIONS_CACHE_URL) {
+        process.env.ACTIONS_CACHE_URL = process.env.GITHUB_ACTIONS_CACHE_URL;
+    }
 }
 exports.setActionsCacheUrl = setActionsCacheUrl;
 function setCacheState(state) {

--- a/dist/restore/index.js
+++ b/dist/restore/index.js
@@ -36328,7 +36328,7 @@ var __importStar = (this && this.__importStar) || function (mod) {
     return result;
 };
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.getInputAsInt = exports.getInputAsArray = exports.isValidEvent = exports.logWarning = exports.getCacheState = exports.setOutputAndState = exports.setCacheHitOutput = exports.setCacheState = exports.isExactKeyMatch = exports.isGhes = void 0;
+exports.getInputAsInt = exports.getInputAsArray = exports.isValidEvent = exports.logWarning = exports.getCacheState = exports.setOutputAndState = exports.setCacheHitOutput = exports.setCacheState = exports.setActionsCacheUrl = exports.isExactKeyMatch = exports.isGhes = void 0;
 const core = __importStar(__webpack_require__(470));
 const constants_1 = __webpack_require__(196);
 function isGhes() {
@@ -36343,6 +36343,13 @@ function isExactKeyMatch(key, cacheKey) {
         }) === 0);
 }
 exports.isExactKeyMatch = isExactKeyMatch;
+function setActionsCacheUrl() {
+    const requestedCacheUrl = core.getInput("cache-url");
+    if (requestedCacheUrl) {
+        process.env.ACTIONS_CACHE_URL = requestedCacheUrl;
+    }
+}
+exports.setActionsCacheUrl = setActionsCacheUrl;
 function setCacheState(state) {
     core.saveState(constants_1.State.CacheMatchedKey, state);
 }
@@ -46719,6 +46726,7 @@ const utils = __importStar(__webpack_require__(443));
 function run() {
     return __awaiter(this, void 0, void 0, function* () {
         try {
+            utils.setActionsCacheUrl();
             if (utils.isGhes()) {
                 utils.logWarning("Cache action is not supported on GHES. See https://github.com/actions/cache/issues/505 for more details");
                 utils.setCacheHitOutput(false);

--- a/dist/save/index.js
+++ b/dist/save/index.js
@@ -36328,7 +36328,7 @@ var __importStar = (this && this.__importStar) || function (mod) {
     return result;
 };
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.getInputAsInt = exports.getInputAsArray = exports.isValidEvent = exports.logWarning = exports.getCacheState = exports.setOutputAndState = exports.setCacheHitOutput = exports.setCacheState = exports.isExactKeyMatch = exports.isGhes = void 0;
+exports.getInputAsInt = exports.getInputAsArray = exports.isValidEvent = exports.logWarning = exports.getCacheState = exports.setOutputAndState = exports.setCacheHitOutput = exports.setCacheState = exports.setActionsCacheUrl = exports.isExactKeyMatch = exports.isGhes = void 0;
 const core = __importStar(__webpack_require__(470));
 const constants_1 = __webpack_require__(196);
 function isGhes() {
@@ -36343,6 +36343,13 @@ function isExactKeyMatch(key, cacheKey) {
         }) === 0);
 }
 exports.isExactKeyMatch = isExactKeyMatch;
+function setActionsCacheUrl() {
+    const requestedCacheUrl = core.getInput("cache-url");
+    if (requestedCacheUrl) {
+        process.env.ACTIONS_CACHE_URL = requestedCacheUrl;
+    }
+}
+exports.setActionsCacheUrl = setActionsCacheUrl;
 function setCacheState(state) {
     core.saveState(constants_1.State.CacheMatchedKey, state);
 }
@@ -44905,6 +44912,7 @@ process.on("uncaughtException", e => utils.logWarning(e.message));
 function run() {
     return __awaiter(this, void 0, void 0, function* () {
         try {
+            utils.setActionsCacheUrl();
             if (utils.isGhes()) {
                 utils.logWarning("Cache action is not supported on GHES. See https://github.com/actions/cache/issues/505 for more details");
                 return;

--- a/dist/save/index.js
+++ b/dist/save/index.js
@@ -36348,6 +36348,9 @@ function setActionsCacheUrl() {
     if (requestedCacheUrl) {
         process.env.ACTIONS_CACHE_URL = requestedCacheUrl;
     }
+    else if (process.env.GITHUB_ACTIONS_CACHE_URL) {
+        process.env.ACTIONS_CACHE_URL = process.env.GITHUB_ACTIONS_CACHE_URL;
+    }
 }
 exports.setActionsCacheUrl = setActionsCacheUrl;
 function setCacheState(state) {

--- a/src/restore.ts
+++ b/src/restore.ts
@@ -6,6 +6,7 @@ import * as utils from "./utils/actionUtils";
 
 async function run(): Promise<void> {
     try {
+        utils.setActionsCacheUrl();
         if (utils.isGhes()) {
             utils.logWarning(
                 "Cache action is not supported on GHES. See https://github.com/actions/cache/issues/505 for more details"

--- a/src/save.ts
+++ b/src/save.ts
@@ -11,6 +11,7 @@ process.on("uncaughtException", e => utils.logWarning(e.message));
 
 async function run(): Promise<void> {
     try {
+        utils.setActionsCacheUrl();
         if (utils.isGhes()) {
             utils.logWarning(
                 "Cache action is not supported on GHES. See https://github.com/actions/cache/issues/505 for more details"

--- a/src/utils/actionUtils.ts
+++ b/src/utils/actionUtils.ts
@@ -18,6 +18,13 @@ export function isExactKeyMatch(key: string, cacheKey?: string): boolean {
     );
 }
 
+export function setActionsCacheUrl(): void {
+    const requestedCacheUrl = core.getInput("cache-url");
+    if (requestedCacheUrl) {
+        process.env.ACTIONS_CACHE_URL = requestedCacheUrl;
+    }
+}
+
 export function setCacheState(state: string): void {
     core.saveState(State.CacheMatchedKey, state);
 }

--- a/src/utils/actionUtils.ts
+++ b/src/utils/actionUtils.ts
@@ -22,6 +22,8 @@ export function setActionsCacheUrl(): void {
     const requestedCacheUrl = core.getInput("cache-url");
     if (requestedCacheUrl) {
         process.env.ACTIONS_CACHE_URL = requestedCacheUrl;
+    } else if (process.env.GITHUB_ACTIONS_CACHE_URL) {
+        process.env.ACTIONS_CACHE_URL = process.env.GITHUB_ACTIONS_CACHE_URL;
     }
 }
 


### PR DESCRIPTION
Our organization uses custom github runners for most of our GHA workflows. These runners are running in EKS on AWS so we want to be able to leverage AWS S3 for cache both to limit network ingress/egress and to raise the 5GB limit.

We also want changing between our own cache and GHA's cache to be seamless and hidden from our developers. After looking throught the source code for actions/cache and actions/toolkit I figured something like this had the least impact.

I started by trying to override `ACTIONS_CACHE_URL` in the workflow but javascript actions seem to override `ACTIONS_*` environment variables.