### PR TITLE
Fix Swift Package Manager example

### DIFF
--- a/examples.md
+++ b/examples.md
@@ -623,6 +623,4 @@ whenever possible:
   with:
     path: .build
     key: ${{ runner.os }}-spm-${{ hashFiles('**/Package.resolved') }}
-    restore-keys: |
-      ${{ runner.os }}-spm-
 ```


### PR DESCRIPTION
Previous example is somewhat misleading.

When new package is added, old cache is being restored, which may lead to package resolve errors as described [here](https://forums.swift.org/t/error-during-package-resolution-on-ci-machine-whenever-updating-package-dependencies/56472).

Considering [this guide](https://github.com/apple/swift-package-manager/blob/630bdeaf296efcf0bbfddeb82c4ee754a90cc3a0/Documentation/ContinousIntegration.md?plain=1#L9-L14):

> To ensure the *CI* workflow’s reliability, make sure it uses the appropriate version of package dependencies.
SwiftPM records the result of dependency resolution in `Package.resolved` (at the top-level of the package) and it's used when performing dependency resolution (rather than having SwiftPM searching the latest eligible version of each package).  Running `swift package update` updates all dependencies to the latest eligible versions and updates the `Package.resolved`.  You can commit `Package.resolved` to your *Git* repository to ensure it’s always up-to-date on the *CI* environment to prevent the *CI* from building your project with unexpected versions of package dependencies.  Otherwise you can choose to add `Package.resolved` file to `.gitignore` file and have `swift package resolve` command in charge of resolving the dependencies (`swift package resolve` is invoked by most SwiftPM commands).

We mustn't use restore-keys for spm cache.

