### PR TITLE
Updated release doc with correct env variable

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -28,7 +28,7 @@
 
 ### 3.0.8
 - Fix zstd not working for windows on gnu tar in issues [#888](https://github.com/actions/cache/issues/888) and [#891](https://github.com/actions/cache/issues/891).
-- Allowing users to provide a custom timeout as input for aborting download of a cache segment using an environment variable `SEGMENT_DOWNLOAD_TIMEOUT_MIN`. Default is 60 minutes.
+- Allowing users to provide a custom timeout as input for aborting download of a cache segment using an environment variable `SEGMENT_DOWNLOAD_TIMEOUT_MINS`. Default is 60 minutes.
 
 ### 3.0.9
 - Enhanced the warning message for cache unavailablity in case of GHES.


### PR DESCRIPTION
Fixed environment variable in release docs, changed `SEGMENT_DOWNLOAD_TIMEOUT_MIN` to `SEGMENT_DOWNLOAD_TIMEOUT_MINS` the correct value.