### PR TITLE
Update README with clearer info about cache-hit and its value

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ If you are using this inside a container, a POSIX-compliant `tar` needs to be in
 
 * `cache-hit` - A boolean value to indicate an exact match was found for the key. 
 
-> Note: `cache-hit` will be set to `true` only when cache hit occurs for the exact `key` match. For a partial key match via `restore-keys` or a cache miss, it will be set to `false`. It is recommended to install the missing/updated dependencies in case of a partial key match when the key is dependent on the `hash` of the package file.
+> Note: `cache-hit` will be set to `true` only when cache hit occurs for the exact `key` match. For a partial key match via `restore-keys` or a cache miss, it will be set to `false`.
 
 See [Skipping steps based on cache-hit](#skipping-steps-based-on-cache-hit) for info on using this output
 
@@ -153,7 +153,7 @@ A repository can have up to 10GB of caches. Once the 10GB limit is reached, olde
 
 ## Skipping steps based on cache-hit
 
-Using the `cache-hit` output, subsequent steps (such as install or build) can be skipped when a cache hit occurs on the key.
+Using the `cache-hit` output, subsequent steps (such as install or build) can be skipped when a cache hit occurs on the key.  It is recommended to install the missing/updated dependencies in case of a partial key match when the key is dependent on the `hash` of the package file.
 
 Example:
 ```yaml

--- a/README.md
+++ b/README.md
@@ -34,17 +34,18 @@ If you are using this inside a container, a POSIX-compliant `tar` needs to be in
 
 * `path` - A list of files, directories, and wildcard patterns to cache and restore. See [`@actions/glob`](https://github.com/actions/toolkit/tree/main/packages/glob) for supported patterns.
 * `key` - An explicit key for restoring and saving the cache
-* `restore-keys` - An ordered list of prefix-matched keys to use for restoring stale cache if no cache hit occurred for key. Note
-`cache-hit` returns false in this case.
+* `restore-keys` - An ordered list of prefix-matched keys to use for restoring stale cache if no cache hit occurred for key.
 
 #### Environment Variables
 * `SEGMENT_DOWNLOAD_TIMEOUT_MINS` - Segment download timeout (in minutes, default `60`) to abort download of the segment if not completed in the defined number of minutes. [Read more](#cache-segment-restore-timeout)
 
 ### Outputs
 
-* `cache-hit` - A boolean value to indicate an exact match was found for the key
+* `cache-hit` - A boolean value to indicate an exact match was found for the key. 
 
-> See [Skipping steps based on cache-hit](#Skipping-steps-based-on-cache-hit) for info on using this output
+> Note: `cache-hit` will be set to `true` only when cache hit occurs for the exact `key` match. For a partial key match via `restore-keys` or a cache miss, it will be set to `false`. It is recommended to install the missing/updated dependencies in case of a partial key match when the key is dependent on the `hash` of the package file.
+
+See [Skipping steps based on cache-hit](#skipping-steps-based-on-cache-hit) for info on using this output
 
 ### Cache scopes
 The cache is scoped to the key and branch. The default branch cache is available to other branches.


### PR DESCRIPTION
This PR is being raised to clarify the output `cache-hit` on partial and full match of the key found in `key`, `restore-keys` of the workflow. This is being done as we have [PRs](https://github.com/actions/cache/pull/895) being raised to remove restore keys. 

Updated rendered [file](https://github.com/actions/cache/blob/14f2d18ea2a8de1085ccf3aedfeb86ef1f4b7bdd/README.md)