### PR TITLE
Update toolkit's cache npm module to latest. Bump cache version to v3.0.6

### DIFF
--- a/.licenses/npm/@actions/cache.dep.yml
+++ b/.licenses/npm/@actions/cache.dep.yml
@@ -1,6 +1,6 @@
 ---
 name: "@actions/cache"
-version: 3.0.0
+version: 3.0.1
 type: npm
 summary: 
 homepage: 

--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ See ["Caching dependencies to speed up workflows"](https://help.github.com/githu
 * Updated the minimum runner version support from node 12 -> node 16.
 * Fixed avoiding empty cache save when no files are available for caching.
 * Fixed tar creation error while trying to create tar with path as `~/` home folder on `ubuntu-latest`.
+* Fixed zstd failing on amazon linux 2.0 runners
+* Fixed cache not working with github workspace directory or current directory
 
 Refer [here](https://github.com/actions/cache/blob/v2/README.md) for previous versions
 

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -18,3 +18,7 @@
 
 ### 3.0.5
 - Removed error handling by consuming actions/cache 3.0 toolkit, Now cache server error handling will be done by toolkit. ([PR](https://github.com/actions/cache/pull/834))
+
+### 3.0.6
+- Fixed [#809](https://github.com/actions/cache/issues/809) - zstd -d: no such file or directory error
+- Fixed [#833](https://github.com/actions/cache/issues/833) - cache doesn't work with github workspace directory

--- a/dist/restore/index.js
+++ b/dist/restore/index.js
@@ -1113,7 +1113,13 @@ function resolvePaths(patterns) {
                     .replace(new RegExp(`\\${path.sep}`, 'g'), '/');
                 core.debug(`Matched: ${relativeFile}`);
                 // Paths are made relative so the tar entries are all relative to the root of the workspace.
-                paths.push(`${relativeFile}`);
+                if (relativeFile === '') {
+                    // path.relative returns empty string if workspace and file are equal
+                    paths.push('.');
+                }
+                else {
+                    paths.push(`${relativeFile}`);
+                }
             }
         }
         catch (e_1_1) { e_1 = { error: e_1_1 }; }
@@ -37272,9 +37278,9 @@ function extractTar(archivePath, compressionMethod) {
         function getCompressionProgram() {
             switch (compressionMethod) {
                 case constants_1.CompressionMethod.Zstd:
-                    return ['--use-compress-program', 'zstd -d --long=30'];
+                    return ['--use-compress-program', 'unzstd --long=30'];
                 case constants_1.CompressionMethod.ZstdWithoutLong:
-                    return ['--use-compress-program', 'zstd -d'];
+                    return ['--use-compress-program', 'unzstd'];
                 default:
                     return ['-z'];
             }
@@ -37305,9 +37311,9 @@ function createTar(archiveFolder, sourceDirectories, compressionMethod) {
         function getCompressionProgram() {
             switch (compressionMethod) {
                 case constants_1.CompressionMethod.Zstd:
-                    return ['--use-compress-program', 'zstd -T0 --long=30'];
+                    return ['--use-compress-program', 'zstdmt --long=30'];
                 case constants_1.CompressionMethod.ZstdWithoutLong:
-                    return ['--use-compress-program', 'zstd -T0'];
+                    return ['--use-compress-program', 'zstdmt'];
                 default:
                     return ['-z'];
             }
@@ -37338,9 +37344,9 @@ function listTar(archivePath, compressionMethod) {
         function getCompressionProgram() {
             switch (compressionMethod) {
                 case constants_1.CompressionMethod.Zstd:
-                    return ['--use-compress-program', 'zstd -d --long=30'];
+                    return ['--use-compress-program', 'unzstd --long=30'];
                 case constants_1.CompressionMethod.ZstdWithoutLong:
-                    return ['--use-compress-program', 'zstd -d'];
+                    return ['--use-compress-program', 'unzstd'];
                 default:
                     return ['-z'];
             }

--- a/dist/save/index.js
+++ b/dist/save/index.js
@@ -1113,7 +1113,13 @@ function resolvePaths(patterns) {
                     .replace(new RegExp(`\\${path.sep}`, 'g'), '/');
                 core.debug(`Matched: ${relativeFile}`);
                 // Paths are made relative so the tar entries are all relative to the root of the workspace.
-                paths.push(`${relativeFile}`);
+                if (relativeFile === '') {
+                    // path.relative returns empty string if workspace and file are equal
+                    paths.push('.');
+                }
+                else {
+                    paths.push(`${relativeFile}`);
+                }
             }
         }
         catch (e_1_1) { e_1 = { error: e_1_1 }; }
@@ -37272,9 +37278,9 @@ function extractTar(archivePath, compressionMethod) {
         function getCompressionProgram() {
             switch (compressionMethod) {
                 case constants_1.CompressionMethod.Zstd:
-                    return ['--use-compress-program', 'zstd -d --long=30'];
+                    return ['--use-compress-program', 'unzstd --long=30'];
                 case constants_1.CompressionMethod.ZstdWithoutLong:
-                    return ['--use-compress-program', 'zstd -d'];
+                    return ['--use-compress-program', 'unzstd'];
                 default:
                     return ['-z'];
             }
@@ -37305,9 +37311,9 @@ function createTar(archiveFolder, sourceDirectories, compressionMethod) {
         function getCompressionProgram() {
             switch (compressionMethod) {
                 case constants_1.CompressionMethod.Zstd:
-                    return ['--use-compress-program', 'zstd -T0 --long=30'];
+                    return ['--use-compress-program', 'zstdmt --long=30'];
                 case constants_1.CompressionMethod.ZstdWithoutLong:
-                    return ['--use-compress-program', 'zstd -T0'];
+                    return ['--use-compress-program', 'zstdmt'];
                 default:
                     return ['-z'];
             }
@@ -37338,9 +37344,9 @@ function listTar(archivePath, compressionMethod) {
         function getCompressionProgram() {
             switch (compressionMethod) {
                 case constants_1.CompressionMethod.Zstd:
-                    return ['--use-compress-program', 'zstd -d --long=30'];
+                    return ['--use-compress-program', 'unzstd --long=30'];
                 case constants_1.CompressionMethod.ZstdWithoutLong:
-                    return ['--use-compress-program', 'zstd -d'];
+                    return ['--use-compress-program', 'unzstd'];
                 default:
                     return ['-z'];
             }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "cache",
-  "version": "3.0.5",
+  "version": "3.0.6",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "cache",
-      "version": "3.0.5",
+      "version": "3.0.6",
       "license": "MIT",
       "dependencies": {
-        "@actions/cache": "^3.0.0",
+        "@actions/cache": "^3.0.1",
         "@actions/core": "^1.7.0",
         "@actions/exec": "^1.1.1",
         "@actions/io": "^1.1.2"
@@ -36,9 +36,9 @@
       }
     },
     "node_modules/@actions/cache": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@actions/cache/-/cache-3.0.0.tgz",
-      "integrity": "sha512-GL9CT1Fnu+pqs8TTB621q8Xa8Cilw2n9MwvbgMedetH7L1q2n6jY61gzbwGbKgtVbp3gVJ12aNMi4osSGXx3KQ==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@actions/cache/-/cache-3.0.1.tgz",
+      "integrity": "sha512-z4cbwCuzyZHQ3Y3AyQEFb+WQneC1wcOWfjrKxhulGkbXBLiMH/Uga2hknNEgOY16XaDZ7hArYaY3nUxE7IzqLQ==",
       "dependencies": {
         "@actions/core": "^1.2.6",
         "@actions/exec": "^1.0.1",
@@ -9533,9 +9533,9 @@
   },
   "dependencies": {
     "@actions/cache": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@actions/cache/-/cache-3.0.0.tgz",
-      "integrity": "sha512-GL9CT1Fnu+pqs8TTB621q8Xa8Cilw2n9MwvbgMedetH7L1q2n6jY61gzbwGbKgtVbp3gVJ12aNMi4osSGXx3KQ==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@actions/cache/-/cache-3.0.1.tgz",
+      "integrity": "sha512-z4cbwCuzyZHQ3Y3AyQEFb+WQneC1wcOWfjrKxhulGkbXBLiMH/Uga2hknNEgOY16XaDZ7hArYaY3nUxE7IzqLQ==",
       "requires": {
         "@actions/core": "^1.2.6",
         "@actions/exec": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cache",
-  "version": "3.0.5",
+  "version": "3.0.6",
   "private": true,
   "description": "Cache dependencies and build outputs",
   "main": "dist/restore/index.js",
@@ -23,7 +23,7 @@
   "author": "GitHub",
   "license": "MIT",
   "dependencies": {
-    "@actions/cache": "^3.0.0",
+    "@actions/cache": "^3.0.1",
     "@actions/core": "^1.7.0",
     "@actions/exec": "^1.1.1",
     "@actions/io": "^1.1.2"


### PR DESCRIPTION
This PR includes the latest version `v3.0.1` of toolkit's first party npm module [`@actions/cache`](https://github.com/actions/toolkit/tree/main/packages/cache). 

Please refer https://github.com/actions/toolkit/pull/1144 for more information.

TLDR; This PR merges fixes for issues #809 and #833 and bumps cache action version to `v3.0.6`




 