### PR TITLE
Add `fail-on-cache-miss` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ See ["Caching dependencies to speed up workflows"](https://docs.github.com/en/ac
 * Allowing users to provide a custom timeout as input for aborting download of a cache segment using an environment variable `SEGMENT_DOWNLOAD_TIMEOUT_MINS`. Default is 60 minutes.
 * Two new actions available for granular control over caches - [restore](restore/action.yml) and [save](save/action.yml)
 * Support cross-os caching as an opt-in feature. See [Cross OS caching](./tips-and-workarounds.md#cross-os-cache) for more info.
+* Added option to fail job on cache miss. See [Exit workflow on cache miss](./restore/README.md#exit-workflow-on-cache-miss) for more info.
 
 Refer [here](https://github.com/actions/cache/blob/v2/README.md) for previous versions
 

--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ If you are using this inside a container, a POSIX-compliant `tar` needs to be in
 * `key` - An explicit key for restoring and saving the cache
 * `restore-keys` - An ordered list of prefix-matched keys to use for restoring stale cache if no cache hit occurred for key.
 * `enableCrossOsArchive` - An optional boolean when enabled, allows Windows runners to save or restore caches that can be restored or saved respectively on other platforms. Default: false
+* `fail-on-cache-miss` - Fail the workflow if cache entry is not found
 
 #### Environment Variables
 * `SEGMENT_DOWNLOAD_TIMEOUT_MINS` - Segment download timeout (in minutes, default `60`) to abort download of the segment if not completed in the defined number of minutes. [Read more](https://github.com/actions/cache/blob/main/tips-and-workarounds.md#cache-segment-restore-timeout)

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ If you are using a `self-hosted` Windows runner, `GNU tar` and `zstd` are requir
 * `key` - An explicit key for restoring and saving the cache. Refer [creating a cache key](#creating-a-cache-key).
 * `restore-keys` - An ordered list of prefix-matched keys to use for restoring stale cache if no cache hit occurred for key.
 * `enableCrossOsArchive` - An optional boolean when enabled, allows Windows runners to save or restore caches that can be restored or saved respectively on other platforms. Default: false
-* `fail-on-cache-miss` - Fail the workflow if cache entry is not found
+* `fail-on-cache-miss` - Fail the workflow if cache entry is not found. Default: false
 
 #### Environment Variables
 

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -67,3 +67,6 @@
 ### 3.2.3
 - Support cross os caching on Windows as an opt-in feature.
 - Fix issue with symlink restoration on Windows for cross-os caches.
+
+### 3.2.4
+- Added option to fail job on cache miss.

--- a/__tests__/restore.test.ts
+++ b/__tests__/restore.test.ts
@@ -290,3 +290,43 @@ test("restore when fail on cache miss is enabled and primary key doesn't match r
     );
     expect(failedMock).toHaveBeenCalledTimes(0);
 });
+
+test("restore with fail on cache miss disabled and no cache found", async () => {
+    const path = "node_modules";
+    const key = "node-test";
+    const restoreKey = "node-";
+    testUtils.setInputs({
+        path: path,
+        key,
+        restoreKeys: [restoreKey],
+        failOnCacheMiss: false
+    });
+
+    const infoMock = jest.spyOn(core, "info");
+    const failedMock = jest.spyOn(core, "setFailed");
+    const stateMock = jest.spyOn(core, "saveState");
+    const restoreCacheMock = jest
+        .spyOn(cache, "restoreCache")
+        .mockImplementationOnce(() => {
+            return Promise.resolve(undefined);
+        });
+
+    await run();
+
+    expect(restoreCacheMock).toHaveBeenCalledTimes(1);
+    expect(restoreCacheMock).toHaveBeenCalledWith(
+        [path],
+        key,
+        [restoreKey],
+        {},
+        false
+    );
+
+    expect(stateMock).toHaveBeenCalledWith("CACHE_KEY", key);
+    expect(stateMock).toHaveBeenCalledTimes(1);
+
+    expect(infoMock).toHaveBeenCalledWith(
+        `Cache not found for input keys: ${key}, ${restoreKey}`
+    );
+    expect(failedMock).toHaveBeenCalledTimes(0);
+});

--- a/__tests__/restore.test.ts
+++ b/__tests__/restore.test.ts
@@ -206,7 +206,7 @@ test("restore with cache found for restore key", async () => {
     expect(failedMock).toHaveBeenCalledTimes(0);
 });
 
-test("Fail restore when fail on cache miss is enabled and primary key not found", async () => {
+test("Fail restore when fail on cache miss is enabled and primary + restore keys not found", async () => {
     const path = "node_modules";
     const key = "node-test";
     const restoreKey = "node-";
@@ -246,7 +246,7 @@ test("Fail restore when fail on cache miss is enabled and primary key not found"
     expect(failedMock).toHaveBeenCalledTimes(1);
 });
 
-test("Fail restore when fail on cache miss is enabled and primary key doesn't match restored key", async () => {
+test("restore when fail on cache miss is enabled and primary key doesn't match restored key", async () => {
     const path = "node_modules";
     const key = "node-test";
     const restoreKey = "node-";
@@ -257,6 +257,7 @@ test("Fail restore when fail on cache miss is enabled and primary key doesn't ma
         failOnCacheMiss: true
     });
 
+    const infoMock = jest.spyOn(core, "info");
     const failedMock = jest.spyOn(core, "setFailed");
     const stateMock = jest.spyOn(core, "saveState");
     const setCacheHitOutputMock = jest.spyOn(core, "setOutput");
@@ -278,11 +279,14 @@ test("Fail restore when fail on cache miss is enabled and primary key doesn't ma
     );
 
     expect(stateMock).toHaveBeenCalledWith("CACHE_KEY", key);
+    expect(stateMock).toHaveBeenCalledWith("CACHE_RESULT", restoreKey);
+    expect(stateMock).toHaveBeenCalledTimes(2);
+
     expect(setCacheHitOutputMock).toHaveBeenCalledTimes(1);
     expect(setCacheHitOutputMock).toHaveBeenCalledWith("cache-hit", "false");
 
-    expect(failedMock).toHaveBeenCalledWith(
-        `Restored cache key doesn't match the given input key. Exiting as fail-on-cache-miss is set. Input key: ${key}`
+    expect(infoMock).toHaveBeenCalledWith(
+        `Cache restored from key: ${restoreKey}`
     );
-    expect(failedMock).toHaveBeenCalledTimes(1);
+    expect(failedMock).toHaveBeenCalledTimes(0);
 });

--- a/__tests__/restore.test.ts
+++ b/__tests__/restore.test.ts
@@ -214,7 +214,7 @@ test("Fail restore when fail on cache miss is enabled and primary key not found"
         path: path,
         key,
         restoreKeys: [restoreKey],
-        failOnCacheMiss: "true"
+        failOnCacheMiss: true
     });
 
     const failedMock = jest.spyOn(core, "setFailed");
@@ -229,7 +229,13 @@ test("Fail restore when fail on cache miss is enabled and primary key not found"
     await run();
 
     expect(restoreCacheMock).toHaveBeenCalledTimes(1);
-    expect(restoreCacheMock).toHaveBeenCalledWith([path], key, [restoreKey]);
+    expect(restoreCacheMock).toHaveBeenCalledWith(
+        [path],
+        key,
+        [restoreKey],
+        {},
+        false
+    );
 
     expect(stateMock).toHaveBeenCalledWith("CACHE_KEY", key);
     expect(setCacheHitOutputMock).toHaveBeenCalledTimes(0);
@@ -248,7 +254,7 @@ test("Fail restore when fail on cache miss is enabled and primary key doesn't ma
         path: path,
         key,
         restoreKeys: [restoreKey],
-        failOnCacheMiss: "true"
+        failOnCacheMiss: true
     });
 
     const failedMock = jest.spyOn(core, "setFailed");
@@ -263,7 +269,13 @@ test("Fail restore when fail on cache miss is enabled and primary key doesn't ma
     await run();
 
     expect(restoreCacheMock).toHaveBeenCalledTimes(1);
-    expect(restoreCacheMock).toHaveBeenCalledWith([path], key, [restoreKey]);
+    expect(restoreCacheMock).toHaveBeenCalledWith(
+        [path],
+        key,
+        [restoreKey],
+        {},
+        false
+    );
 
     expect(stateMock).toHaveBeenCalledWith("CACHE_KEY", key);
     expect(setCacheHitOutputMock).toHaveBeenCalledTimes(1);

--- a/__tests__/restore.test.ts
+++ b/__tests__/restore.test.ts
@@ -214,7 +214,7 @@ test("Fail restore when fail on cache miss is enabled and primary key not found"
         path: path,
         key,
         restoreKeys: [restoreKey],
-        failOnCacheMiss: true
+        failOnCacheMiss: "true"
     });
 
     const failedMock = jest.spyOn(core, "setFailed");
@@ -248,7 +248,7 @@ test("Fail restore when fail on cache miss is enabled and primary key doesn't ma
         path: path,
         key,
         restoreKeys: [restoreKey],
-        failOnCacheMiss: true
+        failOnCacheMiss: "true"
     });
 
     const failedMock = jest.spyOn(core, "setFailed");

--- a/action.yml
+++ b/action.yml
@@ -11,15 +11,15 @@ inputs:
   restore-keys:
     description: 'An ordered list of keys to use for restoring stale cache if no cache hit occurred for key. Note `cache-hit` returns false in this case.'
     required: false
-  fail-on-cache-miss:
-    description: 'Fail the workflow if the cache is not found for the primary key'
-    required: false
-    default: "false"
   upload-chunk-size:
     description: 'The chunk size used to split up large files during upload, in bytes'
     required: false
   enableCrossOsArchive:
     description: 'An optional boolean when enabled, allows windows runners to save or restore caches that can be restored or saved respectively on other platforms'
+    default: 'false'
+    required: false
+  fail-on-cache-miss:
+    description: 'Fail the workflow if the cache is not found for the primary key'
     default: 'false'
     required: false
 outputs:

--- a/action.yml
+++ b/action.yml
@@ -11,6 +11,10 @@ inputs:
   restore-keys:
     description: 'An ordered list of keys to use for restoring stale cache if no cache hit occurred for key. Note `cache-hit` returns false in this case.'
     required: false
+  fail-on-cache-miss:
+    description: 'Fail the workflow if the cache is not found for the primary key'
+    required: false
+    default: "false"
   upload-chunk-size:
     description: 'The chunk size used to split up large files during upload, in bytes'
     required: false

--- a/action.yml
+++ b/action.yml
@@ -19,7 +19,7 @@ inputs:
     default: 'false'
     required: false
   fail-on-cache-miss:
-    description: 'Fail the workflow if no cache entry is not found'
+    description: 'Fail the workflow if cache entry is not found'
     default: 'false'
     required: false
 outputs:

--- a/action.yml
+++ b/action.yml
@@ -19,7 +19,7 @@ inputs:
     default: 'false'
     required: false
   fail-on-cache-miss:
-    description: 'Fail the workflow if the cache is not found for the primary key or no cache is found at all'
+    description: 'Fail the workflow if no cache entry is not found'
     default: 'false'
     required: false
 outputs:

--- a/action.yml
+++ b/action.yml
@@ -19,7 +19,7 @@ inputs:
     default: 'false'
     required: false
   fail-on-cache-miss:
-    description: 'Fail the workflow if the cache is not found for the primary key'
+    description: 'Fail the workflow if the cache is not found for the primary key or no cache is found at all'
     default: 'false'
     required: false
 outputs:

--- a/dist/restore-only/index.js
+++ b/dist/restore-only/index.js
@@ -50512,9 +50512,6 @@ function restoreImpl(stateProvider) {
             stateProvider.setState(constants_1.State.CacheMatchedKey, cacheKey);
             const isExactKeyMatch = utils.isExactKeyMatch(core.getInput(constants_1.Inputs.Key, { required: true }), cacheKey);
             core.setOutput(constants_1.Outputs.CacheHit, isExactKeyMatch.toString());
-            if (!isExactKeyMatch && failOnCacheMiss) {
-                throw new Error(`Restored cache key doesn't match the given input key. Exiting as fail-on-cache-miss is set. Input key: ${primaryKey}`);
-            }
             core.info(`Cache restored from key: ${cacheKey}`);
             return cacheKey;
         }

--- a/dist/restore-only/index.js
+++ b/dist/restore-only/index.js
@@ -50496,9 +50496,10 @@ function restoreImpl(stateProvider) {
                 required: true
             });
             const enableCrossOsArchive = utils.getInputAsBool(constants_1.Inputs.EnableCrossOsArchive);
+            const failOnCacheMiss = utils.getInputAsBool(constants_1.Inputs.FailOnCacheMiss);
             const cacheKey = yield cache.restoreCache(cachePaths, primaryKey, restoreKeys, {}, enableCrossOsArchive);
             if (!cacheKey) {
-                if (core.getBooleanInput(constants_1.Inputs.FailOnCacheMiss)) {
+                if (failOnCacheMiss) {
                     throw new Error(`Failed to restore cache entry. Exiting as fail-on-cache-miss is set. Input key: ${primaryKey}`);
                 }
                 core.info(`Cache not found for input keys: ${[
@@ -50511,7 +50512,7 @@ function restoreImpl(stateProvider) {
             stateProvider.setState(constants_1.State.CacheMatchedKey, cacheKey);
             const isExactKeyMatch = utils.isExactKeyMatch(core.getInput(constants_1.Inputs.Key, { required: true }), cacheKey);
             core.setOutput(constants_1.Outputs.CacheHit, isExactKeyMatch.toString());
-            if (!isExactKeyMatch && core.getBooleanInput(constants_1.Inputs.FailOnCacheMiss)) {
+            if (!isExactKeyMatch && failOnCacheMiss) {
                 throw new Error(`Restored cache key doesn't match the given input key. Exiting as fail-on-cache-miss is set. Input key: ${primaryKey}`);
             }
             core.info(`Cache restored from key: ${cacheKey}`);

--- a/dist/restore-only/index.js
+++ b/dist/restore-only/index.js
@@ -50498,7 +50498,7 @@ function restoreImpl(stateProvider) {
             const enableCrossOsArchive = utils.getInputAsBool(constants_1.Inputs.EnableCrossOsArchive);
             const cacheKey = yield cache.restoreCache(cachePaths, primaryKey, restoreKeys, {}, enableCrossOsArchive);
             if (!cacheKey) {
-                if (core.getBooleanInput(constants_1.Inputs.FailOnCacheMiss) == true) {
+                if (core.getBooleanInput(constants_1.Inputs.FailOnCacheMiss)) {
                     throw new Error(`Failed to restore cache entry. Exiting as fail-on-cache-miss is set. Input key: ${primaryKey}`);
                 }
                 core.info(`Cache not found for input keys: ${[
@@ -50511,8 +50511,7 @@ function restoreImpl(stateProvider) {
             stateProvider.setState(constants_1.State.CacheMatchedKey, cacheKey);
             const isExactKeyMatch = utils.isExactKeyMatch(core.getInput(constants_1.Inputs.Key, { required: true }), cacheKey);
             core.setOutput(constants_1.Outputs.CacheHit, isExactKeyMatch.toString());
-            if (!isExactKeyMatch &&
-                core.getBooleanInput(constants_1.Inputs.FailOnCacheMiss) == true) {
+            if (!isExactKeyMatch && core.getBooleanInput(constants_1.Inputs.FailOnCacheMiss)) {
                 throw new Error(`Restored cache key doesn't match the given input key. Exiting as fail-on-cache-miss is set. Input key: ${primaryKey}`);
             }
             core.info(`Cache restored from key: ${cacheKey}`);

--- a/dist/restore/index.js
+++ b/dist/restore/index.js
@@ -50512,9 +50512,6 @@ function restoreImpl(stateProvider) {
             stateProvider.setState(constants_1.State.CacheMatchedKey, cacheKey);
             const isExactKeyMatch = utils.isExactKeyMatch(core.getInput(constants_1.Inputs.Key, { required: true }), cacheKey);
             core.setOutput(constants_1.Outputs.CacheHit, isExactKeyMatch.toString());
-            if (!isExactKeyMatch && failOnCacheMiss) {
-                throw new Error(`Restored cache key doesn't match the given input key. Exiting as fail-on-cache-miss is set. Input key: ${primaryKey}`);
-            }
             core.info(`Cache restored from key: ${cacheKey}`);
             return cacheKey;
         }

--- a/dist/restore/index.js
+++ b/dist/restore/index.js
@@ -50496,9 +50496,10 @@ function restoreImpl(stateProvider) {
                 required: true
             });
             const enableCrossOsArchive = utils.getInputAsBool(constants_1.Inputs.EnableCrossOsArchive);
+            const failOnCacheMiss = utils.getInputAsBool(constants_1.Inputs.FailOnCacheMiss);
             const cacheKey = yield cache.restoreCache(cachePaths, primaryKey, restoreKeys, {}, enableCrossOsArchive);
             if (!cacheKey) {
-                if (core.getBooleanInput(constants_1.Inputs.FailOnCacheMiss)) {
+                if (failOnCacheMiss) {
                     throw new Error(`Failed to restore cache entry. Exiting as fail-on-cache-miss is set. Input key: ${primaryKey}`);
                 }
                 core.info(`Cache not found for input keys: ${[
@@ -50511,7 +50512,7 @@ function restoreImpl(stateProvider) {
             stateProvider.setState(constants_1.State.CacheMatchedKey, cacheKey);
             const isExactKeyMatch = utils.isExactKeyMatch(core.getInput(constants_1.Inputs.Key, { required: true }), cacheKey);
             core.setOutput(constants_1.Outputs.CacheHit, isExactKeyMatch.toString());
-            if (!isExactKeyMatch && core.getBooleanInput(constants_1.Inputs.FailOnCacheMiss)) {
+            if (!isExactKeyMatch && failOnCacheMiss) {
                 throw new Error(`Restored cache key doesn't match the given input key. Exiting as fail-on-cache-miss is set. Input key: ${primaryKey}`);
             }
             core.info(`Cache restored from key: ${cacheKey}`);

--- a/dist/restore/index.js
+++ b/dist/restore/index.js
@@ -50498,7 +50498,7 @@ function restoreImpl(stateProvider) {
             const enableCrossOsArchive = utils.getInputAsBool(constants_1.Inputs.EnableCrossOsArchive);
             const cacheKey = yield cache.restoreCache(cachePaths, primaryKey, restoreKeys, {}, enableCrossOsArchive);
             if (!cacheKey) {
-                if (core.getBooleanInput(constants_1.Inputs.FailOnCacheMiss) == true) {
+                if (core.getBooleanInput(constants_1.Inputs.FailOnCacheMiss)) {
                     throw new Error(`Failed to restore cache entry. Exiting as fail-on-cache-miss is set. Input key: ${primaryKey}`);
                 }
                 core.info(`Cache not found for input keys: ${[
@@ -50511,8 +50511,7 @@ function restoreImpl(stateProvider) {
             stateProvider.setState(constants_1.State.CacheMatchedKey, cacheKey);
             const isExactKeyMatch = utils.isExactKeyMatch(core.getInput(constants_1.Inputs.Key, { required: true }), cacheKey);
             core.setOutput(constants_1.Outputs.CacheHit, isExactKeyMatch.toString());
-            if (!isExactKeyMatch &&
-                core.getBooleanInput(constants_1.Inputs.FailOnCacheMiss) == true) {
+            if (!isExactKeyMatch && core.getBooleanInput(constants_1.Inputs.FailOnCacheMiss)) {
                 throw new Error(`Restored cache key doesn't match the given input key. Exiting as fail-on-cache-miss is set. Input key: ${primaryKey}`);
             }
             core.info(`Cache restored from key: ${cacheKey}`);

--- a/dist/save-only/index.js
+++ b/dist/save-only/index.js
@@ -5034,7 +5034,8 @@ var Inputs;
     Inputs["Path"] = "path";
     Inputs["RestoreKeys"] = "restore-keys";
     Inputs["UploadChunkSize"] = "upload-chunk-size";
-    Inputs["EnableCrossOsArchive"] = "enableCrossOsArchive"; // Input for cache, restore, save action
+    Inputs["EnableCrossOsArchive"] = "enableCrossOsArchive";
+    Inputs["FailOnCacheMiss"] = "fail-on-cache-miss"; // Input for cache, restore action
 })(Inputs = exports.Inputs || (exports.Inputs = {}));
 var Outputs;
 (function (Outputs) {

--- a/dist/save/index.js
+++ b/dist/save/index.js
@@ -4978,7 +4978,8 @@ var Inputs;
     Inputs["Path"] = "path";
     Inputs["RestoreKeys"] = "restore-keys";
     Inputs["UploadChunkSize"] = "upload-chunk-size";
-    Inputs["EnableCrossOsArchive"] = "enableCrossOsArchive"; // Input for cache, restore, save action
+    Inputs["EnableCrossOsArchive"] = "enableCrossOsArchive";
+    Inputs["FailOnCacheMiss"] = "fail-on-cache-miss"; // Input for cache, restore action
 })(Inputs = exports.Inputs || (exports.Inputs = {}));
 var Outputs;
 (function (Outputs) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cache",
-  "version": "3.2.3",
+  "version": "3.2.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "cache",
-      "version": "3.2.3",
+      "version": "3.2.4",
       "license": "MIT",
       "dependencies": {
         "@actions/cache": "^3.1.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cache",
-  "version": "3.2.3",
+  "version": "3.2.4",
   "private": true,
   "description": "Cache dependencies and build outputs",
   "main": "dist/restore/index.js",

--- a/restore/README.md
+++ b/restore/README.md
@@ -7,7 +7,7 @@ The restore action, as the name suggest, restores a cache. It acts similar to th
 * `path` - A list of files, directories, and wildcard patterns to cache and restore. See [`@actions/glob`](https://github.com/actions/toolkit/tree/main/packages/glob) for supported patterns.
 * `key` - String used while saving cache for restoring the cache
 * `restore-keys` - An ordered list of prefix-matched keys to use for restoring stale cache if no cache hit occurred for key.
-* `fail-on-cache-miss` - Fail the workflow if cache entry is not found
+* `fail-on-cache-miss` - Fail the workflow if cache entry is not found. Default: false
 
 ## Outputs
 

--- a/restore/README.md
+++ b/restore/README.md
@@ -7,7 +7,7 @@ The restore action, as the name suggest, restores a cache. It acts similar to th
 * `path` - A list of files, directories, and wildcard patterns to cache and restore. See [`@actions/glob`](https://github.com/actions/toolkit/tree/main/packages/glob) for supported patterns.
 * `key` - String used while saving cache for restoring the cache
 * `restore-keys` - An ordered list of prefix-matched keys to use for restoring stale cache if no cache hit occurred for key.
-* `fail-on-cache-miss` - Fail the workflow if no cache entry is not found
+* `fail-on-cache-miss` - Fail the workflow if cache entry is not found
 
 ## Outputs
 
@@ -96,7 +96,7 @@ steps:
 
 ### Exit workflow on cache miss
 
-You can use `fail-on-cache-miss: true` to exit the workflow on a cache miss. This way you can restrict your workflow to only initiate the build when a cache with the exact key is found. Make sure to leave `restore-keys` empty!
+You can use `fail-on-cache-miss: true` to exit the workflow on a cache miss. This way you can restrict your workflow to only initiate the build when a cache is matched. Also, if you want to fail if cache did not match primary key, additionally leave `restore-keys` empty!
 
 ```yaml
 steps:

--- a/restore/README.md
+++ b/restore/README.md
@@ -7,7 +7,7 @@ The restore action, as the name suggest, restores a cache. It acts similar to th
 * `path` - A list of files, directories, and wildcard patterns to cache and restore. See [`@actions/glob`](https://github.com/actions/toolkit/tree/main/packages/glob) for supported patterns.
 * `key` - String used while saving cache for restoring the cache
 * `restore-keys` - An ordered list of prefix-matched keys to use for restoring stale cache if no cache hit occurred for key.
-* `fail-on-cache-miss` - Fail the workflow if the cache is not found for the primary key
+* `fail-on-cache-miss` - Fail the workflow if the cache is not found for the primary key or no cache is found at all
 
 ## Outputs
 

--- a/restore/README.md
+++ b/restore/README.md
@@ -7,7 +7,7 @@ The restore action, as the name suggest, restores a cache. It acts similar to th
 * `path` - A list of files, directories, and wildcard patterns to cache and restore. See [`@actions/glob`](https://github.com/actions/toolkit/tree/main/packages/glob) for supported patterns.
 * `key` - String used while saving cache for restoring the cache
 * `restore-keys` - An ordered list of prefix-matched keys to use for restoring stale cache if no cache hit occurred for key.
-* `fail-on-cache-miss` - Fail the workflow if the cache is not found for the primary key or no cache is found at all
+* `fail-on-cache-miss` - Fail the workflow if no cache entry is not found
 
 ## Outputs
 
@@ -96,7 +96,7 @@ steps:
 
 ### Exit workflow on cache miss
 
-You can use `fail-on-cache-miss: true` to exit the workflow on a cache miss. This way you can restrict your workflow to only initiate the build when a cache with the exact key is found.
+You can use `fail-on-cache-miss: true` to exit the workflow on a cache miss. This way you can restrict your workflow to only initiate the build when a cache with the exact key is found. Make sure to leave `restore-keys` empty!
 
 ```yaml
 steps:

--- a/restore/README.md
+++ b/restore/README.md
@@ -7,6 +7,7 @@ The restore action, as the name suggest, restores a cache. It acts similar to th
 * `path` - A list of files, directories, and wildcard patterns to cache and restore. See [`@actions/glob`](https://github.com/actions/toolkit/tree/main/packages/glob) for supported patterns.
 * `key` - String used while saving cache for restoring the cache
 * `restore-keys` - An ordered list of prefix-matched keys to use for restoring stale cache if no cache hit occurred for key.
+* `fail-on-cache-miss` - Fail the workflow if the cache is not found for the primary key
 
 ## Outputs
 
@@ -95,7 +96,7 @@ steps:
 
 ### Exit workflow on cache miss
 
-You can use the output of this action to exit the workflow on cache miss. This way you can restrict your workflow to only initiate the build when `cache-hit` occurs, in other words, cache with exact key is found.
+You can use `fail-on-cache-miss: true` to exit the workflow on a cache miss. This way you can restrict your workflow to only initiate the build when a cache with the exact key is found.
 
 ```yaml
 steps:
@@ -106,10 +107,7 @@ steps:
     with:
       path: path/to/dependencies
       key: ${{ runner.os }}-${{ hashFiles('**/lockfiles') }}
-
-  - name: Check cache hit
-    if: steps.cache.outputs.cache-hit != 'true'
-    run: exit 1
+      fail-on-cache-miss: true
 
   - name: Build
     run: /build.sh

--- a/restore/action.yml
+++ b/restore/action.yml
@@ -16,7 +16,7 @@ inputs:
     default: 'false'
     required: false
   fail-on-cache-miss:
-    description: 'Fail the workflow if the cache is not found for the primary key or no cache is found at all'
+    description: 'Fail the workflow if no cache entry is not found'
     default: 'false'
     required: false
 outputs:

--- a/restore/action.yml
+++ b/restore/action.yml
@@ -16,7 +16,7 @@ inputs:
     default: 'false'
     required: false
   fail-on-cache-miss:
-    description: 'Fail the workflow if no cache entry is not found'
+    description: 'Fail the workflow if cache entry is not found'
     default: 'false'
     required: false
 outputs:

--- a/restore/action.yml
+++ b/restore/action.yml
@@ -15,6 +15,10 @@ inputs:
     description: 'An optional boolean when enabled, allows windows runners to restore caches that were saved on other platforms'
     default: 'false'
     required: false
+  fail-on-cache-miss:
+    description: 'Fail the workflow if the cache is not found for the primary key'
+    required: false
+    default: "false"
 outputs:
   cache-hit:
     description: 'A boolean value to indicate an exact match was found for the primary key'

--- a/restore/action.yml
+++ b/restore/action.yml
@@ -17,8 +17,8 @@ inputs:
     required: false
   fail-on-cache-miss:
     description: 'Fail the workflow if the cache is not found for the primary key'
+    default: 'false'
     required: false
-    default: "false"
 outputs:
   cache-hit:
     description: 'A boolean value to indicate an exact match was found for the primary key'

--- a/restore/action.yml
+++ b/restore/action.yml
@@ -16,7 +16,7 @@ inputs:
     default: 'false'
     required: false
   fail-on-cache-miss:
-    description: 'Fail the workflow if the cache is not found for the primary key'
+    description: 'Fail the workflow if the cache is not found for the primary key or no cache is found at all'
     default: 'false'
     required: false
 outputs:

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -3,7 +3,8 @@ export enum Inputs {
     Path = "path", // Input for cache, restore, save action
     RestoreKeys = "restore-keys", // Input for cache, restore action
     UploadChunkSize = "upload-chunk-size", // Input for cache, save action
-    EnableCrossOsArchive = "enableCrossOsArchive" // Input for cache, restore, save action
+    EnableCrossOsArchive = "enableCrossOsArchive", // Input for cache, restore, save action
+    FailOnCacheMiss = "fail-on-cache-miss" // Input for cache, restore action
 }
 
 export enum Outputs {

--- a/src/restoreImpl.ts
+++ b/src/restoreImpl.ts
@@ -44,6 +44,11 @@ async function restoreImpl(
         );
 
         if (!cacheKey) {
+            if (core.getBooleanInput(Inputs.FailOnCacheMiss) == true) {
+                throw new Error(
+                    `Failed to restore cache entry. Exiting as fail-on-cache-miss is set. Input key: ${primaryKey}`
+                );
+            }
             core.info(
                 `Cache not found for input keys: ${[
                     primaryKey,
@@ -63,6 +68,15 @@ async function restoreImpl(
         );
 
         core.setOutput(Outputs.CacheHit, isExactKeyMatch.toString());
+        if (
+            !isExactKeyMatch &&
+            core.getBooleanInput(Inputs.FailOnCacheMiss) == true
+        ) {
+            throw new Error(
+                `Restored cache key doesn't match the given input key. Exiting as fail-on-cache-miss is set. Input key: ${primaryKey}`
+            );
+        }
+
         core.info(`Cache restored from key: ${cacheKey}`);
 
         return cacheKey;

--- a/src/restoreImpl.ts
+++ b/src/restoreImpl.ts
@@ -69,12 +69,6 @@ async function restoreImpl(
         );
 
         core.setOutput(Outputs.CacheHit, isExactKeyMatch.toString());
-        if (!isExactKeyMatch && failOnCacheMiss) {
-            throw new Error(
-                `Restored cache key doesn't match the given input key. Exiting as fail-on-cache-miss is set. Input key: ${primaryKey}`
-            );
-        }
-
         core.info(`Cache restored from key: ${cacheKey}`);
 
         return cacheKey;

--- a/src/restoreImpl.ts
+++ b/src/restoreImpl.ts
@@ -34,6 +34,7 @@ async function restoreImpl(
         const enableCrossOsArchive = utils.getInputAsBool(
             Inputs.EnableCrossOsArchive
         );
+        const failOnCacheMiss = utils.getInputAsBool(Inputs.FailOnCacheMiss);
 
         const cacheKey = await cache.restoreCache(
             cachePaths,
@@ -44,7 +45,7 @@ async function restoreImpl(
         );
 
         if (!cacheKey) {
-            if (core.getBooleanInput(Inputs.FailOnCacheMiss)) {
+            if (failOnCacheMiss) {
                 throw new Error(
                     `Failed to restore cache entry. Exiting as fail-on-cache-miss is set. Input key: ${primaryKey}`
                 );
@@ -68,7 +69,7 @@ async function restoreImpl(
         );
 
         core.setOutput(Outputs.CacheHit, isExactKeyMatch.toString());
-        if (!isExactKeyMatch && core.getBooleanInput(Inputs.FailOnCacheMiss)) {
+        if (!isExactKeyMatch && failOnCacheMiss) {
             throw new Error(
                 `Restored cache key doesn't match the given input key. Exiting as fail-on-cache-miss is set. Input key: ${primaryKey}`
             );

--- a/src/restoreImpl.ts
+++ b/src/restoreImpl.ts
@@ -44,7 +44,7 @@ async function restoreImpl(
         );
 
         if (!cacheKey) {
-            if (core.getBooleanInput(Inputs.FailOnCacheMiss) == true) {
+            if (core.getBooleanInput(Inputs.FailOnCacheMiss)) {
                 throw new Error(
                     `Failed to restore cache entry. Exiting as fail-on-cache-miss is set. Input key: ${primaryKey}`
                 );
@@ -68,10 +68,7 @@ async function restoreImpl(
         );
 
         core.setOutput(Outputs.CacheHit, isExactKeyMatch.toString());
-        if (
-            !isExactKeyMatch &&
-            core.getBooleanInput(Inputs.FailOnCacheMiss) == true
-        ) {
+        if (!isExactKeyMatch && core.getBooleanInput(Inputs.FailOnCacheMiss)) {
             throw new Error(
                 `Restored cache key doesn't match the given input key. Exiting as fail-on-cache-miss is set. Input key: ${primaryKey}`
             );

--- a/src/utils/testUtils.ts
+++ b/src/utils/testUtils.ts
@@ -14,11 +14,13 @@ interface CacheInput {
     key: string;
     restoreKeys?: string[];
     enableCrossOsArchive?: boolean;
+    failOnCacheMiss?: boolean;
 }
 
 export function setInputs(input: CacheInput): void {
     setInput(Inputs.Path, input.path);
     setInput(Inputs.Key, input.key);
+    setInput(Inputs.FailOnCacheMiss, "false");
     input.restoreKeys &&
         setInput(Inputs.RestoreKeys, input.restoreKeys.join("\n"));
     input.enableCrossOsArchive !== undefined &&
@@ -26,12 +28,15 @@ export function setInputs(input: CacheInput): void {
             Inputs.EnableCrossOsArchive,
             input.enableCrossOsArchive.toString()
         );
+    input.failOnCacheMiss &&
+        setInput(Inputs.FailOnCacheMiss, String(input.failOnCacheMiss));
 }
 
 export function clearInputs(): void {
     delete process.env[getInputName(Inputs.Path)];
     delete process.env[getInputName(Inputs.Key)];
     delete process.env[getInputName(Inputs.RestoreKeys)];
+    delete process.env[getInputName(Inputs.FailOnCacheMiss)];
     delete process.env[getInputName(Inputs.UploadChunkSize)];
     delete process.env[getInputName(Inputs.EnableCrossOsArchive)];
 }

--- a/src/utils/testUtils.ts
+++ b/src/utils/testUtils.ts
@@ -14,7 +14,7 @@ interface CacheInput {
     key: string;
     restoreKeys?: string[];
     enableCrossOsArchive?: boolean;
-    failOnCacheMiss?: boolean;
+    failOnCacheMiss?: string;
 }
 
 export function setInputs(input: CacheInput): void {
@@ -29,7 +29,7 @@ export function setInputs(input: CacheInput): void {
             input.enableCrossOsArchive.toString()
         );
     input.failOnCacheMiss &&
-        setInput(Inputs.FailOnCacheMiss, String(input.failOnCacheMiss));
+        setInput(Inputs.FailOnCacheMiss, input.failOnCacheMiss);
 }
 
 export function clearInputs(): void {

--- a/src/utils/testUtils.ts
+++ b/src/utils/testUtils.ts
@@ -14,13 +14,12 @@ interface CacheInput {
     key: string;
     restoreKeys?: string[];
     enableCrossOsArchive?: boolean;
-    failOnCacheMiss?: string;
+    failOnCacheMiss?: boolean;
 }
 
 export function setInputs(input: CacheInput): void {
     setInput(Inputs.Path, input.path);
     setInput(Inputs.Key, input.key);
-    setInput(Inputs.FailOnCacheMiss, "false");
     input.restoreKeys &&
         setInput(Inputs.RestoreKeys, input.restoreKeys.join("\n"));
     input.enableCrossOsArchive !== undefined &&
@@ -28,15 +27,15 @@ export function setInputs(input: CacheInput): void {
             Inputs.EnableCrossOsArchive,
             input.enableCrossOsArchive.toString()
         );
-    input.failOnCacheMiss &&
-        setInput(Inputs.FailOnCacheMiss, input.failOnCacheMiss);
+    input.failOnCacheMiss !== undefined &&
+        setInput(Inputs.FailOnCacheMiss, input.failOnCacheMiss.toString());
 }
 
 export function clearInputs(): void {
     delete process.env[getInputName(Inputs.Path)];
     delete process.env[getInputName(Inputs.Key)];
     delete process.env[getInputName(Inputs.RestoreKeys)];
-    delete process.env[getInputName(Inputs.FailOnCacheMiss)];
     delete process.env[getInputName(Inputs.UploadChunkSize)];
     delete process.env[getInputName(Inputs.EnableCrossOsArchive)];
+    delete process.env[getInputName(Inputs.FailOnCacheMiss)];
 }


### PR DESCRIPTION
## Description
Add an advanced option to fail job if cache miss occurs.
Based on the work from @kotewar which was reverted in https://github.com/actions/cache/pull/1006/commits/11ab7ccfa2803e57082f50b6bcf6d627d72f6b26.


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes #955 and partially https://github.com/actions/cache/discussions/1020#discussioncomment-4341251

This is already possible via the `cache-hit` output. However, especially for advanced workflows, this quickly becomes cumbersome to add every time. It's also an additional 3 line for each job and doesn't include a good error message.
```yaml
  - name: Check cache hit
    if: steps.cache.outputs.cache-hit != 'true'
    run: exit 1
```

As mentioned in https://github.com/actions/cache/issues/955#issuecomment-1362681576, the goal to simplify the configuration doesn't exclude the possibility to help with more advanced use cases. Including the new option will make it easier to use, help keep workflows more readable, and enable better error messages.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Added test cases and run a test workflow using the feature branch.

## Screenshots (if appropriate):
 --

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (add or update README or docs)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
