### PR TITLE
Add an example enabling Rust incremental builds

### DIFF
--- a/examples.md
+++ b/examples.md
@@ -596,7 +596,26 @@ whenever possible:
       ~/.cargo/registry/cache/
       ~/.cargo/git/db/
       target/
-    key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+    key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock', 'rust-toolchain.toml') }}
+```
+
+Since Rust compile times are so long, you might want to take advantage of incremental builds. To do this, use the configuration below.
+- Include the `run_id` in the key to force `actions/cache` to upload a new snapshot after every build.
+- Use `restore-keys:` to load the previous build (when there are multiple partial matches, it selects the most recent).
+
+```yaml
+- uses: actions/cache@v3
+  with:
+    path: |
+      ~/.cargo/bin/
+      ~/.cargo/registry/index/
+      ~/.cargo/registry/cache/
+      ~/.cargo/git/db/
+      ~/.rustup/
+      target/
+    key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock', 'rust-toolchain.toml') }}-${{ github.run_id }}
+    restore-keys: |
+      ${{ runner.os }}-cargo-${{ hashFiles(**/'Cargo.lock', 'rust-toolchain.toml') }}
 ```
 
 ## Scala - SBT


### PR DESCRIPTION
## Description

Add an example of how to get the most out of Rust incremental builds.

Also, changes to rust-toolchain.toml should invalidate the cache.

## Motivation and Context

Our Rust builds were taking too long. Rust has a notoriously slow compiler, and we expect many users have the same problem.

Rust's compiler has a feature to help in this situation: incremental builds. `actions/cache` does not directly support having each job start with the build directory produced by the previous successful build. But Rust's compiler can save a significant amount of work if you do things this way. In each build, it only has to compile the code that has actually changed.

With a typical `actions/cache` configuration, Rust ends up doing more and more work with each push, as the changes between the cached build and the current build accumulate. With the example added in this PR, the cached build will be the latest. Incremental builds will then kick in automatically (you don't have to pass any special flags to `cargo`).

The only downside is that this produces more cache entries. It creates a new cache entry after _every_ successful run, not just when the cache is invalidated. I don't know if that's likely to make problems for anyone. If so, let's talk about it.

## How Has This Been Tested?

We've been using this technique in @github/blackbird for months now.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation (add or update README or docs)

## Checklist:
I don't think any of this applies to this minor docs-only change.
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
