### PR TITLE
Mention empty possibility for `outputs.cache-hit`

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ If you are using a `self-hosted` Windows runner, `GNU tar` and `zstd` are requir
 
 ### Outputs
 
-* `cache-hit` - A boolean value to indicate an exact match was found for the key.
+* `cache-hit` - A boolean value to indicate an exact match was found for the key, or empty (not set) if no cache was restored.
 
     > **Note** `cache-hit` will only be set to `true` when a cache hit occurs for the exact `key` match. For a partial key match via `restore-keys` or a cache miss, it will be set to `false`.
 

--- a/restore/README.md
+++ b/restore/README.md
@@ -14,7 +14,7 @@ The restore action restores a cache. It works similarly to the `cache` action ex
 
 ### Outputs
 
-* `cache-hit` - A boolean value to indicate an exact match was found for the key.
+* `cache-hit` - A boolean value to indicate an exact match was found for the key, or empty (not set) if no cache was restored.
 * `cache-primary-key` - Cache primary key passed in the input to use in subsequent steps of the workflow.
 * `cache-matched-key` - Key of the cache that was restored, it could either be the primary key on cache-hit or a partial/complete match of one of the restore keys.
 


### PR DESCRIPTION
The `outputs.cache-hit` used to indicate that the value is a boolean, which means `true` or `false`. However, `outputs.cache-hit` is not set when there is no cache restored. I discovered this the hard way and also @aparna-ravindra mentioned it in https://github.com/github/docs/pull/18524#issuecomment-1161626882:

> However, if no cache was restored (either on the primary key or the restore-keys), then the cache-hit output value is not set.
