### PR TITLE
fix: fix cache-hit value when cache not found

### DIFF
--- a/__tests__/restore.test.ts
+++ b/__tests__/restore.test.ts
@@ -205,6 +205,7 @@ test("restore with no cache found", async () => {
         key
     });
 
+    const setCacheHitOutputMock = jest.spyOn(actionUtils, "setCacheHitOutput");
     const infoMock = jest.spyOn(core, "info");
     const failedMock = jest.spyOn(core, "setFailed");
     const stateMock = jest.spyOn(core, "saveState");
@@ -215,6 +216,9 @@ test("restore with no cache found", async () => {
         });
 
     await run();
+
+    expect(setCacheHitOutputMock).toHaveBeenCalledTimes(1);
+    expect(setCacheHitOutputMock).toHaveBeenCalledWith(false);
 
     expect(restoreCacheMock).toHaveBeenCalledTimes(1);
     expect(restoreCacheMock).toHaveBeenCalledWith([path], key, []);
@@ -237,6 +241,7 @@ test("restore with restore keys and no cache found", async () => {
         restoreKeys: [restoreKey]
     });
 
+    const setCacheHitOutputMock = jest.spyOn(actionUtils, "setCacheHitOutput");
     const infoMock = jest.spyOn(core, "info");
     const failedMock = jest.spyOn(core, "setFailed");
     const stateMock = jest.spyOn(core, "saveState");
@@ -247,6 +252,9 @@ test("restore with restore keys and no cache found", async () => {
         });
 
     await run();
+
+    expect(setCacheHitOutputMock).toHaveBeenCalledTimes(1);
+    expect(setCacheHitOutputMock).toHaveBeenCalledWith(false);
 
     expect(restoreCacheMock).toHaveBeenCalledTimes(1);
     expect(restoreCacheMock).toHaveBeenCalledWith([path], key, [restoreKey]);

--- a/src/restore.ts
+++ b/src/restore.ts
@@ -43,6 +43,7 @@ async function run(): Promise<void> {
                 ].join(", ")}`
             );
 
+            utils.setCacheHitOutput(false);
             return;
         }
 


### PR DESCRIPTION
related to https://github.com/github/docs/pull/18524

set `cache-hit` to `false` when there is no cache matched