### PR TITLE
Replace deprecated command with environment file in example

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -27,8 +27,8 @@ jobs:
         node-version: 16.x
     - name: Determine npm cache directory
       id: npm-cache
-      run: |
-        echo "::set-output name=dir::$(npm config get cache)"
+      run: echo "dir=$(npm config get cache)" >> $GITHUB_OUTPUT
+     
     - name: Restore npm cache
       uses: actions/cache@v3
       with:

--- a/README.md
+++ b/README.md
@@ -135,8 +135,8 @@ Additionally, you can use arbitrary command output in a cache key, such as a dat
   # http://man7.org/linux/man-pages/man1/date.1.html
   - name: Get Date
     id: get-date
-    run: |
-      echo "::set-output name=date::$(/bin/date -u "+%Y%m%d")"
+    run: echo "date=$(/bin/date -u "+%Y%m%d")" >> $GITHUB_OUTPUT
+
     shell: bash
 
   - uses: actions/cache@v3

--- a/examples.md
+++ b/examples.md
@@ -264,7 +264,7 @@ We cache the elements of the Cabal store separately, as the entirety of `~/.caba
   with:
     path: |
       ~\AppData\Roaming\stack
-      ~\AppData\Local\Programs\stack    
+      ~\AppData\Local\Programs\stack
     key: ${{ runner.os }}-stack-global-${{ hashFiles('stack.yaml') }}-${{ hashFiles('package.yaml') }}
     restore-keys: |
       ${{ runner.os }}-stack-global-
@@ -315,8 +315,8 @@ If using `npm config` to retrieve the cache directory, ensure you run [actions/s
 ```yaml
 - name: Get npm cache directory
   id: npm-cache-dir
-  run: |
-    echo "::set-output name=dir::$(npm config get cache)"
+  run: echo "dir=$(npm config get cache)" >> $GITHUB_OUTPUT
+
 - uses: actions/cache@v3
   id: npm-cache # use this to check for `cache-hit` ==> if: steps.npm-cache.outputs.cache-hit != 'true'
   with:
@@ -342,7 +342,7 @@ The yarn cache directory will depend on your operating system and version of `ya
 ```yaml
 - name: Get yarn cache directory path
   id: yarn-cache-dir-path
-  run: echo "::set-output name=dir::$(yarn cache dir)"
+  run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
 
 - uses: actions/cache@v3
   id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
@@ -360,7 +360,7 @@ The yarn 2 cache directory will depend on your config. See https://yarnpkg.com/c
 ```yaml
 - name: Get yarn cache directory path
   id: yarn-cache-dir-path
-  run: echo "::set-output name=dir::$(yarn config get cacheFolder)"
+  run: echo "dir=$(yarn config get cacheFolder)" >> $GITHUB_OUTPUT
 
 - uses: actions/cache@v3
   id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
@@ -404,8 +404,8 @@ Esy allows you to export built dependencies and import pre-built dependencies.
 ```yaml
 - name: Get Composer Cache Directory
   id: composer-cache
-  run: |
-    echo "::set-output name=dir::$(composer config cache-files-dir)"
+  run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
+
 - uses: actions/cache@v3
   with:
     path: ${{ steps.composer-cache.outputs.dir }}
@@ -496,8 +496,7 @@ jobs:
 ```yaml
 - name: Get pip cache dir
   id: pip-cache
-  run: |
-    echo "::set-output name=dir::$(pip cache dir)"
+  run: echo "dir=$(pip cache dir)" >> $GITHUB_OUTPUT
 
 - name: pip cache
   uses: actions/cache@v3


### PR DESCRIPTION

## Description
Update the example to use environment file instead of deprecated `set-output` command

## Motivation and Context
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation (add or update README or docs)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
