### PR TITLE
Configurable save cache via environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ If you are using this inside a container, a POSIX-compliant `tar` needs to be in
 #### Environment Variables
 * `SEGMENT_DOWNLOAD_TIMEOUT_MINS` - Segment download timeout (in minutes, default `60`) to abort download of the segment if not completed in the defined number of minutes. [Read more](#cache-segment-restore-timeout)
 
+* `GHA_CACHE_SAVE` - Controls when to save cache. By default, a new cache is created if the job completes successfully. If this variable is set to `always`, the cache is saved also on job failure. If set to `never`, the cache is never saved, i.e. realizing read-only cache.
+
 ### Outputs
 
 * `cache-hit` - A boolean value to indicate an exact match was found for the key
@@ -80,7 +82,8 @@ jobs:
       run: /primes.sh -d prime-numbers
 ```
 
-> Note: You must use the `cache` action in your workflow before you need to use the files that might be restored from the cache. If the provided `key` matches an existing cache, a new cache is not created and if the provided `key` doesn't match an existing cache, a new cache is automatically created provided the job completes successfully.
+> Note: You must use the `cache` action in your workflow _before_ you need to use the files that might be restored from the cache. If the provided `key` matches an existing cache exactly, a new cache is not created. Include `${{github.run_id}}` as the last component of your `key` to save the cache in each workflow run.
+If the provided `key` doesn't match an existing cache exactly, a new cache is automatically created provided the job completes successfully. This behavior can be changed with the environment variable `GHA_CACHE_SAVE` ([see above](#environment-variables)).
 
 ## Implementation Examples
 

--- a/action.yml
+++ b/action.yml
@@ -21,7 +21,9 @@ runs:
   using: 'node16'
   main: 'dist/restore/index.js'
   post: 'dist/save/index.js'
-  post-if: 'success()'
+  post-if: |
+    ((env.GHA_CACHE_SAVE == 'always') && (success() || failure())) ||
+    ((env.GHA_CACHE_SAVE != 'never') && success())
 branding:
   icon: 'archive'
   color: 'gray-dark'


### PR DESCRIPTION
Following the suggestion in https://github.com/actions/cache/issues/92#issuecomment-754108243, this implements conditional execution of the post-step to save the cache.
If the environment variable `GHA_CACHE_SAVE` is set to `always`, the `post-if` condition will evaluate to true.
If it is set to `never`, the condition will evaluate to false, thus not saving the cache.

Fixes #350
Fixes #334
Fixes #92

In contrast to #474, which used input variables and an implementation of the condition evaluation in source code, this PR implements the behavior using an appropriate `post-if` condition, thus nicely visualizing the execution status in the log UI.
Actually, an implementation using input variables would be more appealing, but input variables are currently silently ignored in `post-if` condition expressions.
Compared to #489, this PR not only allows skipping the post-step but also enforcing it.

simple test results can be found here:
- [default + success()](https://github.com/rhaschke/test/actions/runs/3303219650)
- [default + failure()](https://github.com/rhaschke/test/actions/runs/3303224615)
- [always](https://github.com/rhaschke/test/actions/runs/3303231700)
- [never](https://github.com/rhaschke/test/actions/runs/3303160629)

Unfortunately, I'm not proficient in JavaScript or TypeScript. Thus I cannot provide unit tests.