### PR TITLE
:memo: #1045 update using the `set-output` command is deprecated

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ Additionally, you can use arbitrary command output in a cache key, such as a dat
   - name: Get Date
     id: get-date
     run: |
-      echo "::set-output name=date::$(/bin/date -u "+%Y%m%d")"
+      echo "date=$(/bin/date -u "+%Y%m%d")" >> $GITHUB_OUTPUT
     shell: bash
 
   - uses: actions/cache@v3

--- a/examples.md
+++ b/examples.md
@@ -357,7 +357,7 @@ The yarn cache directory will depend on your operating system and version of `ya
 ```yaml
 - name: Get yarn cache directory path
   id: yarn-cache-dir-path
-  run: echo "::set-output name=dir::$(yarn cache dir)"
+  run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
 
 - uses: actions/cache@v3
   id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
@@ -375,7 +375,7 @@ The yarn 2 cache directory will depend on your config. See https://yarnpkg.com/c
 ```yaml
 - name: Get yarn cache directory path
   id: yarn-cache-dir-path
-  run: echo "::set-output name=dir::$(yarn config get cacheFolder)"
+  run: echo "dir=$(yarn config get cacheFolder)" >> $GITHUB_OUTPUT
 
 - uses: actions/cache@v3
   id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
@@ -420,7 +420,7 @@ Esy allows you to export built dependencies and import pre-built dependencies.
 - name: Get Composer Cache Directory
   id: composer-cache
   run: |
-    echo "::set-output name=dir::$(composer config cache-files-dir)"
+    echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
 - uses: actions/cache@v3
   with:
     path: ${{ steps.composer-cache.outputs.dir }}
@@ -512,7 +512,7 @@ jobs:
 - name: Get pip cache dir
   id: pip-cache
   run: |
-    echo "::set-output name=dir::$(pip cache dir)"
+    echo "dir=$(pip cache dir)" >> $GITHUB_OUTPUT
 
 - name: pip cache
   uses: actions/cache@v3


### PR DESCRIPTION
The use of `save-state` and `set-output` commands is deprecated ([See on the GitHub Blog](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands)).

I previously created an issue about this (#1045).

This PR updates the README.md and example.md files as shown in [blog example](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/#examples).

Below is a screenshot of the blog example:

![blog-example](https://user-images.githubusercontent.com/62618356/209511794-88ae4b0a-ece2-4b46-af3d-bacf6da41d9c.png)
