### PR TITLE
Add Hugo resources example

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,7 @@ See [Examples](examples.md) for a list of `actions/cache` implementations for us
 * [Go - Modules](./examples.md#go---modules)
 * [Haskell - Cabal](./examples.md#haskell---cabal)
 * [Haskell - Stack](./examples.md#haskell---stack)
+* [Hugo - Resources](./examples.md#hugo---resources)
 * [Java - Gradle](./examples.md#java---gradle)
 * [Java - Maven](./examples.md#java---maven)
 * [Node - npm](./examples.md#node---npm)

--- a/examples.md
+++ b/examples.md
@@ -17,6 +17,7 @@
   - [Windows](#windows-2)
 - [Haskell - Cabal](#haskell---cabal)
 - [Haskell - Stack](#haskell---stack)
+- [Hugo - Resources](#hugo---resources)
 - [Java - Gradle](#java---gradle)
 - [Java - Maven](#java---maven)
 - [Node - npm](#node---npm)
@@ -277,6 +278,15 @@ We cache the elements of the Cabal store separately, as the entirety of `~/.caba
     key: ${{ runner.os }}-stack-work-${{ hashFiles('stack.yaml') }}-${{ hashFiles('package.yaml') }}-${{ hashFiles('**/*.hs') }}
     restore-keys: |
       ${{ runner.os }}-stack-work-
+```
+
+## Hugo - Resources
+
+```yaml
+- uses: actions/cache@v3
+  with:
+    path: resources
+    key: ${{ runner.os }}-hugo-resources
 ```
 
 ## Java - Gradle


### PR DESCRIPTION
## Description
This PR adds an example for caching the `resources` folder in Hugo builds.

## Motivation and Context
Caching the `resources` folder greatly reduces the building time in Hugo, specially for sites with lots of images.

## How Has This Been Tested?
In my own tests, building time is reduced from 4–5 minutes to less than 1 minute. Reducing processing times is always good at least for the planet 🌱🌍.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation (add or update README or docs)

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
