### PR TITLE
Add boolean input variables to reevaluate primary cache key & to only restore (skip save post run) 

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -78,6 +78,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macOS-latest]
+        reeval: [false, true]
       fail-fast: false
     runs-on: ${{ matrix.os }}
     steps:
@@ -103,6 +104,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macOS-latest]
+        reeval: [false, true]
       fail-fast: false
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -53,6 +53,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macOS-latest]
+        reeval: [false, true]
       fail-fast: false
     runs-on: ${{ matrix.os }}
     steps:
@@ -67,10 +68,36 @@ jobs:
     - name: Save cache
       uses: ./
       with:
-        key: test-${{ runner.os }}-${{ github.run_id }}
+        reeval: ${{ matrix.reeval }}
+        key: test-${{ runner.os }}-${{ github.run_id }}-${{ matrix.reeval }}
         path: |
           test-cache
           ~/test-cache
+  test-only-restore:
+    needs: test-save
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest, macOS-latest]
+      fail-fast: false
+    runs-on: ${{ matrix.os }}
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+    - name: Restore cache
+      uses: ./
+      with:
+        only-restore: true
+        reeval: ${{ matrix.reeval }}
+        key: test-${{ runner.os }}-${{ github.run_id }}-${{ matrix.reeval }}
+        path: |
+          test-cache
+          ~/test-cache
+    - name: Verify cache files in working directory
+      shell: bash
+      run: __tests__/verify-cache-files.sh ${{ runner.os }} test-cache
+    - name: Verify cache files outside working directory
+      shell: bash
+      run: __tests__/verify-cache-files.sh ${{ runner.os }} ~/test-cache
   test-restore:
     needs: test-save
     strategy:
@@ -84,7 +111,8 @@ jobs:
     - name: Restore cache
       uses: ./
       with:
-        key: test-${{ runner.os }}-${{ github.run_id }}
+        reeval: ${{ matrix.reeval }}
+        key: test-${{ runner.os }}-${{ github.run_id }}-${{ matrix.reeval }}
         path: |
           test-cache
           ~/test-cache
@@ -97,6 +125,9 @@ jobs:
 
   # End to end with proxy
   test-proxy-save:
+    strategy:
+      matrix:
+        reeval: [false, true]
     runs-on: ubuntu-latest
     container:
       image: ubuntu:latest
@@ -116,10 +147,14 @@ jobs:
     - name: Save cache
       uses: ./
       with:
-        key: test-proxy-${{ github.run_id }}
+        reeval: ${{ matrix.reeval }}
+        key: test-proxy-${{ github.run_id }}-${{ matrix.reeval }}
         path: test-cache
-  test-proxy-restore:
+  test-proxy-only-restore:
     needs: test-proxy-save
+    strategy:
+      matrix:
+        reeval: [false, true]
     runs-on: ubuntu-latest
     container:
       image: ubuntu:latest
@@ -137,7 +172,36 @@ jobs:
     - name: Restore cache
       uses: ./
       with:
-        key: test-proxy-${{ github.run_id }}
+        only-restore: true
+        reeval: ${{ matrix.reeval }}
+        key: test-proxy-${{ github.run_id }}-${{ matrix.reeval }}
+        path: test-cache
+    - name: Verify cache
+      run: __tests__/verify-cache-files.sh proxy test-cache
+  test-proxy-restore:
+    needs: test-proxy-save
+    strategy:
+      matrix:
+        reeval: [false, true]
+    runs-on: ubuntu-latest
+    container:
+      image: ubuntu:latest
+      options: --dns 127.0.0.1
+    services:
+      squid-proxy:
+        image: datadog/squid:latest
+        ports:
+          - 3128:3128
+    env:
+      https_proxy: http://squid-proxy:3128
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+    - name: Restore cache
+      uses: ./
+      with:
+        reeval: ${{ matrix.reeval }}
+        key: test-proxy-${{ github.run_id }}-${{ matrix.reeval }}
         path: test-cache
     - name: Verify cache
       run: __tests__/verify-cache-files.sh proxy test-cache

--- a/.gitignore
+++ b/.gitignore
@@ -94,3 +94,6 @@ typings/
 
 # Text editor files
 .vscode/
