### PR TITLE
Replace deprecated set-output workflow command

### DIFF
--- a/examples.md
+++ b/examples.md
@@ -316,7 +316,7 @@ If using `npm config` to retrieve the cache directory, ensure you run [actions/s
 - name: Get npm cache directory
   id: npm-cache-dir
   run: |
-    echo "::set-output name=dir::$(npm config get cache)"
+    echo "dir=$(npm config get cache)" >> $GITHUB_OUTPUT
 - uses: actions/cache@v3
   id: npm-cache # use this to check for `cache-hit` ==> if: steps.npm-cache.outputs.cache-hit != 'true'
   with:
@@ -342,7 +342,7 @@ The yarn cache directory will depend on your operating system and version of `ya
 ```yaml
 - name: Get yarn cache directory path
   id: yarn-cache-dir-path
-  run: echo "::set-output name=dir::$(yarn cache dir)"
+  run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
 
 - uses: actions/cache@v3
   id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
@@ -360,7 +360,7 @@ The yarn 2 cache directory will depend on your config. See https://yarnpkg.com/c
 ```yaml
 - name: Get yarn cache directory path
   id: yarn-cache-dir-path
-  run: echo "::set-output name=dir::$(yarn config get cacheFolder)"
+  run: echo "dir=$(yarn config get cacheFolder)" >> $GITHUB_OUTPUT
 
 - uses: actions/cache@v3
   id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
@@ -405,7 +405,7 @@ Esy allows you to export built dependencies and import pre-built dependencies.
 - name: Get Composer Cache Directory
   id: composer-cache
   run: |
-    echo "::set-output name=dir::$(composer config cache-files-dir)"
+    echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
 - uses: actions/cache@v3
   with:
     path: ${{ steps.composer-cache.outputs.dir }}
@@ -497,7 +497,7 @@ jobs:
 - name: Get pip cache dir
   id: pip-cache
   run: |
-    echo "::set-output name=dir::$(pip cache dir)"
+    echo "dir=$(pip cache dir)" >> $GITHUB_OUTPUT
 
 - name: pip cache
   uses: actions/cache@v3


### PR DESCRIPTION
Make use of `GITHUB_OUTPUT` instead.


## Description

Workflow command `set-output` is deprecated.
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

## Motivation and Context

To avoid deprecation warning when using workflow command `set-output`.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x ] Documentation (add or update README or docs)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
