### PR TITLE
Warning added for save only action

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -6,7 +6,7 @@
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.
 	// "forwardPorts": [],
 	// Use 'postCreateCommand' to run commands after the container is created.
-	"postCreateCommand": "npm install && npm run build"
+	"postCreateCommand": "npm install"
 	// Configure tool-specific properties.
 	// "customizations": {},
 	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.

--- a/__tests__/saveOnly.test.ts
+++ b/__tests__/saveOnly.test.ts
@@ -91,3 +91,31 @@ test("save with valid inputs uploads a cache", async () => {
 
     expect(failedMock).toHaveBeenCalledTimes(0);
 });
+
+test("save failing logs the warning message", async () => {
+    const warningMock = jest.spyOn(core, "warning");
+
+    const primaryKey = "Linux-node-bb828da54c148048dd17899ba9fda624811cfb43";
+
+    const inputPath = "node_modules";
+    testUtils.setInput(Inputs.Key, primaryKey);
+    testUtils.setInput(Inputs.Path, inputPath);
+    testUtils.setInput(Inputs.UploadChunkSize, "4000000");
+
+    const cacheId = -1;
+    const saveCacheMock = jest
+        .spyOn(cache, "saveCache")
+        .mockImplementationOnce(() => {
+            return Promise.resolve(cacheId);
+        });
+
+    await run();
+
+    expect(saveCacheMock).toHaveBeenCalledTimes(1);
+    expect(saveCacheMock).toHaveBeenCalledWith([inputPath], primaryKey, {
+        uploadChunkSize: 4000000
+    });
+
+    expect(warningMock).toHaveBeenCalledTimes(1);
+    expect(warningMock).toHaveBeenCalledWith("Cache save failed.");
+});

