### PR TITLE
Fix formatting error in restore/README.md

### DIFF
--- a/restore/README.md
+++ b/restore/README.md
@@ -120,7 +120,7 @@ steps:
 
 #### Reusing primary key and restored key in the save action
 
-Usually you may want to use same `key` in both actions/cache/restore` and `actions/cache/save` action. To achieve this, use `outputs` from the restore action to reuse the same primary key (or the key of the cache that was restored).
+Usually you may want to use same `key` in both `actions/cache/restore` and `actions/cache/save` action. To achieve this, use `outputs` from the restore action to reuse the same primary key (or the key of the cache that was restored).
 
 #### Using restore action outputs to make save action behave just like the cache action
 


### PR DESCRIPTION
A missing backtick caused a formatting error in `restore/README.md`

## Description
Add the missing backtick.

## Motivation and Context
This is a trivial fix to a formatting issue in `restore/README.md`

## How Has This Been Tested?
Visually checked the new formatting.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation (add or update README or docs)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
