### PR TITLE
Remove .md files skip condition from test workflow

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -5,14 +5,10 @@ on:
     branches:
       - main
       - releases/**
-    paths-ignore:
-      - '**.md'
   push:
     branches:
       - main
       - releases/**
-    paths-ignore:
-      - '**.md'
 
 jobs:
   # Build and unit test


### PR DESCRIPTION
Remove .md files skip condition from test workflow

This is required as we have made the test workflow checks required. So, they'll need to executed for all PRs. Also for PRs that include .md file changes.