### PR TITLE
feat: bump to use node20 runtime, actions/checkout to v4

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -17,7 +17,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
     - name: Setup Node.js 16.x
       uses: actions/setup-node@v3
       with:
@@ -43,7 +43,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
     - name: Generate files in working directory
       shell: bash
       run: __tests__/create-cache-files.sh ${{ runner.os }} test-cache
@@ -66,7 +66,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
     - name: Restore cache
       uses: ./
       with:
@@ -96,7 +96,7 @@ jobs:
       https_proxy: http://squid-proxy:3128
     steps:
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
     - name: Generate files
       run: __tests__/create-cache-files.sh proxy test-cache
     - name: Save cache
@@ -119,7 +119,7 @@ jobs:
       https_proxy: http://squid-proxy:3128
     steps:
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
     - name: Restore cache
       uses: ./
       with:

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Cache Primes
       id: cache-primes
@@ -117,7 +117,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Restore cached Primes
       id: cache-primes-restore
@@ -224,7 +224,7 @@ Example:
 
 ```yaml
 steps:
-  - uses: actions/checkout@v3
+  - uses: actions/checkout@v4
 
   - uses: actions/cache@v3
     id: cache
@@ -254,7 +254,7 @@ jobs:
   build-linux:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Cache Primes
         id: cache-primes
@@ -281,7 +281,7 @@ jobs:
   build-windows:
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Cache Primes
         id: cache-primes

--- a/action.yml
+++ b/action.yml
@@ -30,7 +30,7 @@ outputs:
   cache-hit:
     description: 'A boolean value to indicate an exact match was found for the primary key'
 runs:
-  using: 'node16'
+  using: 'node20'
   main: 'dist/restore/index.js'
   post: 'dist/save/index.js'
   post-if: success()

--- a/caching-strategies.md
+++ b/caching-strategies.md
@@ -146,7 +146,7 @@ In case you are using a centralized job to create and save your cache that can b
 
 ```yaml
 steps:
-  - uses: actions/checkout@v3
+  - uses: actions/checkout@v4
 
   - uses: actions/cache/restore@v3
     id: cache
@@ -171,7 +171,7 @@ You can use the output of this action to exit the workflow on cache miss. This w
 
 ```yaml
 steps:
-  - uses: actions/checkout@v3
+  - uses: actions/checkout@v4
 
   - uses: actions/cache/restore@v3
     id: cache
@@ -249,7 +249,7 @@ Similarly, `actions/cache/save` action can be conditionally used based on the ou
 
 ```yaml
 steps:
-  - uses: actions/checkout@v3
+  - uses: actions/checkout@v4
   .
   . // restore if need be
   .
@@ -270,7 +270,7 @@ In case of multi-module projects, where the built artifact of one project needs 
 
 ```yaml
 steps:
-  - uses: actions/checkout@v3
+  - uses: actions/checkout@v4
 
   - name: Build
     run: ./build-parent-module.sh
@@ -286,7 +286,7 @@ steps:
 
 ```yaml
 steps:
-  - uses: actions/checkout@v3
+  - uses: actions/checkout@v4
 
   - uses: actions/cache/restore@v3
     id: cache

--- a/restore/README.md
+++ b/restore/README.md
@@ -35,7 +35,7 @@ If you are using separate jobs to create and save your cache(s) to be reused by 
 
 ```yaml
 steps:
-  - uses: actions/checkout@v3
+  - uses: actions/checkout@v4
 
   - uses: actions/cache/restore@v3
     id: cache
@@ -64,7 +64,7 @@ In case of multi-module projects, where the built artifact of one project needs 
 
 ```yaml
 steps:
-  - uses: actions/checkout@v3
+  - uses: actions/checkout@v4
 
   - name: Build
     run: /build-parent-module.sh
@@ -80,7 +80,7 @@ steps:
 
 ```yaml
 steps:
-  - uses: actions/checkout@v3
+  - uses: actions/checkout@v4
 
   - uses: actions/cache/restore@v3
     id: cache
@@ -107,7 +107,7 @@ To fail if there is no cache hit for the primary key, leave `restore-keys` empty
 
 ```yaml
 steps:
-  - uses: actions/checkout@v3
+  - uses: actions/checkout@v4
 
   - uses: actions/cache/restore@v3
     id: cache

--- a/restore/action.yml
+++ b/restore/action.yml
@@ -31,7 +31,7 @@ outputs:
   cache-matched-key:
     description: 'Key of the cache that was restored, it could either be the primary key on cache-hit or a partial/complete match of one of the restore keys'
 runs:
-  using: 'node16'
+  using: 'node20'
   main: '../dist/restore-only/index.js'
 branding:
   icon: 'archive'

--- a/save/README.md
+++ b/save/README.md
@@ -23,7 +23,7 @@ If you are using separate jobs for generating common artifacts and sharing them 
 
 ```yaml
 steps:
-  - uses: actions/checkout@v3
+  - uses: actions/checkout@v4
 
   - name: Install Dependencies
     run: /install.sh
@@ -74,7 +74,7 @@ There are instances where some flaky test cases would fail the entire workflow a
 
 ```yaml
 steps:
-  - uses: actions/checkout@v3
+  - uses: actions/checkout@v4
   .
   . // restore if need be
   .

--- a/save/action.yml
+++ b/save/action.yml
@@ -16,7 +16,7 @@ inputs:
     default: 'false'
     required: false
 runs:
-  using: 'node16'
+  using: 'node20'
   main: '../dist/save-only/index.js'
 branding:
   icon: 'archive'

--- a/tips-and-workarounds.md
+++ b/tips-and-workarounds.md
@@ -61,7 +61,7 @@ jobs:
       contents: read
     steps:
       - name: Check out code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Cleanup
         run: |


### PR DESCRIPTION
**Description and Context:**

Node 16 reaches the [end of life soon on 11 Sep 2023](https://nodejs.org/en/blog/announcements/nodejs16-eol). This PR updates the default runtime to `node20` (Node 20). I have also bumped the `actions/checkout` version to v4 for the same.

**Related issue:**

https://github.com/actions/runner/pull/2732

-----------------
A major version bump might be needed after the PRs merge.