### PR TITLE
Remove final incorrect instances of `%AppData%` / `%LocalAppData%` from Windows cache examples

### DIFF
--- a/examples.md
+++ b/examples.md
@@ -137,10 +137,9 @@ steps:
   with:
     path: |
       ~\.deno
-      %LocalAppData%\deno
+      ~\AppData\Local\deno
     key: ${{ runner.os }}-deno-${{ hashFiles('**/deps.ts') }}
 ```
-
 
 ## Elixir - Mix
 
@@ -260,7 +259,7 @@ We cache the elements of the Cabal store separately, as the entirety of `~/.caba
 
 ## Node - npm
 
-For npm, cache files are stored in `~/.npm` on Posix, or `%AppData%/npm-cache` on Windows. See https://docs.npmjs.com/cli/cache#cache
+For npm, cache files are stored in `~/.npm` on Posix, or `~\AppData\npm-cache` on Windows. See https://docs.npmjs.com/cli/cache#cache
 
 If using `npm config` to retrieve the cache directory, ensure you run [actions/setup-node](https://github.com/actions/setup-node) first to ensure your `npm` version is correct.
 


### PR DESCRIPTION
As noted by @vsvipul and related to #651 - dropping final mentions of `%AppData%` / `%LocalAppData%` from example docs.