+
+# OS
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ If you are using this inside a container, a POSIX-compliant `tar` needs to be in
 * `key` - An explicit key for restoring and saving the cache
 * `restore-keys` - An ordered list of keys to use for restoring stale cache if no cache hit occurred for key. Note
 `cache-hit` returns false in this case.
+* `reeval` - A boolean. Whether to reevaluate the `key` argument in the action's post run script when saving cache. Set to `true` if you would like your cache key set after your job's steps are complete.
+* `only-restore` - A boolean. Whether to only perform cache restoration and not the save post run script.
 
 ### Outputs
 

--- a/README.md
+++ b/README.md
@@ -31,8 +31,8 @@ If you are using this inside a container, a POSIX-compliant `tar` needs to be in
 * `key` - An explicit key for restoring and saving the cache
 * `restore-keys` - An ordered list of keys to use for restoring stale cache if no cache hit occurred for key. Note
 `cache-hit` returns false in this case.
-* `reeval` - A boolean. Whether to reevaluate the `key` argument in the action's post run script when saving cache. Set to `true` if you would like your cache key set after your job's steps are complete.
-* `only-restore` - A boolean. Whether to only perform cache restoration and not the save post run script.
+* `reeval` - A boolean. Default set to `false`. Whether to reevaluate the `key` argument in the action's post run script when saving cache. Set to `true` if you would like your cache key set after your job's steps are complete.
+* `only-restore` - A boolean. Default set to `false`. Whether to only perform cache restoration and not the save post run script.
 
 ### Outputs
 

--- a/__tests__/restore.test.ts
+++ b/__tests__/restore.test.ts
@@ -27,11 +27,19 @@ beforeAll(() => {
             return actualUtils.getInputAsArray(name, options);
         }
     );
