### PR TITLE
docs: Indicate that `restore-keys` uses prefix in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ If you are using this inside a container, a POSIX-compliant `tar` needs to be in
 * `path` - A list of files, directories, and wildcard patterns to cache and restore. See [`@actions/glob`](https://github.com/actions/toolkit/tree/main/packages/glob) for supported patterns.
 * `key` - An explicit key for restoring and saving the cache
 * `restore-keys` - An ordered list of keys to use for restoring stale cache if no cache hit occurred for key. Note
-`cache-hit` returns false in this case.
+`cache-hit` returns false in this case. When a key doesn't match directly, the action searches for keys prefixed with the restore key.
 
 #### Environment Variables
 * `SEGMENT_DOWNLOAD_TIMEOUT_MIN` - Segment download timeout (in minutes, default `60`) to abort download of the segment if not completed in the defined number of minutes. [Read more](#cache-segment-restore-timeout)


### PR DESCRIPTION
I think we should state here that `restore-keys` supports prefixes as it is mentioned [here](https://docs.github.com/en/actions/using-workflows/caching-dependencies-to-speed-up-workflows#matching-a-cache-key).