### PR TITLE
feat: 🎸 add example for clojure lein project deps

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ Every programming language and framework has its own way of caching.
 See [Examples](examples.md) for a list of `actions/cache` implementations for use with:
 
 - [C# - NuGet](./examples.md#c---nuget)
+- [Clojure - Lein Deps](./examples.md#clojure---lein-deps)
 - [D - DUB](./examples.md#d---dub)
 - [Deno](./examples.md#deno)
 - [Elixir - Mix](./examples.md#elixir---mix)

--- a/examples.md
+++ b/examples.md
@@ -1,6 +1,7 @@
 # Examples
 
 - [C# - NuGet](#c---nuget)
+- [Clojure - Lein Deps](#clojure---lein-deps)
 - [D - DUB](#d---dub)
   - [POSIX](#posix)
   - [Windows](#windows)
@@ -79,6 +80,19 @@ steps:
       restore-keys: |
         ${{ runner.os }}-nuget-
 ```
+
+## Clojure - Lein Deps
+
+```yaml
+- name: Cache lein project dependencies
+  uses: actions/cache@v3
+  with:
+    path: ~/.m2/repository
+    key: ${{ runner.os }}-clojure-${{ hashFiles('**/project.clj') }}
+    restore-keys: |
+      ${{ runner.os }}-clojure
+```
+
 
 ## D - DUB
 


### PR DESCRIPTION
In Clojure, **Lein too**l is used to generate templates for various projects. **Lein project** metadata (including **project dependencies**) are stored in `project.clj` (in root directory) file. **Lein** downloads use **Maven** and download all dependencies in classpath (`~/.m2/repository`). 
Here I am caching `~/.m2/repository` path for reusing the cache in subsequent builds.