+
+    jest.spyOn(actionUtils, "getInputAsBoolean").mockImplementation(
+        (name, options) => {
+            const actualUtils = jest.requireActual("../src/utils/actionUtils");
+            return actualUtils.getInputAsBoolean(name, options);
+        }
+    );
 });
 
 beforeEach(() => {
     process.env[Events.Key] = Events.Push;
     process.env[RefKey] = "refs/heads/feature-branch";
+    testUtils.setInput(Inputs.Reeval, "false");
 
     jest.spyOn(actionUtils, "isGhes").mockImplementation(() => false);
     jest.spyOn(actionUtils, "isCacheFeatureAvailable").mockImplementation(

--- a/__tests__/save.test.ts
+++ b/__tests__/save.test.ts
@@ -27,6 +27,13 @@ beforeAll(() => {
         }
     );
 
+    jest.spyOn(actionUtils, "getInputAsBoolean").mockImplementation(
+        (name, options) => {
+            const actualUtils = jest.requireActual("../src/utils/actionUtils");
+            return actualUtils.getInputAsBoolean(name, options);
+        }
+    );
+
     jest.spyOn(actionUtils, "getInputAsInt").mockImplementation(
         (name, options) => {
             return jest
@@ -52,6 +59,7 @@ beforeAll(() => {
 beforeEach(() => {
     process.env[Events.Key] = Events.Push;
     process.env[RefKey] = "refs/heads/feature-branch";
+    testUtils.setInput(Inputs.Reeval, "false");
 
     jest.spyOn(actionUtils, "isGhes").mockImplementation(() => false);
     jest.spyOn(actionUtils, "isCacheFeatureAvailable").mockImplementation(

--- a/action.yml
+++ b/action.yml
@@ -15,11 +15,11 @@ inputs:
     description: 'The chunk size used to split up large files during upload, in bytes'
     required: false
   reeval:
-    description: "Boolean. Whether to reevaluate the key argument in post. Set to TRUE if you would like your cache key set after your job's steps are complete."
+    description: "A boolean. Whether to reevaluate the `key` argument in the action's post run script when saving cache. Set to `true` if you would like your cache key set after your job's steps are complete."
     required: false
     default: false
   only-restore:
-    description: 'Boolean. Whether to only perform cache restoration and NOT the save post run step.'
+    description: 'A boolean. Whether to only perform cache restoration and not the save post run script.'
     required: false
     default: false
 outputs:

--- a/action.yml
+++ b/action.yml
@@ -14,6 +14,14 @@ inputs:
   upload-chunk-size:
     description: 'The chunk size used to split up large files during upload, in bytes'
     required: false
+  reeval:
+    description: "Boolean. Whether to reevaluate the key argument in post. Set to TRUE if you would like your cache key set after your job's steps are complete."
+    required: false
+    default: false
+  only-restore:
+    description: 'Boolean. Whether to only perform cache restoration and NOT the save post run step.'
+    required: false
+    default: false
 outputs:
   cache-hit:
     description: 'A boolean value to indicate an exact match was found for the primary key'

--- a/dist/restore/index.js
+++ b/dist/restore/index.js
@@ -37588,7 +37588,7 @@ var __importStar = (this && this.__importStar) || function (mod) {
     return result;
 };
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.isCacheFeatureAvailable = exports.getInputAsInt = exports.getInputAsArray = exports.isValidEvent = exports.logWarning = exports.getCacheState = exports.setOutputAndState = exports.setCacheHitOutput = exports.setCacheState = exports.isExactKeyMatch = exports.isGhes = void 0;
+exports.isCacheFeatureAvailable = exports.getInputAsInt = exports.getInputAsBoolean = exports.getInputAsArray = exports.isValidEvent = exports.logWarning = exports.getCacheState = exports.setOutputAndState = exports.setCacheHitOutput = exports.setCacheState = exports.isExactKeyMatch = exports.isGhes = void 0;
 const cache = __importStar(__webpack_require__(692));
 const core = __importStar(__webpack_require__(470));
 const constants_1 = __webpack_require__(196);
@@ -37646,6 +37646,11 @@ function getInputAsArray(name, options) {
         .filter(x => x !== "");
 }
 exports.getInputAsArray = getInputAsArray;
+function getInputAsBoolean(name, options) {
+    const value = core.getBooleanInput(name, options);
+    return value;
+}
+exports.getInputAsBoolean = getInputAsBoolean;
 function getInputAsInt(name, options) {
     const value = parseInt(core.getInput(name, options));
     if (isNaN(value) || value < 0) {
@@ -48993,7 +48998,11 @@ function run() {
                 return;
             }
             const primaryKey = core.getInput(constants_1.Inputs.Key, { required: true });
-            core.saveState(constants_1.State.CachePrimaryKey, primaryKey);
+            // when selecting to reevaluate primary key - state is saved in save step
+            const reeval = utils.getInputAsBoolean(constants_1.Inputs.Reeval);
+            if (!reeval) {
+                core.saveState(constants_1.State.CachePrimaryKey, primaryKey);
+            }
             const restoreKeys = utils.getInputAsArray(constants_1.Inputs.RestoreKeys);
             const cachePaths = utils.getInputAsArray(constants_1.Inputs.Path, {
                 required: true

--- a/dist/restore/index.js
+++ b/dist/restore/index.js
@@ -4607,7 +4607,9 @@ exports.RefKey = exports.Events = exports.State = exports.Outputs = exports.Inpu
 var Inputs;
 (function (Inputs) {
     Inputs["Key"] = "key";
+    Inputs["OnlyRestore"] = "only-restore";
     Inputs["Path"] = "path";
+    Inputs["Reeval"] = "reeval";
     Inputs["RestoreKeys"] = "restore-keys";
     Inputs["UploadChunkSize"] = "upload-chunk-size";
 })(Inputs = exports.Inputs || (exports.Inputs = {}));

--- a/dist/save/index.js
+++ b/dist/save/index.js
@@ -4607,7 +4607,9 @@ exports.RefKey = exports.Events = exports.State = exports.Outputs = exports.Inpu
 var Inputs;
 (function (Inputs) {
     Inputs["Key"] = "key";
+    Inputs["OnlyRestore"] = "only-restore";
     Inputs["Path"] = "path";
+    Inputs["Reeval"] = "reeval";
     Inputs["RestoreKeys"] = "restore-keys";
     Inputs["UploadChunkSize"] = "upload-chunk-size";
 })(Inputs = exports.Inputs || (exports.Inputs = {}));
@@ -46770,49 +46772,60 @@ const utils = __importStar(__webpack_require__(443));
 process.on("uncaughtException", e => utils.logWarning(e.message));
 function run() {
     return __awaiter(this, void 0, void 0, function* () {
-        try {
-            if (!utils.isCacheFeatureAvailable()) {
-                return;
-            }
-            if (!utils.isValidEvent()) {
-                utils.logWarning(`Event Validation Error: The event type ${process.env[constants_1.Events.Key]} is not supported because it's not tied to a branch or tag ref.`);
-                return;
-            }
-            const state = utils.getCacheState();
-            // Inputs are re-evaluted before the post action, so we want the original key used for restore
-            const primaryKey = core.getState(constants_1.State.CachePrimaryKey);
-            if (!primaryKey) {
-                utils.logWarning(`Error retrieving key from state.`);
-                return;
-            }
-            if (utils.isExactKeyMatch(primaryKey, state)) {
-                core.info(`Cache hit occurred on the primary key ${primaryKey}, not saving cache.`);
-                return;
-            }
-            const cachePaths = utils.getInputAsArray(constants_1.Inputs.Path, {
-                required: true
-            });
+        const save = !core.getBooleanInput(constants_1.Inputs.OnlyRestore);
+        if (save) {
             try {
-                yield cache.saveCache(cachePaths, primaryKey, {
-                    uploadChunkSize: utils.getInputAsInt(constants_1.Inputs.UploadChunkSize)
-                });
-                core.info(`Cache saved with key: ${primaryKey}`);
-            }
-            catch (error) {
-                const typedError = error;
-                if (typedError.name === cache.ValidationError.name) {
-                    throw error;
+                if (!utils.isCacheFeatureAvailable()) {
+                    return;
                 }
-                else if (typedError.name === cache.ReserveCacheError.name) {
-                    core.info(typedError.message);
+                if (!utils.isValidEvent()) {
+                    utils.logWarning(`Event Validation Error: The event type ${process.env[constants_1.Events.Key]} is not supported because it's not tied to a branch or tag ref.`);
+                    return;
+                }
+                const state = utils.getCacheState();
+                let primaryKey = "";
+                const reeval = core.getBooleanInput(constants_1.Inputs.Reeval);
+                if (!reeval) {
+                    // Inputs are reevaluted before the post action, so we want the original key used for restore
+                    primaryKey = core.getState(constants_1.State.CachePrimaryKey);
                 }
                 else {
-                    utils.logWarning(typedError.message);
+                    // choose to reevaluate primary key
+                    primaryKey = core.getInput(constants_1.Inputs.Key, { required: true });
+                }
+                if (!primaryKey) {
+                    utils.logWarning(`Error retrieving key from state.`);
+                    return;
+                }
+                if (utils.isExactKeyMatch(primaryKey, state)) {
+                    core.info(`Cache hit occurred on the primary key ${primaryKey}, not saving cache.`);
+                    return;
+                }
+                const cachePaths = utils.getInputAsArray(constants_1.Inputs.Path, {
+                    required: true
+                });
+                try {
+                    yield cache.saveCache(cachePaths, primaryKey, {
+                        uploadChunkSize: utils.getInputAsInt(constants_1.Inputs.UploadChunkSize)
+                    });
+                    core.info(`Cache saved with key: ${primaryKey}`);
+                }
+                catch (error) {
+                    const typedError = error;
+                    if (typedError.name === cache.ValidationError.name) {
+                        throw error;
+                    }
+                    else if (typedError.name === cache.ReserveCacheError.name) {
+                        core.info(typedError.message);
+                    }
+                    else {
+                        utils.logWarning(typedError.message);
+                    }
                 }
             }
-        }
-        catch (error) {
-            utils.logWarning(error.message);
+            catch (error) {
+                utils.logWarning(error.message);
+            }
         }
     });
 }

--- a/dist/save/index.js
+++ b/dist/save/index.js
@@ -37588,7 +37588,7 @@ var __importStar = (this && this.__importStar) || function (mod) {
     return result;
 };
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.isCacheFeatureAvailable = exports.getInputAsInt = exports.getInputAsArray = exports.isValidEvent = exports.logWarning = exports.getCacheState = exports.setOutputAndState = exports.setCacheHitOutput = exports.setCacheState = exports.isExactKeyMatch = exports.isGhes = void 0;
+exports.isCacheFeatureAvailable = exports.getInputAsInt = exports.getInputAsBoolean = exports.getInputAsArray = exports.isValidEvent = exports.logWarning = exports.getCacheState = exports.setOutputAndState = exports.setCacheHitOutput = exports.setCacheState = exports.isExactKeyMatch = exports.isGhes = void 0;
 const cache = __importStar(__webpack_require__(692));
 const core = __importStar(__webpack_require__(470));
 const constants_1 = __webpack_require__(196);
@@ -37646,6 +37646,11 @@ function getInputAsArray(name, options) {
         .filter(x => x !== "");
 }
 exports.getInputAsArray = getInputAsArray;
+function getInputAsBoolean(name, options) {
+    const value = core.getBooleanInput(name, options);
+    return value;
+}
+exports.getInputAsBoolean = getInputAsBoolean;
 function getInputAsInt(name, options) {
     const value = parseInt(core.getInput(name, options));
     if (isNaN(value) || value < 0) {
@@ -46782,14 +46787,15 @@ function run() {
                     utils.logWarning(`Event Validation Error: The event type ${process.env[constants_1.Events.Key]} is not supported because it's not tied to a branch or tag ref.`);
                     return;
                 }
+                const state = utils.getCacheState();
                 let primaryKey = "";
-                const reeval = core.getBooleanInput(constants_1.Inputs.Reeval);
+                const reeval = utils.getInputAsBoolean(constants_1.Inputs.Reeval);
                 if (!reeval) {
                     // Inputs are reevaluted before the post action, so we want the original key used for restore
                     primaryKey = core.getState(constants_1.State.CachePrimaryKey);
                 }
                 else {
-                    // choose to reevaluate primary key - resave state to correctly test cache hit
+                    // choose to reevaluate primary key - resave state to correctly test cache hit on next run
                     primaryKey = core.getInput(constants_1.Inputs.Key, { required: true });
                     core.saveState(constants_1.State.CachePrimaryKey, primaryKey);
                 }
@@ -46797,7 +46803,6 @@ function run() {
                     utils.logWarning(`Error retrieving key from state.`);
                     return;
                 }
-                const state = utils.getCacheState();
                 if (utils.isExactKeyMatch(primaryKey, state)) {
                     core.info(`Cache hit occurred on the primary key ${primaryKey}, not saving cache.`);
                     return;

--- a/dist/save/index.js
+++ b/dist/save/index.js
@@ -46782,7 +46782,6 @@ function run() {
                     utils.logWarning(`Event Validation Error: The event type ${process.env[constants_1.Events.Key]} is not supported because it's not tied to a branch or tag ref.`);
                     return;
                 }
-                const state = utils.getCacheState();
                 let primaryKey = "";
                 const reeval = core.getBooleanInput(constants_1.Inputs.Reeval);
                 if (!reeval) {
@@ -46790,13 +46789,15 @@ function run() {
                     primaryKey = core.getState(constants_1.State.CachePrimaryKey);
                 }
                 else {
-                    // choose to reevaluate primary key
+                    // choose to reevaluate primary key - resave state to correctly test cache hit
                     primaryKey = core.getInput(constants_1.Inputs.Key, { required: true });
+                    core.saveState(constants_1.State.CachePrimaryKey, primaryKey);
                 }
                 if (!primaryKey) {
                     utils.logWarning(`Error retrieving key from state.`);
                     return;
                 }
+                const state = utils.getCacheState();
                 if (utils.isExactKeyMatch(primaryKey, state)) {
                     core.info(`Cache hit occurred on the primary key ${primaryKey}, not saving cache.`);
                     return;

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,6 +1,8 @@
 export enum Inputs {
     Key = "key",
+    OnlyRestore = "only-restore",
     Path = "path",
+    Reeval = "reeval",
     RestoreKeys = "restore-keys",
     UploadChunkSize = "upload-chunk-size"
 }

--- a/src/restore.ts
+++ b/src/restore.ts
@@ -22,7 +22,12 @@ async function run(): Promise<void> {
         }
 
         const primaryKey = core.getInput(Inputs.Key, { required: true });
-        core.saveState(State.CachePrimaryKey, primaryKey);
+
+        // when selecting to reevaluate primary key - state is saved in save step
+        const reeval = utils.getInputAsBoolean(Inputs.Reeval);
+        if (!reeval) {
+            core.saveState(State.CachePrimaryKey, primaryKey);
+        }
 
         const restoreKeys = utils.getInputAsArray(Inputs.RestoreKeys);
         const cachePaths = utils.getInputAsArray(Inputs.Path, {

--- a/src/save.ts
+++ b/src/save.ts
@@ -26,13 +26,15 @@ async function run(): Promise<void> {
                 return;
             }
 
+            const state = utils.getCacheState();
+
             let primaryKey = "";
-            const reeval = core.getBooleanInput(Inputs.Reeval);
+            const reeval = utils.getInputAsBoolean(Inputs.Reeval);
             if (!reeval) {
                 // Inputs are reevaluted before the post action, so we want the original key used for restore
                 primaryKey = core.getState(State.CachePrimaryKey);
             } else {
-                // choose to reevaluate primary key - resave state to correctly test cache hit
+                // choose to reevaluate primary key - resave state to correctly test cache hit on next run
                 primaryKey = core.getInput(Inputs.Key, { required: true });
                 core.saveState(State.CachePrimaryKey, primaryKey);
             }
@@ -40,8 +42,6 @@ async function run(): Promise<void> {
                 utils.logWarning(`Error retrieving key from state.`);
                 return;
             }
-
-            const state = utils.getCacheState();
 
             if (utils.isExactKeyMatch(primaryKey, state)) {
                 core.info(

--- a/src/save.ts
+++ b/src/save.ts
@@ -26,21 +26,22 @@ async function run(): Promise<void> {
                 return;
             }
 
-            const state = utils.getCacheState();
-
             let primaryKey = "";
             const reeval = core.getBooleanInput(Inputs.Reeval);
             if (!reeval) {
                 // Inputs are reevaluted before the post action, so we want the original key used for restore
                 primaryKey = core.getState(State.CachePrimaryKey);
             } else {
-                // choose to reevaluate primary key
+                // choose to reevaluate primary key - resave state to correctly test cache hit
                 primaryKey = core.getInput(Inputs.Key, { required: true });
+                core.saveState(State.CachePrimaryKey, primaryKey);
             }
             if (!primaryKey) {
                 utils.logWarning(`Error retrieving key from state.`);
                 return;
             }
+
+            const state = utils.getCacheState();
 
             if (utils.isExactKeyMatch(primaryKey, state)) {
                 core.info(

--- a/src/save.ts
+++ b/src/save.ts
@@ -10,57 +10,67 @@ import * as utils from "./utils/actionUtils";
 process.on("uncaughtException", e => utils.logWarning(e.message));
 
 async function run(): Promise<void> {
-    try {
-        if (!utils.isCacheFeatureAvailable()) {
-            return;
-        }
-
-        if (!utils.isValidEvent()) {
-            utils.logWarning(
-                `Event Validation Error: The event type ${
-                    process.env[Events.Key]
-                } is not supported because it's not tied to a branch or tag ref.`
-            );
-            return;
-        }
-
-        const state = utils.getCacheState();
-
-        // Inputs are re-evaluted before the post action, so we want the original key used for restore
-        const primaryKey = core.getState(State.CachePrimaryKey);
-        if (!primaryKey) {
-            utils.logWarning(`Error retrieving key from state.`);
-            return;
-        }
-
-        if (utils.isExactKeyMatch(primaryKey, state)) {
-            core.info(
-                `Cache hit occurred on the primary key ${primaryKey}, not saving cache.`
-            );
-            return;
-        }
-
-        const cachePaths = utils.getInputAsArray(Inputs.Path, {
-            required: true
-        });
-
+    const save = !core.getBooleanInput(Inputs.OnlyRestore);
+    if (save) {
         try {
-            await cache.saveCache(cachePaths, primaryKey, {
-                uploadChunkSize: utils.getInputAsInt(Inputs.UploadChunkSize)
-            });
-            core.info(`Cache saved with key: ${primaryKey}`);
-        } catch (error: unknown) {
-            const typedError = error as Error;
-            if (typedError.name === cache.ValidationError.name) {
-                throw error;
-            } else if (typedError.name === cache.ReserveCacheError.name) {
-                core.info(typedError.message);
-            } else {
-                utils.logWarning(typedError.message);
+            if (!utils.isCacheFeatureAvailable()) {
+                return;
             }
+
+            if (!utils.isValidEvent()) {
+                utils.logWarning(
+                    `Event Validation Error: The event type ${
+                        process.env[Events.Key]
+                    } is not supported because it's not tied to a branch or tag ref.`
+                );
+                return;
+            }
+
+            const state = utils.getCacheState();
+
+            let primaryKey = "";
+            const reeval = core.getBooleanInput(Inputs.Reeval);
+            if (!reeval) {
+                // Inputs are reevaluted before the post action, so we want the original key used for restore
+                primaryKey = core.getState(State.CachePrimaryKey);
+            } else {
+                // choose to reevaluate primary key
+                primaryKey = core.getInput(Inputs.Key, { required: true });
+            }
+            if (!primaryKey) {
+                utils.logWarning(`Error retrieving key from state.`);
+                return;
+            }
+
+            if (utils.isExactKeyMatch(primaryKey, state)) {
+                core.info(
+                    `Cache hit occurred on the primary key ${primaryKey}, not saving cache.`
+                );
+                return;
+            }
+
+            const cachePaths = utils.getInputAsArray(Inputs.Path, {
+                required: true
+            });
+
+            try {
+                await cache.saveCache(cachePaths, primaryKey, {
+                    uploadChunkSize: utils.getInputAsInt(Inputs.UploadChunkSize)
+                });
+                core.info(`Cache saved with key: ${primaryKey}`);
+            } catch (error: unknown) {
+                const typedError = error as Error;
+                if (typedError.name === cache.ValidationError.name) {
+                    throw error;
+                } else if (typedError.name === cache.ReserveCacheError.name) {
+                    core.info(typedError.message);
+                } else {
+                    utils.logWarning(typedError.message);
+                }
+            }
+        } catch (error: unknown) {
+            utils.logWarning((error as Error).message);
         }
-    } catch (error: unknown) {
-        utils.logWarning((error as Error).message);
     }
 }
 

--- a/src/utils/actionUtils.ts
+++ b/src/utils/actionUtils.ts
@@ -65,6 +65,14 @@ export function getInputAsArray(
         .filter(x => x !== "");
 }
 
+export function getInputAsBoolean(
+    name: string,
+    options?: core.InputOptions
+): boolean {
+    const value = core.getBooleanInput(name, options);
+    return value;    
+}
+
 export function getInputAsInt(
     name: string,
     options?: core.InputOptions

--- a/src/utils/actionUtils.ts
+++ b/src/utils/actionUtils.ts
@@ -70,7 +70,7 @@ export function getInputAsBoolean(
     options?: core.InputOptions
 ): boolean {
     const value = core.getBooleanInput(name, options);
-    return value;    
+    return value;
 }
 
 export function getInputAsInt(

--- a/src/utils/testUtils.ts
+++ b/src/utils/testUtils.ts
@@ -12,12 +12,16 @@ export function setInput(name: string, value: string): void {
 interface CacheInput {
     path: string;
     key: string;
+    // onlyRestore: string;
+    // reeval: string;
     restoreKeys?: string[];
 }
 
 export function setInputs(input: CacheInput): void {
     setInput(Inputs.Path, input.path);
     setInput(Inputs.Key, input.key);
+    // setInput(Inputs.OnlyRestore, input.onlyRestore);
+    // setInput(Inputs.Reeval, input.reeval);
     input.restoreKeys &&
         setInput(Inputs.RestoreKeys, input.restoreKeys.join("\n"));
 }
@@ -27,4 +31,6 @@ export function clearInputs(): void {
     delete process.env[getInputName(Inputs.Key)];
     delete process.env[getInputName(Inputs.RestoreKeys)];
     delete process.env[getInputName(Inputs.UploadChunkSize)];
+    delete process.env[getInputName(Inputs.OnlyRestore)];
+    delete process.env[getInputName(Inputs.Reeval)];
 }


### PR DESCRIPTION
I got a little ambitious with this one. Understand it may never get merged. This tackles a few PRs / issues & topics of conversation all in one:

On the topic of skipping the post run save script, aka only restoring:
- #489 
  - Instead of an environment variable, I add the input variable `only-restore`. Default is set to `false`.

On the topic of reevaluating the primary cache key:
- #673
- #784
  - For this, I add the input variable `reeval`. Default is set to `false`. 

Being that I added **new** input variables, I had to do quite a bit to get all checks to pass. The goal was adding reevaluation of the primary key during the post run save script as a capability, which was accomplished. In a nut shell, for reevaluation, you need logic to handle when the primary key gets saved to the cache's state. This PR handles doing that.

The jest tests were edited bare minimally to pass. New jest tests were not added for say, testing setting boolean inputs of `only-restore` and `reeval` to either `true` or `false`. However, test utilities were added to be able to read these input boolean variables. Also, `Inputs.Reeval` was set to `false` throughout both save and restore jest tests to evaluate save & restore scripts appropriately with the default `reeval` action input value. 

The 'Tests' workflow was however changed to begin to handle setting the boolean variables to either. 

The new field of `reeval` was added to the job matrix of the `test-save` & `test-restore` jobs. In addition, matrices were added to the `test-proxy-save` & `test-proxy-restore` jobs to handle this input as well. To differentiate primary keys between matrix runs, a `-${{ matrix.reeval }}` partial was appended to these keys. 

In addition, to handle the `only-restore` case, new jobs of `test-only-restore` & `test-proxy-only-restore` were created, each setting `reeval` to `true`, and their setting of the primary key follows the convention described above. 

I created a tag on the main branch of my own repo with these features as well. I've also tested it in quite a few other repos where it's used within composite actions. 
- [prncevince/actions-cache@v1.0.0](https://github.com/prncevince/actions-cache/tree/v1.0.0)

Examples using the [prncevince/r-actions/setup-knitr-cache](https://github.com/prncevince/r-actions/blob/main/setup-knitr-cache/action.yaml) composite action: 
- `reeval` set to `true`:
  - [prncevince/r-actions/.github/workflows/knitr-cache.yaml](https://github.com/prncevince/r-actions/blob/c23c797f61e99828067bbfc5caadadff2688fc5f/.github/workflows/knitr-cache.yaml#L39)
  - [prncevince/test-workflow-knitr-cache/.github/workflows/knitr-cache.yaml](https://github.com/prncevince/test-workflow-knitr-cache/blob/1c98aea57f245cd2c83908989bed32457686f8af/.github/workflows/knitr-cache.yaml#L40)
- `only-restore` set to `true`:
  - [prncevince/r-actions/.github/workflows/restore-cache.yaml](https://github.com/prncevince/r-actions/blob/c23c797f61e99828067bbfc5caadadff2688fc5f/.github/workflows/restore-cache.yaml)

I also added to the [README.md](https://github.com/actions/cache/tree/e5e58a06aad59db0cf971fca74c5eabeaf3181c1#inputs) & to [examples.md](https://github.com/actions/cache/blob/e5e58a06aad59db0cf971fca74c5eabeaf3181c1/examples.md#r-markdown---knitr-cache). To the readme I added descriptions of the [input variables](https://github.com/actions/cache/tree/e5e58a06aad59db0cf971fca74c5eabeaf3181c1#inputs) with their defaults. To the examples I added an example for [using knitr caching](https://github.com/actions/cache/blob/e5e58a06aad59db0cf971fca74c5eabeaf3181c1/examples.md#r-markdown---knitr-cache) when rendering R Markdown, as well as detailed explanation of why you would want to use it, with links to examples mentioned above.

A lot of this implementation could be better. I think that the creation of the primary keys during the Tests workflow could be based on an actual file hashing. This could be checked into the repository - say the [\_\_test\_\_/\_\_fixtures\_\_/helloWorld.txt](https://github.com/actions/cache/blob/c3f1317a9e7b1ef106c153ac8c0f00fed3ddbc0d/__tests__/__fixtures__/helloWorld.txt)). Then, edits to the file could be reflected in the primary key and indeed be tested upon reevaluation. 

I'm sure better messaging could be implemented with only restoring (forgoing the post run save script). Not sure that I'm going to pursue this much. Full implementation works right now on my own tag. But if what's requested by reviewers is simple enough for me to have a go to get it merged, I may be interested.

Cheers
