### PR TITLE
Update cache to use @actions/core@^1.10.0

### DIFF
--- a/.licenses/npm/@actions/cache.dep.yml
+++ b/.licenses/npm/@actions/cache.dep.yml
@@ -1,6 +1,6 @@
 ---
 name: "@actions/cache"
-version: 3.0.4
+version: 3.0.5
 type: npm
 summary:
 homepage:

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -36,3 +36,7 @@
 ### 3.0.10
 - Fix a bug with sorting inputs.
 - Update definition for restore-keys in README.md
+
+### 3.0.11
+- Update toolkit version to 3.0.5 to include `@actions/core@^1.10.0`
+- Update `@actions/cache` to use updated `saveState` and `setOutput` functions from `@actions/core@^1.10.0`

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "cache",
-  "version": "3.0.10",
+  "version": "3.0.11",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,10 +6,10 @@
   "packages": {
     "": {
       "name": "cache",
-      "version": "3.0.10",
+      "version": "3.0.11",
       "license": "MIT",
       "dependencies": {
-        "@actions/cache": "^3.0.4",
+        "@actions/cache": "^3.0.5",
         "@actions/core": "^1.10.0",
         "@actions/exec": "^1.1.1",
         "@actions/io": "^1.1.2"
@@ -36,11 +36,11 @@
       }
     },
     "node_modules/@actions/cache": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/@actions/cache/-/cache-3.0.4.tgz",
-      "integrity": "sha512-9RwVL8/ISJoYWFNH1wR/C26E+M3HDkGPWmbFJMMCKwTkjbNZJreMT4XaR/EB1bheIvN4PREQxEQQVJ18IPnf/Q==",
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@actions/cache/-/cache-3.0.5.tgz",
+      "integrity": "sha512-0WpPmwnRPkn5k5ASmjoX8bY8NrZEPTwN+64nGYJmR/bHjEVgC8svdf5K956wi67tNJBGJky2+UfvNbUOtHmMHg==",
       "dependencies": {
-        "@actions/core": "^1.2.6",
+        "@actions/core": "^1.10.0",
         "@actions/exec": "^1.0.1",
         "@actions/glob": "^0.1.0",
         "@actions/http-client": "^2.0.1",
@@ -9534,11 +9534,11 @@
   },
   "dependencies": {
     "@actions/cache": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/@actions/cache/-/cache-3.0.4.tgz",
-      "integrity": "sha512-9RwVL8/ISJoYWFNH1wR/C26E+M3HDkGPWmbFJMMCKwTkjbNZJreMT4XaR/EB1bheIvN4PREQxEQQVJ18IPnf/Q==",
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@actions/cache/-/cache-3.0.5.tgz",
+      "integrity": "sha512-0WpPmwnRPkn5k5ASmjoX8bY8NrZEPTwN+64nGYJmR/bHjEVgC8svdf5K956wi67tNJBGJky2+UfvNbUOtHmMHg==",
       "requires": {
-        "@actions/core": "^1.2.6",
+        "@actions/core": "^1.10.0",
         "@actions/exec": "^1.0.1",
         "@actions/glob": "^0.1.0",
         "@actions/http-client": "^2.0.1",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "author": "GitHub",
   "license": "MIT",
   "dependencies": {
-    "@actions/cache": "^3.0.4",
+    "@actions/cache": "^3.0.5",
     "@actions/core": "^1.10.0",
     "@actions/exec": "^1.1.1",
     "@actions/io": "^1.1.2"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cache",
-  "version": "3.0.10",
+  "version": "3.0.11",
   "private": true,
   "description": "Cache dependencies and build outputs",
   "main": "dist/restore/index.js",


### PR DESCRIPTION
This PR aims to update the `@actions/core` version to `1.10.0` due to actions deprecating save state and set output commands. Please refer [here](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/).

The code changes pertaining to this change were already merged in the previous [PR](https://github.com/actions/cache/pull/950). Thank you @rentziass🔥

Fixes #953 and several other issues due to the depreciation messages.