### PR TITLE
Enabling actions cache for GHES

### DIFF
--- a/__tests__/actionUtils.test.ts
+++ b/__tests__/actionUtils.test.ts
@@ -17,24 +17,6 @@ afterEach(() => {
     delete process.env[RefKey];
 });
 
-test("isGhes returns true if server url is not github.com", () => {
-    try {
-        process.env["GITHUB_SERVER_URL"] = "http://example.com";
-        expect(actionUtils.isGhes()).toBe(true);
-    } finally {
-        process.env["GITHUB_SERVER_URL"] = undefined;
-    }
-});
-
-test("isGhes returns true when server url is github.com", () => {
-    try {
-        process.env["GITHUB_SERVER_URL"] = "http://github.com";
-        expect(actionUtils.isGhes()).toBe(false);
-    } finally {
-        process.env["GITHUB_SERVER_URL"] = undefined;
-    }
-});
-
 test("isExactKeyMatch with undefined cache key returns false", () => {
     const key = "linux-rust";
     const cacheKey = undefined;

--- a/__tests__/restore.test.ts
+++ b/__tests__/restore.test.ts
@@ -32,8 +32,6 @@ beforeAll(() => {
 beforeEach(() => {
     process.env[Events.Key] = Events.Push;
     process.env[RefKey] = "refs/heads/feature-branch";
-
-    jest.spyOn(actionUtils, "isGhes").mockImplementation(() => false);
 });
 
 afterEach(() => {
@@ -53,23 +51,6 @@ test("restore with invalid event outputs warning", async () => {
         `Event Validation Error: The event type ${invalidEvent} is not supported because it's not tied to a branch or tag ref.`
     );
     expect(failedMock).toHaveBeenCalledTimes(0);
-});
-
-test("restore on GHES should no-op", async () => {
-    jest.spyOn(actionUtils, "isGhes").mockImplementation(() => true);
-
-    const logWarningMock = jest.spyOn(actionUtils, "logWarning");
-    const restoreCacheMock = jest.spyOn(cache, "restoreCache");
-    const setCacheHitOutputMock = jest.spyOn(actionUtils, "setCacheHitOutput");
-
-    await run();
-
-    expect(restoreCacheMock).toHaveBeenCalledTimes(0);
-    expect(setCacheHitOutputMock).toHaveBeenCalledTimes(1);
-    expect(setCacheHitOutputMock).toHaveBeenCalledWith(false);
-    expect(logWarningMock).toHaveBeenCalledWith(
-        "Cache action is not supported on GHES. See https://github.com/actions/cache/issues/505 for more details"
-    );
 });
 
 test("restore with no path should fail", async () => {

--- a/__tests__/save.test.ts
+++ b/__tests__/save.test.ts
@@ -52,8 +52,6 @@ beforeAll(() => {
 beforeEach(() => {
     process.env[Events.Key] = Events.Push;
     process.env[RefKey] = "refs/heads/feature-branch";
-
-    jest.spyOn(actionUtils, "isGhes").mockImplementation(() => false);
 });
 
 afterEach(() => {
@@ -99,20 +97,6 @@ test("save with no primary key in state outputs warning", async () => {
     );
     expect(logWarningMock).toHaveBeenCalledTimes(1);
     expect(failedMock).toHaveBeenCalledTimes(0);
-});
-
-test("save on GHES should no-op", async () => {
-    jest.spyOn(actionUtils, "isGhes").mockImplementation(() => true);
-
-    const logWarningMock = jest.spyOn(actionUtils, "logWarning");
-    const saveCacheMock = jest.spyOn(cache, "saveCache");
-
-    await run();
-
-    expect(saveCacheMock).toHaveBeenCalledTimes(0);
-    expect(logWarningMock).toHaveBeenCalledWith(
-        "Cache action is not supported on GHES. See https://github.com/actions/cache/issues/505 for more details"
-    );
 });
 
 test("save with exact match returns early", async () => {

--- a/dist/restore/index.js
+++ b/dist/restore/index.js
@@ -36328,14 +36328,9 @@ var __importStar = (this && this.__importStar) || function (mod) {
     return result;
 };
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.getInputAsInt = exports.getInputAsArray = exports.isValidEvent = exports.logWarning = exports.getCacheState = exports.setOutputAndState = exports.setCacheHitOutput = exports.setCacheState = exports.isExactKeyMatch = exports.isGhes = void 0;
+exports.getInputAsInt = exports.getInputAsArray = exports.isValidEvent = exports.logWarning = exports.getCacheState = exports.setOutputAndState = exports.setCacheHitOutput = exports.setCacheState = exports.isExactKeyMatch = void 0;
 const core = __importStar(__webpack_require__(470));
 const constants_1 = __webpack_require__(196);
-function isGhes() {
-    const ghUrl = new URL(process.env["GITHUB_SERVER_URL"] || "https://github.com");
-    return ghUrl.hostname.toUpperCase() !== "GITHUB.COM";
-}
-exports.isGhes = isGhes;
 function isExactKeyMatch(key, cacheKey) {
     return !!(cacheKey &&
         cacheKey.localeCompare(key, undefined, {
@@ -46719,11 +46714,6 @@ const utils = __importStar(__webpack_require__(443));
 function run() {
     return __awaiter(this, void 0, void 0, function* () {
         try {
-            if (utils.isGhes()) {
-                utils.logWarning("Cache action is not supported on GHES. See https://github.com/actions/cache/issues/505 for more details");
-                utils.setCacheHitOutput(false);
-                return;
-            }
             // Validate inputs, this can cause task failure
             if (!utils.isValidEvent()) {
                 utils.logWarning(`Event Validation Error: The event type ${process.env[constants_1.Events.Key]} is not supported because it's not tied to a branch or tag ref.`);

--- a/dist/save/index.js
+++ b/dist/save/index.js
@@ -36328,14 +36328,9 @@ var __importStar = (this && this.__importStar) || function (mod) {
     return result;
 };
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.getInputAsInt = exports.getInputAsArray = exports.isValidEvent = exports.logWarning = exports.getCacheState = exports.setOutputAndState = exports.setCacheHitOutput = exports.setCacheState = exports.isExactKeyMatch = exports.isGhes = void 0;
+exports.getInputAsInt = exports.getInputAsArray = exports.isValidEvent = exports.logWarning = exports.getCacheState = exports.setOutputAndState = exports.setCacheHitOutput = exports.setCacheState = exports.isExactKeyMatch = void 0;
 const core = __importStar(__webpack_require__(470));
 const constants_1 = __webpack_require__(196);
-function isGhes() {
-    const ghUrl = new URL(process.env["GITHUB_SERVER_URL"] || "https://github.com");
-    return ghUrl.hostname.toUpperCase() !== "GITHUB.COM";
-}
-exports.isGhes = isGhes;
 function isExactKeyMatch(key, cacheKey) {
     return !!(cacheKey &&
         cacheKey.localeCompare(key, undefined, {
@@ -44905,10 +44900,6 @@ process.on("uncaughtException", e => utils.logWarning(e.message));
 function run() {
     return __awaiter(this, void 0, void 0, function* () {
         try {
-            if (utils.isGhes()) {
-                utils.logWarning("Cache action is not supported on GHES. See https://github.com/actions/cache/issues/505 for more details");
-                return;
-            }
             if (!utils.isValidEvent()) {
                 utils.logWarning(`Event Validation Error: The event type ${process.env[constants_1.Events.Key]} is not supported because it's not tied to a branch or tag ref.`);
                 return;

--- a/src/restore.ts
+++ b/src/restore.ts
@@ -6,14 +6,6 @@ import * as utils from "./utils/actionUtils";
 
 async function run(): Promise<void> {
     try {
-        if (utils.isGhes()) {
-            utils.logWarning(
-                "Cache action is not supported on GHES. See https://github.com/actions/cache/issues/505 for more details"
-            );
-            utils.setCacheHitOutput(false);
-            return;
-        }
-
         // Validate inputs, this can cause task failure
         if (!utils.isValidEvent()) {
             utils.logWarning(

--- a/src/save.ts
+++ b/src/save.ts
@@ -11,13 +11,6 @@ process.on("uncaughtException", e => utils.logWarning(e.message));
 
 async function run(): Promise<void> {
     try {
-        if (utils.isGhes()) {
-            utils.logWarning(
-                "Cache action is not supported on GHES. See https://github.com/actions/cache/issues/505 for more details"
-            );
-            return;
-        }
-
         if (!utils.isValidEvent()) {
             utils.logWarning(
                 `Event Validation Error: The event type ${

--- a/src/utils/actionUtils.ts
+++ b/src/utils/actionUtils.ts
@@ -2,13 +2,6 @@ import * as core from "@actions/core";
 
 import { Outputs, RefKey, State } from "../constants";
 
-export function isGhes(): boolean {
-    const ghUrl = new URL(
-        process.env["GITHUB_SERVER_URL"] || "https://github.com"
-    );
-    return ghUrl.hostname.toUpperCase() !== "GITHUB.COM";
-}
-
 export function isExactKeyMatch(key: string, cacheKey?: string): boolean {
     return !!(
         cacheKey &&


### PR DESCRIPTION
### Description
This PR is enabling actions cache on GHES by removing the ``isGhes()`` condition and also removing its related test cases.

### Release Process
This change will not be released to the marketplace as an official release, till ac on GHES is released and tested. Till that point, this change/commit will be tagged with ``enabledForGHES.v1`` and users who have GHES with AC can use these changes with ``actions/cache@enabledForGHES.v1``. The reason for not creating a release is that it will then become visible to the marketplace.

### Open question
@bishal-pdMSFT / @aparna-ravindra 
As we know this action is not bydefault packaged in GHES. Do we want this to be packaged by default in GHES releases like these https://github.com/github/ghes-actions/tree/master/config/actions  actions or we are expecting the admin to add it using the ``actions-sync`` tool.

### Linked Issue
https://github.com/github/c2c-actions/issues/3851