### PR TITLE
Fix: Node npm doc example 

### DIFF
--- a/examples.md
+++ b/examples.md
@@ -317,7 +317,7 @@ After [deprecation](https://github.blog/changelog/2022-10-11-github-actions-depr
 ### Bash shell
 ```yaml
 - name: Get npm cache directory
-  id: npm-cache
+  id: npm-cache-dir
   shell: bash
   run: echo "dir=$(npm config get cache)" >> ${GITHUB_OUTPUT}
 ```
@@ -325,7 +325,7 @@ After [deprecation](https://github.blog/changelog/2022-10-11-github-actions-depr
 ### PWSH shell
 ```yaml
 - name: Get npm cache directory
-  id: npm-cache
+  id: npm-cache-dir
   shell: pwsh
   run: echo "dir=$(npm config get cache)" >> ${env:GITHUB_OUTPUT}
 ```


### PR DESCRIPTION
Try the use of cache for a npm project, i get a error while follow the example

## Description
According with the behavior description the id of "Get npm cache directory" must be "npm-cache-dir".

In the original doc all steps (node npm) have the same id, this is wrong.

## Motivation and Context
I think that improve the documentation is good for all.

## How Has This Been Tested?
I checked it in my own project.

## Screenshots (if appropriate):

According with current doc:
![imagen](https://user-images.githubusercontent.com/1436116/206871664-20f7f01e-0f9d-49ba-b2d4-1677cb67e43f.png)

After change Id, according to pull-request:
![imagen](https://user-images.githubusercontent.com/1436116/206871578-6156ebac-3b9c-4988-a184-a8c0835029ce.png)

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue): change id in documentation.
