### PR TITLE
Fix for the download stuck problem

### DIFF
--- a/.licenses/npm/@actions/cache.dep.yml
+++ b/.licenses/npm/@actions/cache.dep.yml
@@ -1,6 +1,6 @@
 ---
 name: "@actions/cache"
-version: 3.0.2
+version: 3.0.3
 type: npm
 summary: 
 homepage: 

--- a/.licenses/npm/@actions/cache.dep.yml
+++ b/.licenses/npm/@actions/cache.dep.yml
@@ -1,6 +1,6 @@
 ---
 name: "@actions/cache"
-version: 3.0.1
+version: 3.0.2
 type: npm
 summary: 
 homepage: 

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ See ["Caching dependencies to speed up workflows"](https://help.github.com/githu
 * Fixed tar creation error while trying to create tar with path as `~/` home folder on `ubuntu-latest`.
 * Fixed zstd failing on amazon linux 2.0 runners
 * Fixed cache not working with github workspace directory or current directory
+* Fixed the download stuck problem by introducing a timeout of 1 hour for cache downloads.
 
 Refer [here](https://github.com/actions/cache/blob/v2/README.md) for previous versions
 

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -22,3 +22,6 @@
 ### 3.0.6
 - Fixed [#809](https://github.com/actions/cache/issues/809) - zstd -d: no such file or directory error
 - Fixed [#833](https://github.com/actions/cache/issues/833) - cache doesn't work with github workspace directory
+
+### 3.0.7
+- Fixed [#810](https://github.com/actions/cache/issues/810) - download stuck issue. A new timeout is introduced in the download process to abort the download if it gets stuck and doesn't finish within an hour.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "cache",
-  "version": "3.0.6",
+  "version": "3.0.7",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "cache",
-      "version": "3.0.6",
+      "version": "3.0.7",
       "license": "MIT",
       "dependencies": {
-        "@actions/cache": "^3.0.1",
+        "@actions/cache": "^3.0.2",
         "@actions/core": "^1.7.0",
         "@actions/exec": "^1.1.1",
         "@actions/io": "^1.1.2"
@@ -36,9 +36,9 @@
       }
     },
     "node_modules/@actions/cache": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@actions/cache/-/cache-3.0.1.tgz",
-      "integrity": "sha512-z4cbwCuzyZHQ3Y3AyQEFb+WQneC1wcOWfjrKxhulGkbXBLiMH/Uga2hknNEgOY16XaDZ7hArYaY3nUxE7IzqLQ==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@actions/cache/-/cache-3.0.2.tgz",
+      "integrity": "sha512-XGhWOYgMr3ZHxZ07uFis7dHM1/3xgwASPEm4i5Tb6ag6NbvLY86bb3Nik/EKWV2w1jUTdKEpim5EBalo+glzZQ==",
       "dependencies": {
         "@actions/core": "^1.2.6",
         "@actions/exec": "^1.0.1",
@@ -9533,9 +9533,9 @@
   },
   "dependencies": {
     "@actions/cache": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@actions/cache/-/cache-3.0.1.tgz",
-      "integrity": "sha512-z4cbwCuzyZHQ3Y3AyQEFb+WQneC1wcOWfjrKxhulGkbXBLiMH/Uga2hknNEgOY16XaDZ7hArYaY3nUxE7IzqLQ==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@actions/cache/-/cache-3.0.2.tgz",
+      "integrity": "sha512-XGhWOYgMr3ZHxZ07uFis7dHM1/3xgwASPEm4i5Tb6ag6NbvLY86bb3Nik/EKWV2w1jUTdKEpim5EBalo+glzZQ==",
       "requires": {
         "@actions/core": "^1.2.6",
         "@actions/exec": "^1.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "3.0.7",
       "license": "MIT",
       "dependencies": {
-        "@actions/cache": "^3.0.2",
+        "@actions/cache": "^3.0.3",
         "@actions/core": "^1.7.0",
         "@actions/exec": "^1.1.1",
         "@actions/io": "^1.1.2"
@@ -36,9 +36,9 @@
       }
     },
     "node_modules/@actions/cache": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@actions/cache/-/cache-3.0.2.tgz",
-      "integrity": "sha512-XGhWOYgMr3ZHxZ07uFis7dHM1/3xgwASPEm4i5Tb6ag6NbvLY86bb3Nik/EKWV2w1jUTdKEpim5EBalo+glzZQ==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@actions/cache/-/cache-3.0.3.tgz",
+      "integrity": "sha512-kn0pZRQNFRg1IQnW/N7uTNbbLqYalvQW2bmrznn3C34LMY/rSuEmH6Uo69HDh335Q0vKs9kg/jsIarzUBKzEXg==",
       "dependencies": {
         "@actions/core": "^1.2.6",
         "@actions/exec": "^1.0.1",
@@ -9533,9 +9533,9 @@
   },
   "dependencies": {
     "@actions/cache": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@actions/cache/-/cache-3.0.2.tgz",
-      "integrity": "sha512-XGhWOYgMr3ZHxZ07uFis7dHM1/3xgwASPEm4i5Tb6ag6NbvLY86bb3Nik/EKWV2w1jUTdKEpim5EBalo+glzZQ==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@actions/cache/-/cache-3.0.3.tgz",
+      "integrity": "sha512-kn0pZRQNFRg1IQnW/N7uTNbbLqYalvQW2bmrznn3C34LMY/rSuEmH6Uo69HDh335Q0vKs9kg/jsIarzUBKzEXg==",
       "requires": {
         "@actions/core": "^1.2.6",
         "@actions/exec": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "author": "GitHub",
   "license": "MIT",
   "dependencies": {
-    "@actions/cache": "^3.0.2",
+    "@actions/cache": "^3.0.3",
     "@actions/core": "^1.7.0",
     "@actions/exec": "^1.1.1",
     "@actions/io": "^1.1.2"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cache",
-  "version": "3.0.6",
+  "version": "3.0.7",
   "private": true,
   "description": "Cache dependencies and build outputs",
   "main": "dist/restore/index.js",
@@ -23,7 +23,7 @@
   "author": "GitHub",
   "license": "MIT",
   "dependencies": {
-    "@actions/cache": "^3.0.1",
+    "@actions/cache": "^3.0.2",
     "@actions/core": "^1.7.0",
     "@actions/exec": "^1.1.1",
     "@actions/io": "^1.1.2"


### PR DESCRIPTION
This PR introduces a timeout in the download process so that the runner doesn't keep running for 6 hours in case the download is stuck.

We are fixing #810 with this pull request.

An `abortcontroller` is added to the download request such that it aborts the download, if not completed within an hour.