### PR TITLE
Release cache `3.1.0-beta.2` with gzip fallback for old cache

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -43,3 +43,6 @@
 
 ### 3.1.0-beta.1
 - Update `@actions/cache` on windows to use gnu tar and zstd by default and fallback to bsdtar and zstd if gnu tar is not available. ([issue](https://github.com/actions/cache/issues/984))
+
+### 3.1.0-beta.2
+- Added support for fallback to gzip to restore old caches on windows.

--- a/dist/restore/index.js
+++ b/dist/restore/index.js
@@ -47081,6 +47081,7 @@ const path = __importStar(__webpack_require__(622));
 const utils = __importStar(__webpack_require__(15));
 const cacheHttpClient = __importStar(__webpack_require__(114));
 const tar_1 = __webpack_require__(434);
+const constants_1 = __webpack_require__(931);
 class ValidationError extends Error {
     constructor(message) {
         super(message);
@@ -47142,13 +47143,33 @@ function restoreCache(paths, primaryKey, restoreKeys, options) {
         for (const key of keys) {
             checkKey(key);
         }
-        const compressionMethod = yield utils.getCompressionMethod();
+        let cacheEntry;
+        let compressionMethod = yield utils.getCompressionMethod();
         let archivePath = '';
         try {
-            // path are needed to compute version
-            const cacheEntry = yield cacheHttpClient.getCacheEntry(keys, paths, {
-                compressionMethod
-            });
+            try {
+                // path are needed to compute version
+                cacheEntry = yield cacheHttpClient.getCacheEntry(keys, paths, {
+                    compressionMethod
+                });
+            }
+            catch (error) {
+                // This is to support the old cache entry created
+                // by the old version of the cache action on windows.
+                if (process.platform === 'win32' &&
+                    compressionMethod !== constants_1.CompressionMethod.Gzip) {
+                    compressionMethod = constants_1.CompressionMethod.Gzip;
+                    cacheEntry = yield cacheHttpClient.getCacheEntry(keys, paths, {
+                        compressionMethod
+                    });
+                    if (!(cacheEntry === null || cacheEntry === void 0 ? void 0 : cacheEntry.archiveLocation)) {
+                        throw error;
+                    }
+                }
+                else {
+                    throw error;
+                }
+            }
             if (!(cacheEntry === null || cacheEntry === void 0 ? void 0 : cacheEntry.archiveLocation)) {
                 // Cache not found
                 return undefined;

--- a/dist/save/index.js
+++ b/dist/save/index.js
@@ -47167,6 +47167,7 @@ const path = __importStar(__webpack_require__(622));
 const utils = __importStar(__webpack_require__(15));
 const cacheHttpClient = __importStar(__webpack_require__(114));
 const tar_1 = __webpack_require__(434);
+const constants_1 = __webpack_require__(931);
 class ValidationError extends Error {
     constructor(message) {
         super(message);
@@ -47228,13 +47229,33 @@ function restoreCache(paths, primaryKey, restoreKeys, options) {
         for (const key of keys) {
             checkKey(key);
         }
-        const compressionMethod = yield utils.getCompressionMethod();
+        let cacheEntry;
+        let compressionMethod = yield utils.getCompressionMethod();
         let archivePath = '';
         try {
-            // path are needed to compute version
-            const cacheEntry = yield cacheHttpClient.getCacheEntry(keys, paths, {
-                compressionMethod
-            });
+            try {
+                // path are needed to compute version
+                cacheEntry = yield cacheHttpClient.getCacheEntry(keys, paths, {
+                    compressionMethod
+                });
+            }
+            catch (error) {
+                // This is to support the old cache entry created
+                // by the old version of the cache action on windows.
+                if (process.platform === 'win32' &&
+                    compressionMethod !== constants_1.CompressionMethod.Gzip) {
+                    compressionMethod = constants_1.CompressionMethod.Gzip;
+                    cacheEntry = yield cacheHttpClient.getCacheEntry(keys, paths, {
+                        compressionMethod
+                    });
+                    if (!(cacheEntry === null || cacheEntry === void 0 ? void 0 : cacheEntry.archiveLocation)) {
+                        throw error;
+                    }
+                }
+                else {
+                    throw error;
+                }
+            }
             if (!(cacheEntry === null || cacheEntry === void 0 ? void 0 : cacheEntry.archiveLocation)) {
                 // Cache not found
                 return undefined;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "cache",
-  "version": "3.1.0-beta.1",
+  "version": "3.1.0-beta.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "cache",
-      "version": "3.1.0-beta.1",
+      "version": "3.1.0-beta.2",
       "license": "MIT",
       "dependencies": {
-        "@actions/cache": "3.1.0-beta.1",
+        "@actions/cache": "3.1.0-beta.2",
         "@actions/core": "^1.10.0",
         "@actions/exec": "^1.1.1",
         "@actions/io": "^1.1.2"
@@ -36,9 +36,9 @@
       }
     },
     "node_modules/@actions/cache": {
-      "version": "3.1.0-beta.1",
-      "resolved": "https://registry.npmjs.org/@actions/cache/-/cache-3.1.0-beta.1.tgz",
-      "integrity": "sha512-E+lNTJ4x1baOVHbhkkGK7JebxChMM/ogDSWIuDJsiPlpi7bzzL8RnKTk4zlZ3OYmWK8tF2/5QZMerg3rY4c/9A==",
+      "version": "3.1.0-beta.2",
+      "resolved": "https://registry.npmjs.org/@actions/cache/-/cache-3.1.0-beta.2.tgz",
+      "integrity": "sha512-xt9NLWPCh5WU9Z5ITeGpT5Nza/57wMXeLsGuNVcRCIVpPuNTf3Puj82vjZZQw4rGqiCCs+n4+hnkTcE9BKw2sw==",
       "dependencies": {
         "@actions/core": "^1.10.0",
         "@actions/exec": "^1.0.1",
@@ -9722,9 +9722,9 @@
   },
   "dependencies": {
     "@actions/cache": {
-      "version": "3.1.0-beta.1",
-      "resolved": "https://registry.npmjs.org/@actions/cache/-/cache-3.1.0-beta.1.tgz",
-      "integrity": "sha512-E+lNTJ4x1baOVHbhkkGK7JebxChMM/ogDSWIuDJsiPlpi7bzzL8RnKTk4zlZ3OYmWK8tF2/5QZMerg3rY4c/9A==",
+      "version": "3.1.0-beta.2",
+      "resolved": "https://registry.npmjs.org/@actions/cache/-/cache-3.1.0-beta.2.tgz",
+      "integrity": "sha512-xt9NLWPCh5WU9Z5ITeGpT5Nza/57wMXeLsGuNVcRCIVpPuNTf3Puj82vjZZQw4rGqiCCs+n4+hnkTcE9BKw2sw==",
       "requires": {
         "@actions/core": "^1.10.0",
         "@actions/exec": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cache",
-  "version": "3.1.0-beta.1",
+  "version": "3.1.0-beta.2",
   "private": true,
   "description": "Cache dependencies and build outputs",
   "main": "dist/restore/index.js",
@@ -23,7 +23,7 @@
   "author": "GitHub",
   "license": "MIT",
   "dependencies": {
-    "@actions/cache": "3.1.0-beta.1",
+    "@actions/cache": "3.1.0-beta.2",
     "@actions/core": "^1.10.0",
     "@actions/exec": "^1.1.1",
     "@actions/io": "^1.1.2"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Add support for gzip fallback for restore of old cache on windows

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
With compression switching to zstd, old gzip cache might not recover. To support old cache recovery use of gzip is needed. Need to be removed in future

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Added extra test for this case.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (add or update README or docs)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
