### PR TITLE
docs: fix an invalid link in workarounds.md

### DIFF
--- a/tips-and-workarounds.md
+++ b/tips-and-workarounds.md
@@ -14,7 +14,7 @@ A cache today is immutable and cannot be updated. But some use cases require the
           restore-keys: |
             primes-${{ runner.os }}
   ```          
-  Please note that this will create a new cache on every run and hence will consume the cache [quota](#cache-limits).
+  Please note that this will create a new cache on every run and hence will consume the cache [quota](./README.md#cache-limits).
   
 ## Use cache across feature branches
 Reusing cache across feature branches is not allowed today to provide cache [isolation](https://docs.github.com/en/actions/using-workflows/caching-dependencies-to-speed-up-workflows#restrictions-for-accessing-a-cache). However if both feature branches are from the default branch, a good way to achieve this is to ensure that the default branch has a cache. This cache will then be consumable by both feature branches.


### PR DESCRIPTION
This PR fixes a link in workarounds.md to match [this change](https://github.com/actions/cache/commit/471fb0c87e5d7210f339d8ea2e01505ddafd793d).