### PR TITLE
Updated @actions/cache to v2.0.6

### DIFF
--- a/.licenses/npm/@actions/cache.dep.yml
+++ b/.licenses/npm/@actions/cache.dep.yml
@@ -1,6 +1,6 @@
 ---
 name: "@actions/cache"
-version: 2.0.5
+version: 2.0.6
 type: npm
 summary: 
 homepage: 

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -12,3 +12,6 @@
 
 ### 3.0.3
 - Fixed avoiding empty cache save when no files are available for caching. ([issue](https://github.com/actions/cache/issues/624))
+
+### 3.0.4
+- Fixed tar creation error while trying to create tar with path has `~/` home folder on ubuntu-latest. ([issue](https://github.com/actions/cache/issues/689))

--- a/dist/restore/index.js
+++ b/dist/restore/index.js
@@ -37317,6 +37317,8 @@ function createTar(archiveFolder, sourceDirectories, compressionMethod) {
             ...getCompressionProgram(),
             '-cf',
             cacheFileName.replace(new RegExp(`\\${path.sep}`, 'g'), '/'),
+            '--exclude',
+            cacheFileName.replace(new RegExp(`\\${path.sep}`, 'g'), '/'),
             '-P',
             '-C',
             workingDirectory.replace(new RegExp(`\\${path.sep}`, 'g'), '/'),

--- a/dist/save/index.js
+++ b/dist/save/index.js
@@ -37317,6 +37317,8 @@ function createTar(archiveFolder, sourceDirectories, compressionMethod) {
             ...getCompressionProgram(),
             '-cf',
             cacheFileName.replace(new RegExp(`\\${path.sep}`, 'g'), '/'),
+            '--exclude',
+            cacheFileName.replace(new RegExp(`\\${path.sep}`, 'g'), '/'),
             '-P',
             '-C',
             workingDirectory.replace(new RegExp(`\\${path.sep}`, 'g'), '/'),

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cache",
-  "version": "3.0.3",
+  "version": "3.0.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "cache",
-      "version": "3.0.3",
+      "version": "3.0.4",
       "license": "MIT",
       "dependencies": {
         "@actions/cache": "^2.0.6",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "3.0.3",
       "license": "MIT",
       "dependencies": {
-        "@actions/cache": "^2.0.5",
+        "@actions/cache": "^2.0.6",
         "@actions/core": "^1.7.0",
         "@actions/exec": "^1.1.1",
         "@actions/io": "^1.1.2"
@@ -36,9 +36,9 @@
       }
     },
     "node_modules/@actions/cache": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/@actions/cache/-/cache-2.0.5.tgz",
-      "integrity": "sha512-aG06dsgcVtiuHLJsIfwrDtvzNNJQ+Iqk8DQt1IeI6gG7ezmLaSdZkHEwA/DNrm5TtOahLcgGEo2SXqbFElVMQg==",
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@actions/cache/-/cache-2.0.6.tgz",
+      "integrity": "sha512-Z39ZrWaTRRPaV/AOQdY7hve+Iy/HloH5prpz+k+0lZgGQs/3SeO0UYSIakVuXOk2pdMZnl0Nv0PoK1rmh9YfGQ==",
       "dependencies": {
         "@actions/core": "^1.2.6",
         "@actions/exec": "^1.0.1",
@@ -9533,9 +9533,9 @@
   },
   "dependencies": {
     "@actions/cache": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/@actions/cache/-/cache-2.0.5.tgz",
-      "integrity": "sha512-aG06dsgcVtiuHLJsIfwrDtvzNNJQ+Iqk8DQt1IeI6gG7ezmLaSdZkHEwA/DNrm5TtOahLcgGEo2SXqbFElVMQg==",
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@actions/cache/-/cache-2.0.6.tgz",
+      "integrity": "sha512-Z39ZrWaTRRPaV/AOQdY7hve+Iy/HloH5prpz+k+0lZgGQs/3SeO0UYSIakVuXOk2pdMZnl0Nv0PoK1rmh9YfGQ==",
       "requires": {
         "@actions/core": "^1.2.6",
         "@actions/exec": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cache",
-  "version": "3.0.3",
+  "version": "3.0.4",
   "private": true,
   "description": "Cache dependencies and build outputs",
   "main": "dist/restore/index.js",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "author": "GitHub",
   "license": "MIT",
   "dependencies": {
-    "@actions/cache": "^2.0.5",
+    "@actions/cache": "^2.0.6",
     "@actions/core": "^1.7.0",
     "@actions/exec": "^1.1.1",
     "@actions/io": "^1.1.2"


### PR DESCRIPTION
As part of fix needed for https://github.com/actions/cache/issues/689 , [actions/toolkit](https://github.com/actions/toolkit) was modified recently to exclude the tar file from trying to add itself to the tar resulting into error on `ubuntu-latest` image.

This PR address the fix and has update to the @actions/cache dependency with recently published [v2.0.6](https://www.npmjs.com/package/@actions/cache/v/2.0.6) version of the same.