### PR TITLE
Adapt existing Haskell Stack example for Windows

### DIFF
--- a/examples.md
+++ b/examples.md
@@ -223,11 +223,34 @@ We cache the elements of the Cabal store separately, as the entirety of `~/.caba
 
 ## Haskell - Stack
 
+### Linux or macOS
+
 ```yaml
 - uses: actions/cache@v3
   name: Cache ~/.stack
   with:
     path: ~/.stack
+    key: ${{ runner.os }}-stack-global-${{ hashFiles('stack.yaml') }}-${{ hashFiles('package.yaml') }}
+    restore-keys: |
+      ${{ runner.os }}-stack-global-
+- uses: actions/cache@v3
+  name: Cache .stack-work
+  with:
+    path: .stack-work
+    key: ${{ runner.os }}-stack-work-${{ hashFiles('stack.yaml') }}-${{ hashFiles('package.yaml') }}-${{ hashFiles('**/*.hs') }}
+    restore-keys: |
+      ${{ runner.os }}-stack-work-
+```
+
+### Windows
+
+```yaml
+- uses: actions/cache@v3
+  name: Cache %APPDATA%\stack %LOCALAPPDATA%\Programs\stack
+  with:
+    path: |
+      ~\AppData\Roaming\stack
+      ~\AppData\Local\Programs\stack    
     key: ${{ runner.os }}-stack-global-${{ hashFiles('stack.yaml') }}-${{ hashFiles('package.yaml') }}
     restore-keys: |
       ${{ runner.os }}-stack-global-


### PR DESCRIPTION
The default `STACK_ROOT` is `~/.stack` only on Unix-like operating systems. On Windows, the default is `%APPDATA%/stack` (usually `%HOME%\AppData\Roaming\stack`).

On Unix-like OSs, Stack stores GHC and other tools in a `programs` directory in the `STACK_ROOT`. On Windows, Stack stores those tools and MSYS2 in `%LOCALAPPDATA%\Programs\stack` (usually `%HOME%\AppData\Local\Programs\stack`).