--- a/dist/save-only/index.js
+++ b/dist/save-only/index.js
@@ -41149,7 +41149,6 @@ function saveImpl(stateProvider) {
             cacheId = yield cache.saveCache(cachePaths, primaryKey, {
                 uploadChunkSize: utils.getInputAsInt(constants_1.Inputs.UploadChunkSize)
             });
-            // -1 refers to cache not saved
             if (cacheId != -1) {
                 core.info(`Cache saved with key: ${primaryKey}`);
             }

--- a/dist/save-only/index.js
+++ b/dist/save-only/index.js
@@ -41122,11 +41122,11 @@ function saveImpl(stateProvider) {
         let cacheId;
         try {
             if (!utils.isCacheFeatureAvailable()) {
-                return 0;
+                return -2; //-2 refers as safe to ignore for the caller
             }
             if (!utils.isValidEvent()) {
                 utils.logWarning(`Event Validation Error: The event type ${process.env[constants_1.Events.Key]} is not supported because it's not tied to a branch or tag ref.`);
-                return 0;
+                return -2;
             }
             // If restore has stored a primary key in state, reuse that
             // Else re-evaluate from inputs
@@ -41134,14 +41134,14 @@ function saveImpl(stateProvider) {
                 core.getInput(constants_1.Inputs.Key);
             if (!primaryKey) {
                 utils.logWarning(`Key is not specified.`);
-                return 0;
+                return -2;
             }
             // If matched restore key is same as primary key, then do not save cache
             // NO-OP in case of SaveOnly action
             const restoredKey = stateProvider.getCacheState();
             if (utils.isExactKeyMatch(primaryKey, restoredKey)) {
                 core.info(`Cache hit occurred on the primary key ${primaryKey}, not saving cache.`);
-                return 0;
+                return -2;
             }
             const cachePaths = utils.getInputAsArray(constants_1.Inputs.Path, {
                 required: true
@@ -41149,6 +41149,7 @@ function saveImpl(stateProvider) {
             cacheId = yield cache.saveCache(cachePaths, primaryKey, {
                 uploadChunkSize: utils.getInputAsInt(constants_1.Inputs.UploadChunkSize)
             });
+            // -1 refers to cache not saved
             if (cacheId != -1) {
                 core.info(`Cache saved with key: ${primaryKey}`);
             }

--- a/dist/save-only/index.js
+++ b/dist/save-only/index.js
@@ -41119,14 +41119,14 @@ const utils = __importStar(__webpack_require__(443));
 process.on("uncaughtException", e => utils.logWarning(e.message));
 function saveImpl(stateProvider) {
     return __awaiter(this, void 0, void 0, function* () {
-        let cacheId;
+        let cacheId = -1;
         try {
             if (!utils.isCacheFeatureAvailable()) {
-                return -2; //-2 refers as safe to ignore for the caller
+                return;
             }
             if (!utils.isValidEvent()) {
                 utils.logWarning(`Event Validation Error: The event type ${process.env[constants_1.Events.Key]} is not supported because it's not tied to a branch or tag ref.`);
-                return -2;
+                return;
             }
             // If restore has stored a primary key in state, reuse that
             // Else re-evaluate from inputs
@@ -41134,14 +41134,14 @@ function saveImpl(stateProvider) {
                 core.getInput(constants_1.Inputs.Key);
             if (!primaryKey) {
                 utils.logWarning(`Key is not specified.`);
-                return -2;
+                return;
             }
             // If matched restore key is same as primary key, then do not save cache
             // NO-OP in case of SaveOnly action
             const restoredKey = stateProvider.getCacheState();
             if (utils.isExactKeyMatch(primaryKey, restoredKey)) {
                 core.info(`Cache hit occurred on the primary key ${primaryKey}, not saving cache.`);
-                return -2;
+                return;
             }
             const cachePaths = utils.getInputAsArray(constants_1.Inputs.Path, {
                 required: true

--- a/dist/save/index.js
+++ b/dist/save/index.js
@@ -41063,14 +41063,14 @@ const utils = __importStar(__webpack_require__(443));
 process.on("uncaughtException", e => utils.logWarning(e.message));
 function saveImpl(stateProvider) {
     return __awaiter(this, void 0, void 0, function* () {
-        let cacheId;
+        let cacheId = -1;
         try {
             if (!utils.isCacheFeatureAvailable()) {
-                return -2; //-2 refers as safe to ignore for the caller
+                return;
             }
             if (!utils.isValidEvent()) {
                 utils.logWarning(`Event Validation Error: The event type ${process.env[constants_1.Events.Key]} is not supported because it's not tied to a branch or tag ref.`);
-                return -2;
+                return;
             }
             // If restore has stored a primary key in state, reuse that
             // Else re-evaluate from inputs
@@ -41078,14 +41078,14 @@ function saveImpl(stateProvider) {
                 core.getInput(constants_1.Inputs.Key);
             if (!primaryKey) {
                 utils.logWarning(`Key is not specified.`);
-                return -2;
+                return;
             }
             // If matched restore key is same as primary key, then do not save cache
             // NO-OP in case of SaveOnly action
             const restoredKey = stateProvider.getCacheState();
             if (utils.isExactKeyMatch(primaryKey, restoredKey)) {
                 core.info(`Cache hit occurred on the primary key ${primaryKey}, not saving cache.`);
-                return -2;
+                return;
             }
             const cachePaths = utils.getInputAsArray(constants_1.Inputs.Path, {
                 required: true

--- a/dist/save/index.js
+++ b/dist/save/index.js
@@ -41066,11 +41066,11 @@ function saveImpl(stateProvider) {
         let cacheId;
         try {
             if (!utils.isCacheFeatureAvailable()) {
-                return 0;
+                return -2; //-2 refers as safe to ignore for the caller
             }
             if (!utils.isValidEvent()) {
                 utils.logWarning(`Event Validation Error: The event type ${process.env[constants_1.Events.Key]} is not supported because it's not tied to a branch or tag ref.`);
-                return 0;
+                return -2;
             }
             // If restore has stored a primary key in state, reuse that
             // Else re-evaluate from inputs
@@ -41078,14 +41078,14 @@ function saveImpl(stateProvider) {
                 core.getInput(constants_1.Inputs.Key);
             if (!primaryKey) {
                 utils.logWarning(`Key is not specified.`);
-                return 0;
+                return -2;
             }
             // If matched restore key is same as primary key, then do not save cache
             // NO-OP in case of SaveOnly action
             const restoredKey = stateProvider.getCacheState();
             if (utils.isExactKeyMatch(primaryKey, restoredKey)) {
                 core.info(`Cache hit occurred on the primary key ${primaryKey}, not saving cache.`);
-                return 0;
+                return -2;
             }
             const cachePaths = utils.getInputAsArray(constants_1.Inputs.Path, {
                 required: true
@@ -41093,6 +41093,7 @@ function saveImpl(stateProvider) {
             cacheId = yield cache.saveCache(cachePaths, primaryKey, {
                 uploadChunkSize: utils.getInputAsInt(constants_1.Inputs.UploadChunkSize)
             });
+            // -1 refers to cache not saved
             if (cacheId != -1) {
                 core.info(`Cache saved with key: ${primaryKey}`);
             }

--- a/dist/save/index.js
+++ b/dist/save/index.js
@@ -41093,7 +41093,6 @@ function saveImpl(stateProvider) {
             cacheId = yield cache.saveCache(cachePaths, primaryKey, {
                 uploadChunkSize: utils.getInputAsInt(constants_1.Inputs.UploadChunkSize)
             });
-            // -1 refers to cache not saved
             if (cacheId != -1) {
                 core.info(`Cache saved with key: ${primaryKey}`);
             }

--- a/dist/save/index.js
+++ b/dist/save/index.js
@@ -41063,13 +41063,14 @@ const utils = __importStar(__webpack_require__(443));
 process.on("uncaughtException", e => utils.logWarning(e.message));
 function saveImpl(stateProvider) {
     return __awaiter(this, void 0, void 0, function* () {
+        let cacheId;
         try {
             if (!utils.isCacheFeatureAvailable()) {
-                return;
+                return 0;
             }
             if (!utils.isValidEvent()) {
                 utils.logWarning(`Event Validation Error: The event type ${process.env[constants_1.Events.Key]} is not supported because it's not tied to a branch or tag ref.`);
-                return;
+                return 0;
             }
             // If restore has stored a primary key in state, reuse that
             // Else re-evaluate from inputs
@@ -41077,19 +41078,19 @@ function saveImpl(stateProvider) {
                 core.getInput(constants_1.Inputs.Key);
             if (!primaryKey) {
                 utils.logWarning(`Key is not specified.`);
-                return;
+                return 0;
             }
             // If matched restore key is same as primary key, then do not save cache
             // NO-OP in case of SaveOnly action
             const restoredKey = stateProvider.getCacheState();
             if (utils.isExactKeyMatch(primaryKey, restoredKey)) {
                 core.info(`Cache hit occurred on the primary key ${primaryKey}, not saving cache.`);
-                return;
+                return 0;
             }
             const cachePaths = utils.getInputAsArray(constants_1.Inputs.Path, {
                 required: true
             });
-            const cacheId = yield cache.saveCache(cachePaths, primaryKey, {
+            cacheId = yield cache.saveCache(cachePaths, primaryKey, {
                 uploadChunkSize: utils.getInputAsInt(constants_1.Inputs.UploadChunkSize)
             });
             if (cacheId != -1) {
@@ -41099,6 +41100,7 @@ function saveImpl(stateProvider) {
         catch (error) {
             utils.logWarning(error.message);
         }
+        return cacheId;
     });
 }
 exports.default = saveImpl;

--- a/src/saveImpl.ts
+++ b/src/saveImpl.ts
@@ -14,7 +14,7 @@ async function saveImpl(stateProvider: IStateProvider): Promise<number> {
     let cacheId;
     try {
         if (!utils.isCacheFeatureAvailable()) {
-            return 0;
+            return -2; //-2 refers as safe to ignore for the caller
         }
 
         if (!utils.isValidEvent()) {
@@ -23,7 +23,7 @@ async function saveImpl(stateProvider: IStateProvider): Promise<number> {
                     process.env[Events.Key]
                 } is not supported because it's not tied to a branch or tag ref.`
             );
-            return 0;
+            return -2;
         }
 
         // If restore has stored a primary key in state, reuse that
@@ -34,7 +34,7 @@ async function saveImpl(stateProvider: IStateProvider): Promise<number> {
 
         if (!primaryKey) {
             utils.logWarning(`Key is not specified.`);
-            return 0;
+            return -2;
         }
 
         // If matched restore key is same as primary key, then do not save cache
@@ -45,7 +45,7 @@ async function saveImpl(stateProvider: IStateProvider): Promise<number> {
             core.info(
                 `Cache hit occurred on the primary key ${primaryKey}, not saving cache.`
             );
-            return 0;
+            return -2;
         }
 
         const cachePaths = utils.getInputAsArray(Inputs.Path, {
@@ -56,6 +56,7 @@ async function saveImpl(stateProvider: IStateProvider): Promise<number> {
             uploadChunkSize: utils.getInputAsInt(Inputs.UploadChunkSize)
         });
 
+        // -1 refers to cache not saved
         if (cacheId != -1) {
             core.info(`Cache saved with key: ${primaryKey}`);
         }

--- a/src/saveImpl.ts
+++ b/src/saveImpl.ts
@@ -56,7 +56,6 @@ async function saveImpl(stateProvider: IStateProvider): Promise<number | void> {
             uploadChunkSize: utils.getInputAsInt(Inputs.UploadChunkSize)
         });
 
-        // -1 refers to cache not saved
         if (cacheId != -1) {
             core.info(`Cache saved with key: ${primaryKey}`);
         }

--- a/src/saveImpl.ts
+++ b/src/saveImpl.ts
@@ -10,10 +10,11 @@ import * as utils from "./utils/actionUtils";
 // throw an uncaught exception.  Instead of failing this action, just warn.
 process.on("uncaughtException", e => utils.logWarning(e.message));
 
-async function saveImpl(stateProvider: IStateProvider): Promise<void> {
+async function saveImpl(stateProvider: IStateProvider): Promise<number> {
+    let cacheId;
     try {
         if (!utils.isCacheFeatureAvailable()) {
-            return;
+            return 0;
         }
 
         if (!utils.isValidEvent()) {
@@ -22,7 +23,7 @@ async function saveImpl(stateProvider: IStateProvider): Promise<void> {
                     process.env[Events.Key]
                 } is not supported because it's not tied to a branch or tag ref.`
             );
-            return;
+            return 0;
         }
 
         // If restore has stored a primary key in state, reuse that
@@ -33,7 +34,7 @@ async function saveImpl(stateProvider: IStateProvider): Promise<void> {
 
         if (!primaryKey) {
             utils.logWarning(`Key is not specified.`);
-            return;
+            return 0;
         }
 
         // If matched restore key is same as primary key, then do not save cache
@@ -44,14 +45,14 @@ async function saveImpl(stateProvider: IStateProvider): Promise<void> {
             core.info(
                 `Cache hit occurred on the primary key ${primaryKey}, not saving cache.`
             );
-            return;
+            return 0;
         }
 
         const cachePaths = utils.getInputAsArray(Inputs.Path, {
             required: true
         });
 
-        const cacheId = await cache.saveCache(cachePaths, primaryKey, {
+        cacheId = await cache.saveCache(cachePaths, primaryKey, {
             uploadChunkSize: utils.getInputAsInt(Inputs.UploadChunkSize)
         });
 
@@ -61,6 +62,7 @@ async function saveImpl(stateProvider: IStateProvider): Promise<void> {
     } catch (error: unknown) {
         utils.logWarning((error as Error).message);
     }
+    return cacheId;
 }
 
 export default saveImpl;

--- a/src/saveImpl.ts
+++ b/src/saveImpl.ts
@@ -10,11 +10,11 @@ import * as utils from "./utils/actionUtils";
 // throw an uncaught exception.  Instead of failing this action, just warn.
 process.on("uncaughtException", e => utils.logWarning(e.message));
 
-async function saveImpl(stateProvider: IStateProvider): Promise<number> {
-    let cacheId;
+async function saveImpl(stateProvider: IStateProvider): Promise<number | void> {
+    let cacheId = -1;
     try {
         if (!utils.isCacheFeatureAvailable()) {
-            return -2; //-2 refers as safe to ignore for the caller
+            return;
         }
 
         if (!utils.isValidEvent()) {
@@ -23,7 +23,7 @@ async function saveImpl(stateProvider: IStateProvider): Promise<number> {
                     process.env[Events.Key]
                 } is not supported because it's not tied to a branch or tag ref.`
             );
-            return -2;
+            return;
         }
 
         // If restore has stored a primary key in state, reuse that
@@ -34,7 +34,7 @@ async function saveImpl(stateProvider: IStateProvider): Promise<number> {
 
         if (!primaryKey) {
             utils.logWarning(`Key is not specified.`);
-            return -2;
+            return;
         }
 
         // If matched restore key is same as primary key, then do not save cache
@@ -45,7 +45,7 @@ async function saveImpl(stateProvider: IStateProvider): Promise<number> {
             core.info(
                 `Cache hit occurred on the primary key ${primaryKey}, not saving cache.`
             );
-            return -2;
+            return;
         }
 
         const cachePaths = utils.getInputAsArray(Inputs.Path, {

--- a/src/saveOnly.ts
+++ b/src/saveOnly.ts
@@ -1,8 +1,13 @@
+import * as core from "@actions/core";
+
 import saveImpl from "./saveImpl";
 import { NullStateProvider } from "./stateProvider";
 
 async function run(): Promise<void> {
-    await saveImpl(new NullStateProvider());
+    const cacheId = await saveImpl(new NullStateProvider());
+    if (cacheId === -1) {
+        core.warning(`Cache save failed.`);
+    }
 }
 
 run();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
For save only action, it is important for users to know that the save has failed due to any reason, hence we've added a warning to show the same.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Make user experience better by highlighting any warnings/issues in the workflow run

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Local workflow 

Save action - https://github.com/kotewar/test-continue-on-error-for-cache/actions/runs/3742275202
Default cache action - https://github.com/kotewar/test-continue-on-error-for-cache/actions/runs/3742531272/jobs/6353592058#step:13:665

## Screenshots (if appropriate):
NA 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (add or update README or docs)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
