### PR TITLE
Fixed bad yaml in README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,33 +172,33 @@ jobs:
   build-linux:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+      - uses: actions/checkout@v3
 
-    - name: Cache Primes
-      id: cache-primes
-      uses: actions/cache@v3
-      with:
-        path: prime-numbers
-        key: primes
+      - name: Cache Primes
+        id: cache-primes
+        uses: actions/cache@v3
+        with:
+          path: prime-numbers
+          key: primes
 
-    - name: Generate Prime Numbers
-      if: steps.cache-primes.outputs.cache-hit != 'true'
-      run: ./generate-primes.sh -d prime-numbers
-      
-    - name: Cache Numbers
-      id: cache-numbers
-      uses: actions/cache@v3
-      with:
-        path: numbers
-        key: primes
+      - name: Generate Prime Numbers
+        if: steps.cache-primes.outputs.cache-hit != 'true'
+        run: ./generate-primes.sh -d prime-numbers
 
-    - name: Generate Numbers
-      if: steps.cache-numbers.outputs.cache-hit != 'true'
-      run: ./generate-primes.sh -d numbers
-      
-   build-windows:
-      runs-on: windows-latest
-      steps:
+      - name: Cache Numbers
+        id: cache-numbers
+        uses: actions/cache@v3
+        with:
+          path: numbers
+          key: primes
+
+      - name: Generate Numbers
+        if: steps.cache-numbers.outputs.cache-hit != 'true'
+        run: ./generate-primes.sh -d numbers
+
+  build-windows:
+    runs-on: windows-latest
+    steps:
       - uses: actions/checkout@v3
 
       - name: Cache Primes


### PR DESCRIPTION
Fixed small error in example found on README where yaml is not properly constructed, the `build-windows` section is not at the same indentation leve as the `build-linux` section.