### PR TITLE
Added `cache-restored` boolean flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,8 +45,9 @@ If you are using this inside a container, a POSIX-compliant `tar` needs to be in
 ### Outputs
 
 * `cache-hit` - A boolean value to indicate an exact match was found for the key
+* `cache-restored` - A boolean value to a match was found resulting in a restored cache
 
-> See [Skipping steps based on cache-hit](#Skipping-steps-based-on-cache-hit) for info on using this output
+> See [Skipping steps based on `cache-hit`](#Skipping-steps-based-on-cache-hit) for info on using this output
 
 ### Cache scopes
 The cache is scoped to the key and branch. The default branch cache is available to other branches. 
@@ -147,7 +148,7 @@ See [Using contexts to create cache keys](https://help.github.com/en/actions/con
 
 A repository can have up to 10GB of caches. Once the 10GB limit is reached, older caches will be evicted based on when the cache was last accessed.  Caches that are not accessed within the last week will also be evicted.
 
-## Skipping steps based on cache-hit
+## Skipping steps based on `cache-hit`
 
 Using the `cache-hit` output, subsequent steps (such as install or build) can be skipped when a cache hit occurs on the key.
 

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ If you are using this inside a container, a POSIX-compliant `tar` needs to be in
 ### Outputs
 
 * `cache-hit` - A boolean value to indicate an exact match was found for the key
-* `cache-restored` - A boolean value to a match was found resulting in a restored cache
+* `cache-restored` - A boolean value to indicate a primary key match was found resulting in a restore
 
 > See [Skipping steps based on `cache-hit`](#Skipping-steps-based-on-cache-hit) for info on using this output
 

--- a/action.yml
+++ b/action.yml
@@ -18,7 +18,7 @@ outputs:
   cache-hit:
     description: 'A boolean value to indicate an exact match was found for the primary key'
   cache-restored:
-    description: 'A boolean value to indicate an exact or partial match was found resulting in a restore'
+    description: 'A boolean value to indicate a primary key match was found resulting in a restore'
 runs:
   using: 'node16'
   main: 'dist/restore/index.js'

--- a/action.yml
+++ b/action.yml
@@ -17,6 +17,8 @@ inputs:
 outputs:
   cache-hit:
     description: 'A boolean value to indicate an exact match was found for the primary key'
+  cache-restored:
+    description: 'A boolean value to indicate an exact or partial match was found resulting in a restore'
 runs:
   using: 'node16'
   main: 'dist/restore/index.js'

--- a/dist/restore/index.js
+++ b/dist/restore/index.js
@@ -4610,6 +4610,7 @@ var Inputs;
 var Outputs;
 (function (Outputs) {
     Outputs["CacheHit"] = "cache-hit";
+    Outputs["CacheRestored"] = "cache-restored";
 })(Outputs = exports.Outputs || (exports.Outputs = {}));
 var State;
 (function (State) {
@@ -36294,7 +36295,7 @@ var __importStar = (this && this.__importStar) || function (mod) {
     return result;
 };
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.getInputAsInt = exports.getInputAsArray = exports.isValidEvent = exports.logWarning = exports.getCacheState = exports.setOutputAndState = exports.setCacheHitOutput = exports.setCacheState = exports.isExactKeyMatch = exports.isGhes = void 0;
+exports.getInputAsInt = exports.getInputAsArray = exports.isValidEvent = exports.logWarning = exports.getCacheState = exports.setOutputAndState = exports.setCacheRestoredOutput = exports.setCacheHitOutput = exports.setCacheState = exports.isExactKeyMatch = exports.isGhes = void 0;
 const core = __importStar(__webpack_require__(470));
 const constants_1 = __webpack_require__(196);
 function isGhes() {
@@ -36317,6 +36318,10 @@ function setCacheHitOutput(isCacheHit) {
     core.setOutput(constants_1.Outputs.CacheHit, isCacheHit.toString());
 }
 exports.setCacheHitOutput = setCacheHitOutput;
+function setCacheRestoredOutput(isCacheRestored) {
+    core.setOutput(constants_1.Outputs.CacheRestored, isCacheRestored.toString());
+}
+exports.setCacheRestoredOutput = setCacheRestoredOutput;
 function setOutputAndState(key, cacheKey) {
     setCacheHitOutput(isExactKeyMatch(key, cacheKey));
     // Store the matched cache key if it exists
@@ -46779,6 +46784,7 @@ function run() {
                 // Store the matched cache key
                 utils.setCacheState(cacheKey);
                 const isExactKeyMatch = utils.isExactKeyMatch(primaryKey, cacheKey);
+                utils.setCacheRestoredOutput(true);
                 utils.setCacheHitOutput(isExactKeyMatch);
                 core.info(`Cache restored from key: ${cacheKey}`);
             }
@@ -46788,6 +46794,7 @@ function run() {
                 }
                 else {
                     utils.logWarning(error.message);
+                    utils.setCacheRestoredOutput(false);
                     utils.setCacheHitOutput(false);
                 }
             }

--- a/dist/save/index.js
+++ b/dist/save/index.js
@@ -4610,6 +4610,7 @@ var Inputs;
 var Outputs;
 (function (Outputs) {
     Outputs["CacheHit"] = "cache-hit";
+    Outputs["CacheRestored"] = "cache-restored";
 })(Outputs = exports.Outputs || (exports.Outputs = {}));
 var State;
 (function (State) {
@@ -36294,7 +36295,7 @@ var __importStar = (this && this.__importStar) || function (mod) {
     return result;
 };
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.getInputAsInt = exports.getInputAsArray = exports.isValidEvent = exports.logWarning = exports.getCacheState = exports.setOutputAndState = exports.setCacheHitOutput = exports.setCacheState = exports.isExactKeyMatch = exports.isGhes = void 0;
+exports.getInputAsInt = exports.getInputAsArray = exports.isValidEvent = exports.logWarning = exports.getCacheState = exports.setOutputAndState = exports.setCacheRestoredOutput = exports.setCacheHitOutput = exports.setCacheState = exports.isExactKeyMatch = exports.isGhes = void 0;
 const core = __importStar(__webpack_require__(470));
 const constants_1 = __webpack_require__(196);
 function isGhes() {
@@ -36317,6 +36318,10 @@ function setCacheHitOutput(isCacheHit) {
     core.setOutput(constants_1.Outputs.CacheHit, isCacheHit.toString());
 }
 exports.setCacheHitOutput = setCacheHitOutput;
+function setCacheRestoredOutput(isCacheRestored) {
+    core.setOutput(constants_1.Outputs.CacheRestored, isCacheRestored.toString());
+}
+exports.setCacheRestoredOutput = setCacheRestoredOutput;
 function setOutputAndState(key, cacheKey) {
     setCacheHitOutput(isExactKeyMatch(key, cacheKey));
     // Store the matched cache key if it exists

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -6,7 +6,8 @@ export enum Inputs {
 }
 
 export enum Outputs {
-    CacheHit = "cache-hit"
+    CacheHit = "cache-hit",
+    CacheRestored = "cache-restored"
 }
 
 export enum State {

--- a/src/restore.ts
+++ b/src/restore.ts
@@ -52,6 +52,7 @@ async function run(): Promise<void> {
             utils.setCacheState(cacheKey);
 
             const isExactKeyMatch = utils.isExactKeyMatch(primaryKey, cacheKey);
+            utils.setCacheRestoredOutput(true);
             utils.setCacheHitOutput(isExactKeyMatch);
 
             core.info(`Cache restored from key: ${cacheKey}`);
@@ -60,6 +61,7 @@ async function run(): Promise<void> {
                 throw error;
             } else {
                 utils.logWarning(error.message);
+                utils.setCacheRestoredOutput(false);
                 utils.setCacheHitOutput(false);
             }
         }

--- a/src/utils/actionUtils.ts
+++ b/src/utils/actionUtils.ts
@@ -26,6 +26,10 @@ export function setCacheHitOutput(isCacheHit: boolean): void {
     core.setOutput(Outputs.CacheHit, isCacheHit.toString());
 }
 
+export function setCacheRestoredOutput(isCacheRestored: boolean): void {
+    core.setOutput(Outputs.CacheRestored, isCacheRestored.toString());
+}
+
 export function setOutputAndState(key: string, cacheKey?: string): void {
     setCacheHitOutput(isExactKeyMatch(key, cacheKey));
     // Store the matched cache key if it exists


### PR DESCRIPTION
Description:
```yaml
  cache-restored:
    description: 'A boolean value to indicate an exact or partial match was found resulting in a restore'
```

This flag should be used similarly to `steps.cache.outputs.cache-hit` to indicate when there is a partial match for a cache. 

The aim here is the ability to avoid certain install steps if any part of the cache was restored.