### PR TITLE
Remove sort logic from inputs

### DIFF
--- a/__tests__/actionUtils.test.ts
+++ b/__tests__/actionUtils.test.ts
@@ -215,23 +215,6 @@ test("getInputAsArray handles empty lines correctly", () => {
     expect(actionUtils.getInputAsArray("foo")).toEqual(["bar", "baz"]);
 });
 
-test("getInputAsArray sorts files correctly", () => {
-    testUtils.setInput(
-        "foo",
-        "bar\n!baz\nwaldo\nqux\nquux\ncorge\ngrault\ngarply"
-    );
-    expect(actionUtils.getInputAsArray("foo")).toEqual([
-        "!baz",
-        "bar",
-        "corge",
-        "garply",
-        "grault",
-        "quux",
-        "qux",
-        "waldo"
-    ]);
-});
-
 test("getInputAsArray removes spaces after ! at the beginning", () => {
     testUtils.setInput(
         "foo",
@@ -240,11 +223,11 @@ test("getInputAsArray removes spaces after ! at the beginning", () => {
     expect(actionUtils.getInputAsArray("foo")).toEqual([
         "!bar",
         "!baz",
-        "!quux",
         "!qux",
-        "!waldo",
+        "!quux",
         "corge",
-        "grault! garply"
+        "grault! garply",
+        "!waldo"
     ]);
 });
 

--- a/__tests__/restore.test.ts
+++ b/__tests__/restore.test.ts
@@ -147,7 +147,7 @@ test("restore with no key", async () => {
 test("restore with too many keys should fail", async () => {
     const path = "node_modules";
     const key = "node-test";
-    const restoreKeys = [...Array(20).keys()].map(x => x.toString()).sort();
+    const restoreKeys = [...Array(20).keys()].map(x => x.toString());
     testUtils.setInputs({
         path: path,
         key,

--- a/dist/restore/index.js
+++ b/dist/restore/index.js
@@ -38437,8 +38437,7 @@ function getInputAsArray(name, options) {
         .getInput(name, options)
         .split("\n")
         .map(s => s.replace(/^!\s+/, "!").trim())
-        .filter(x => x !== "")
-        .sort();
+        .filter(x => x !== "");
 }
 exports.getInputAsArray = getInputAsArray;
 function getInputAsInt(name, options) {

--- a/dist/save/index.js
+++ b/dist/save/index.js
@@ -38437,8 +38437,7 @@ function getInputAsArray(name, options) {
         .getInput(name, options)
         .split("\n")
         .map(s => s.replace(/^!\s+/, "!").trim())
-        .filter(x => x !== "")
-        .sort();
+        .filter(x => x !== "");
 }
 exports.getInputAsArray = getInputAsArray;
 function getInputAsInt(name, options) {

--- a/src/utils/actionUtils.ts
+++ b/src/utils/actionUtils.ts
@@ -62,8 +62,7 @@ export function getInputAsArray(
         .getInput(name, options)
         .split("\n")
         .map(s => s.replace(/^!\s+/, "!").trim())
-        .filter(x => x !== "")
-        .sort();
+        .filter(x => x !== "");
 }
 
 export function getInputAsInt(


### PR DESCRIPTION
Fixes https://github.com/actions/cache/issues/941.

This bug was introduced with this commit https://github.com/actions/cache/pull/903/files and also sorts restore-keys which we don't want. Initial intention was to sort paths only.

This PR removes sorting completely. We can discuss later if we want to sort paths separately in save.ts / restore.ts .

After merging this, we'll need to release a new cache version immediately to fix this bug.