### PR TITLE
add support for read-only cache

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -14,6 +14,9 @@ inputs:
   upload-chunk-size:
     description: 'The chunk size used to split up large files during upload, in bytes'
     required: false
+  read-only:
+    description: 'If true, the action will only check for a cache hit and will not save a new cache'
+    required: false
 outputs:
   cache-hit:
     description: 'A boolean value to indicate an exact match was found for the primary key'

--- a/dist/restore/index.js
+++ b/dist/restore/index.js
@@ -4947,6 +4947,7 @@ var Inputs;
     Inputs["Path"] = "path";
     Inputs["RestoreKeys"] = "restore-keys";
     Inputs["UploadChunkSize"] = "upload-chunk-size";
+    Inputs["ReadOnly"] = "read-only";
 })(Inputs = exports.Inputs || (exports.Inputs = {}));
 var Outputs;
 (function (Outputs) {
@@ -38398,7 +38399,7 @@ var __importStar = (this && this.__importStar) || function (mod) {
     return result;
 };
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.isCacheFeatureAvailable = exports.getInputAsInt = exports.getInputAsArray = exports.isValidEvent = exports.logWarning = exports.getCacheState = exports.setOutputAndState = exports.setCacheHitOutput = exports.setCacheState = exports.isExactKeyMatch = exports.isGhes = void 0;
+exports.isCacheFeatureAvailable = exports.getInputAsBoolean = exports.getInputAsInt = exports.getInputAsArray = exports.isValidEvent = exports.logWarning = exports.getCacheState = exports.setOutputAndState = exports.setCacheHitOutput = exports.setCacheState = exports.isExactKeyMatch = exports.isGhes = void 0;
 const cache = __importStar(__webpack_require__(692));
 const core = __importStar(__webpack_require__(470));
 const constants_1 = __webpack_require__(196);
@@ -38464,6 +38465,10 @@ function getInputAsInt(name, options) {
     return value;
 }
 exports.getInputAsInt = getInputAsInt;
+function getInputAsBoolean(name, options) {
+    return core.getInput(name, options) === "true";
+}
+exports.getInputAsBoolean = getInputAsBoolean;
 function isCacheFeatureAvailable() {
     if (!cache.isFeatureAvailable()) {
         if (isGhes()) {

--- a/dist/save/index.js
+++ b/dist/save/index.js
@@ -4947,6 +4947,7 @@ var Inputs;
     Inputs["Path"] = "path";
     Inputs["RestoreKeys"] = "restore-keys";
     Inputs["UploadChunkSize"] = "upload-chunk-size";
+    Inputs["ReadOnly"] = "read-only";
 })(Inputs = exports.Inputs || (exports.Inputs = {}));
 var Outputs;
 (function (Outputs) {
@@ -38398,7 +38399,7 @@ var __importStar = (this && this.__importStar) || function (mod) {
     return result;
 };
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.isCacheFeatureAvailable = exports.getInputAsInt = exports.getInputAsArray = exports.isValidEvent = exports.logWarning = exports.getCacheState = exports.setOutputAndState = exports.setCacheHitOutput = exports.setCacheState = exports.isExactKeyMatch = exports.isGhes = void 0;
+exports.isCacheFeatureAvailable = exports.getInputAsBoolean = exports.getInputAsInt = exports.getInputAsArray = exports.isValidEvent = exports.logWarning = exports.getCacheState = exports.setOutputAndState = exports.setCacheHitOutput = exports.setCacheState = exports.isExactKeyMatch = exports.isGhes = void 0;
 const cache = __importStar(__webpack_require__(692));
 const core = __importStar(__webpack_require__(470));
 const constants_1 = __webpack_require__(196);
@@ -38464,6 +38465,10 @@ function getInputAsInt(name, options) {
     return value;
 }
 exports.getInputAsInt = getInputAsInt;
+function getInputAsBoolean(name, options) {
+    return core.getInput(name, options) === "true";
+}
+exports.getInputAsBoolean = getInputAsBoolean;
 function isCacheFeatureAvailable() {
     if (!cache.isFeatureAvailable()) {
         if (isGhes()) {
@@ -47297,6 +47302,10 @@ function run() {
                 return;
             }
             const state = utils.getCacheState();
+            if (utils.getInputAsBoolean(constants_1.Inputs.ReadOnly)) {
+                core.info(`Cache is read-only, skipping save.`);
+                return;
+            }
             // Inputs are re-evaluted before the post action, so we want the original key used for restore
             const primaryKey = core.getState(constants_1.State.CachePrimaryKey);
             if (!primaryKey) {

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -2,7 +2,8 @@ export enum Inputs {
     Key = "key",
     Path = "path",
     RestoreKeys = "restore-keys",
-    UploadChunkSize = "upload-chunk-size"
+    UploadChunkSize = "upload-chunk-size",
+    ReadOnly = "read-only"
 }
 
 export enum Outputs {

--- a/src/save.ts
+++ b/src/save.ts
@@ -44,6 +44,11 @@ async function run(): Promise<void> {
             required: true
         });
 
+        if (utils.getInputAsBoolean(Inputs.ReadOnly)) {
+          core.info(`Cache is read-only, skipping save.`);
+          return;
+        }
+
         const cacheId = await cache.saveCache(cachePaths, primaryKey, {
             uploadChunkSize: utils.getInputAsInt(Inputs.UploadChunkSize)
         });

--- a/src/utils/actionUtils.ts
+++ b/src/utils/actionUtils.ts
@@ -76,6 +76,14 @@ export function getInputAsInt(
     return value;
 }
 
+export function getInputAsBoolean(
+  name: string,
+  options?: core.InputOptions
+) : boolean {
+  console.log("ReadOnly was: " + core.getInput(name, options));
+  return !!core.getInput(name, options);
+}
+
 export function isCacheFeatureAvailable(): boolean {
     if (!cache.isFeatureAvailable()) {
         if (isGhes()) {

--- a/src/utils/testUtils.ts
+++ b/src/utils/testUtils.ts
@@ -13,6 +13,7 @@ interface CacheInput {
     path: string;
     key: string;
     restoreKeys?: string[];
+    readOnly?: boolean;
 }
 
 export function setInputs(input: CacheInput): void {
@@ -20,6 +21,7 @@ export function setInputs(input: CacheInput): void {
     setInput(Inputs.Key, input.key);
     input.restoreKeys &&
         setInput(Inputs.RestoreKeys, input.restoreKeys.join("\n"));
+    input.readOnly && setInput(Inputs.ReadOnly, "true");
 }
 
 export function clearInputs(): void {


### PR DESCRIPTION
## Description
Add support for not saving the cache.  

Fixes https://github.com/actions/cache/issues/350
Fixes https://github.com/actions/cache/issues/334
Fixes https://github.com/actions/cache/issues/92 

Similar to both https://github.com/actions/cache/pull/489 and https://github.com/actions/cache/pull/964, but here it's implemented as an input to the workflow instead of an environment variable.  

## Motivation and Context
I needed the behavior for this PR: https://github.com/github/codeql/pull/11362. 

In `github/codeql` we have some code that gets faster by using a cache.  
But that code can take [some shortcuts](https://codeql.github.com/docs/codeql-cli/manual/query-compile/#cmdoption-codeql-query-compile-n) if it doesn't have to save a new cache.
So on PRs we essentially run in a "read-only" mode, where we don't expect any cache to be populated.  
And we make sure that the cache is populated on pushes to `main`.  

Our current workaround is to use a key based on the current commit SHA, which no other run will hit.  
But that is currently filling up the cache space in the repo: https://github.com/github/codeql/actions/caches 

## How Has This Been Tested?
- I added a test-case.  
- It's been concretely tested on a workflow here: https://github.com/github/codeql/pull/11362 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (add or update README or docs)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly. **(I'll do that if the PR looks OK).** 
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
