### PR TITLE
README.md: remove outdated Windows cache tip link

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,7 +245,6 @@ Following are some of the known practices/workarounds which community has used t
 - [Cache segment restore timeout](./tips-and-workarounds.md#cache-segment-restore-timeout)
 - [Update a cache](./tips-and-workarounds.md#update-a-cache)
 - [Use cache across feature branches](./tips-and-workarounds.md#use-cache-across-feature-branches)
-- [Improving cache restore performance on Windows/Using cross-os caching](./tips-and-workarounds.md#improving-cache-restore-performance-on-windows-using-cross-os-caching)
 - [Force deletion of caches overriding default cache eviction policy](./tips-and-workarounds.md#force-deletion-of-caches-overriding-default-cache-eviction-policy)
 
 #### Windows environment variables


### PR DESCRIPTION
## Description
As of 9b0be58 (Release compression related changes for windows (#1039), 2022-12-23), the section of tips-and-workarounds.md referring to improving cache restore performance on Windows no longer exists, so don't link to it from README.md.

## Motivation and Context
See above: this is a small change to README.md to remove a link that's no longer needed.

## How Has This Been Tested?
-   GitHub Actions run of the test scripts at https://github.com/me-and/cache/actions/runs/3771529989
-   Visual check of the rendering at https://github.com/me-and/cache/tree/correct-readme-re-windows#known-practices-and-workarounds

## Screenshots (if appropriate):
Not applicable.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation (add or update README or docs)

## Checklist:
- [ ] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.