### PR TITLE
Bug: Permission is missing in cache delete example

### DIFF
--- a/tips-and-workarounds.md
+++ b/tips-and-workarounds.md
@@ -44,6 +44,11 @@ on:
 jobs:
   cleanup:
     runs-on: ubuntu-latest
+    permissions:
+      # `actions:write` permission is required to delete caches
+      #   See also: https://docs.github.com/en/rest/actions/cache?apiVersion=2022-11-28#delete-a-github-actions-cache-for-a-repository-using-a-cache-id
+      actions: write
+      contents: read
     steps:
       - name: Check out code
         uses: actions/checkout@v3


### PR DESCRIPTION
Add permission to delete cache with `gh-actions-cache`

## Description
According to the API documentation, `actions:write` permission is at least required.
( Referred to https://docs.github.com/en/rest/actions/cache?apiVersion=2022-11-28#delete-a-github-actions-cache-for-a-repository-using-a-cache-id )

## Motivation and Context
My action based on the example has failed to delete with `ERROR: Resource not accessible by integration`.
Log: https://github.com/kotokaze/texlive/actions/runs/4272709474/jobs/7438088882
<img width="840" alt="image" src="https://user-images.githubusercontent.com/62094392/221388520-160c022d-85d3-4c19-88d4-618ce16322e3.png">

## How Has This Been Tested?
The action deleted caches as expected by adding `actions:write` permission
Log: https://github.com/kotokaze/texlive/actions/runs/4273085511/jobs/7438755085

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation (add or update README or docs)

## Checklist:
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
