### PR TITLE
Remove actions to add new PRs and issues to a project board

### DIFF
--- a/.github/workflows/issue-opened-workflow.yml
+++ b/.github/workflows/issue-opened-workflow.yml
@@ -14,9 +14,3 @@ jobs:
     - name: add_assignees
       run: |
         curl -X POST -H "Accept: application/vnd.github+json" -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN}}" https://api.github.com/repos/${{github.repository}}/issues/${{ github.event.issue.number}}/assignees -d '{"assignees":["${{steps.oncall.outputs.CURRENT}}"]}'
-
-    - uses: actions/add-to-project@v0.4.0
-      name: Add to Project Board
-      with:
-        project-url: https://github.com/orgs/actions/projects/12                       
-        github-token: ${{ secrets.CACHE_BOARD_TOKEN }}

--- a/.github/workflows/pr-opened-workflow.yml
+++ b/.github/workflows/pr-opened-workflow.yml
@@ -18,9 +18,3 @@ jobs:
     - name: Add Assignee
       run: |
         curl -X POST -H "Accept: application/vnd.github+json" -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN}}" https://api.github.com/repos/${{github.repository}}/issues/${{ github.event.pull_request.number}}/assignees -d '{"assignees":["${{steps.oncall.outputs.CURRENT}}"]}'    
-
-    - uses: actions/add-to-project@v0.4.0
-      name: Add to Project Board
-      with:
-        project-url: https://github.com/orgs/actions/projects/12                       
-        github-token: ${{ secrets.CACHE_BOARD_TOKEN }}


### PR DESCRIPTION
## Description

Remove the actions to add new PRs and new issues to a nonexistent project board.

## Motivation and Context

Every PR to this repo seems to fail CI. There is a job in the "new PR" workflow that tries to add the new repo to a project board. The project doesn't seem to exist, so this always fails.

This PR simply removes the broken step and a corresponding step in the "new issue" workflow. Maybe that's the right thing?

## How Has This Been Tested?

I guess we'll see if this PR passes CI!

## Types of changes

Actions only.

## Checklist:
- [x] I have read the **CONTRIBUTING** document.
- [ ] All new and existing tests passed.
