### PR TITLE
feat: force-update

### DIFF
--- a/__tests__/save.test.ts
+++ b/__tests__/save.test.ts
@@ -142,6 +142,38 @@ test("save with exact match returns early", async () => {
     expect(failedMock).toHaveBeenCalledTimes(0);
 });
 
+test("save with force-update", async () => {
+    const failedMock = jest.spyOn(core, "setFailed");
+
+    const primaryKey = "Linux-node-bb828da54c148048dd17899ba9fda624811cfb43";
+    const savedCacheKey = primaryKey;
+
+    jest.spyOn(core, "getState")
+        // Cache Entry State
+        .mockImplementationOnce(() => {
+            return savedCacheKey;
+        })
+        // Cache Key State
+        .mockImplementationOnce(() => {
+            return primaryKey;
+        });
+
+    testUtils.setInput(Inputs.ForceUpdate, "true");
+    testUtils.setInput(Inputs.Path, "node_modules");
+
+    const cacheId = 4;
+    const saveCacheMock = jest
+        .spyOn(cache, "saveCache")
+        .mockImplementationOnce(() => {
+            return Promise.resolve(cacheId);
+        });
+
+    await run();
+
+    expect(saveCacheMock).toHaveBeenCalledTimes(1);
+    expect(failedMock).toHaveBeenCalledTimes(0);
+});
+
 test("save with missing input outputs warning", async () => {
     const logWarningMock = jest.spyOn(actionUtils, "logWarning");
     const failedMock = jest.spyOn(core, "setFailed");

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,4 +1,5 @@
 export enum Inputs {
+    ForceUpdate = "force-update",
     Key = "key",
     Path = "path",
     RestoreKeys = "restore-keys",

--- a/src/save.ts
+++ b/src/save.ts
@@ -27,8 +27,6 @@ async function run(): Promise<void> {
             return;
         }
 
-        const state = utils.getCacheState();
-
         // Inputs are re-evaluted before the post action, so we want the original key used for restore
         const primaryKey = core.getState(State.CachePrimaryKey);
         if (!primaryKey) {
@@ -36,7 +34,9 @@ async function run(): Promise<void> {
             return;
         }
 
-        if (utils.isExactKeyMatch(primaryKey, state)) {
+        const forceUpdate = core.getInput(Inputs.ForceUpdate) === "true";
+        const state = utils.getCacheState();
+        if (utils.isExactKeyMatch(primaryKey, state) && !forceUpdate) {
             core.info(
                 `Cache hit occurred on the primary key ${primaryKey}, not saving cache.`
             );

--- a/src/utils/testUtils.ts
+++ b/src/utils/testUtils.ts
@@ -23,6 +23,7 @@ export function setInputs(input: CacheInput): void {
 }
 
 export function clearInputs(): void {
+    delete process.env[getInputName(Inputs.ForceUpdate)];
     delete process.env[getInputName(Inputs.Path)];
     delete process.env[getInputName(Inputs.Key)];
     delete process.env[getInputName(Inputs.RestoreKeys)];


### PR DESCRIPTION
Sometimes there is a need to update a cache depending on GitHub Actions context even if key is not changed. For example, I would like to update Next.js build cache on main branch to speed up build process in PRs.

I tied to use core.getBooleanInput, but its always returning _undefined_ in the test.