### PR TITLE
Add option to skip uploading of cache

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -14,6 +14,10 @@ inputs:
   upload-chunk-size:
     description: 'The chunk size used to split up large files during upload, in bytes'
     required: false
+  skip-upload:
+    description: 'Set this to true to skip uploading the cache at the end even if we got a miss'
+    required: false
+    default: 'false'
 outputs:
   cache-hit:
     description: 'A boolean value to indicate an exact match was found for the primary key'

--- a/dist/restore/index.js
+++ b/dist/restore/index.js
@@ -4616,6 +4616,7 @@ var Inputs;
     Inputs["Path"] = "path";
     Inputs["RestoreKeys"] = "restore-keys";
     Inputs["UploadChunkSize"] = "upload-chunk-size";
+    Inputs["SkipUpload"] = "skip-upload";
 })(Inputs = exports.Inputs || (exports.Inputs = {}));
 var Outputs;
 (function (Outputs) {

--- a/dist/save/index.js
+++ b/dist/save/index.js
@@ -4616,6 +4616,7 @@ var Inputs;
     Inputs["Path"] = "path";
     Inputs["RestoreKeys"] = "restore-keys";
     Inputs["UploadChunkSize"] = "upload-chunk-size";
+    Inputs["SkipUpload"] = "skip-upload";
 })(Inputs = exports.Inputs || (exports.Inputs = {}));
 var Outputs;
 (function (Outputs) {
@@ -46794,6 +46795,9 @@ function run() {
             if (utils.isExactKeyMatch(primaryKey, state)) {
                 core.info(`Cache hit occurred on the primary key ${primaryKey}, not saving cache.`);
                 return;
+            }
+            if (core.getBooleanInput(constants_1.Inputs.SkipUpload)) {
+                core.info(`Skipping upload of cache since the skip-upload input was set.`);
             }
             const cachePaths = utils.getInputAsArray(constants_1.Inputs.Path, {
                 required: true

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -2,7 +2,8 @@ export enum Inputs {
     Key = "key",
     Path = "path",
     RestoreKeys = "restore-keys",
-    UploadChunkSize = "upload-chunk-size"
+    UploadChunkSize = "upload-chunk-size",
+    SkipUpload = "skip-upload"
 }
 
 export enum Outputs {

--- a/src/save.ts
+++ b/src/save.ts
@@ -40,6 +40,12 @@ async function run(): Promise<void> {
             return;
         }
 
+        if (core.getBooleanInput(Inputs.SkipUpload)) {
+            core.info(
+                `Skipping upload of cache since the skip-upload input was set.`
+            );
+        }
+
         const cachePaths = utils.getInputAsArray(Inputs.Path, {
             required: true
         });


### PR DESCRIPTION
Hello Actions team! We're currently encountering an issue where we'd like a nightly job to prepare a build cache for PR runs to use by building a big build target so that it gets populated with as much as possible and then individual PR checks can use what they need. So, our cache key would be today's date. However, the problem is that if a PR check completes before the nightly job, it will win the race to upload a cache, and we'll end up with an under-populated cache for the rest of the day. Thus, we'd like to disable cache uploading except on the nightly job, which is currently not supported by this Action. This PR adds a simple extra boolean input so that we can do that.