### PR TITLE
Fix cabal store path for gh-action Ubuntu

### DIFF
--- a/examples.md
+++ b/examples.md
@@ -223,15 +223,15 @@ steps:
 
 ## Haskell - Cabal
 
-We cache the elements of the Cabal store separately, as the entirety of `~/.cabal` can grow very large for projects with many dependencies.
+We cache the elements of the Cabal store.
 
 ```yaml
 - name: Cache ~/.cabal/packages, ~/.cabal/store and dist-newstyle
   uses: actions/cache@v3
   with:
     path: |
-      ~/.cabal/packages
-      ~/.cabal/store
+      ~/.cache/cabal/packages
+      ~/.local/state/cabal
       dist-newstyle
     key: ${{ runner.os }}-${{ matrix.ghc }}-${{ hashFiles('**/*.cabal', '**/cabal.project', '**/cabal.project.freeze') }}
     restore-keys: ${{ runner.os }}-${{ matrix.ghc }}-


### PR DESCRIPTION
Nothing's cached when applying suggested configuration for cabal caching. Exploring the Ubuntu image, it happens that cabal does not store its data in ~/.cabal but, instead, in:

* ~/.cache/cabal/packages
 * ~/.local/state/cabal

You can see this CI using this configuration: https://github.com/pgrange/to_remove_cache/blob/main/.github/workflows/blank.yml

## Description

Fix suggested configuration for cabal.

## Motivation and Context

The cache was not working for me and it took me some time to figure out that the cache was not looking into the appropriate paths.

## How Has This Been Tested?

See this exemple CI: https://github.com/pgrange/to_remove_cache/blob/main/.github/workflows/blank.yml


See this CI run where we can see something's been fetched from the cache: https://github.com/pgrange/to_remove_cache/actions/runs/5216337562/jobs/9414956883

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x ] Documentation (add or update README or docs)

## Checklist:
- [x ] My code follows the code style of this project.
- [ x] My change requires a change to the documentation.
- [ x] I have updated the documentation accordingly.
- [ x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
