### PR TITLE
Bumping up action version to 2.1.7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "cache",
-  "version": "2.1.6",
+  "version": "2.1.7",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cache",
-  "version": "2.1.6",
+  "version": "2.1.7",
   "private": true,
   "description": "Cache dependencies and build outputs",
   "main": "dist/restore/index.js",


### PR DESCRIPTION
The changes in the PR https://github.com/actions/cache/pull/682 to update the toolkit version requires a new action version.