### PR TITLE
Improve cargo example

### DIFF
--- a/examples.md
+++ b/examples.md
@@ -589,14 +589,20 @@ whenever possible:
 
 ```yaml
 - uses: actions/cache@v3
+  env: 
+    BUILD_TYPE: debug # adjust when using `--release` or custom targets
   with:
     path: |
+      ~/.cargo/.crates.toml
+      ~/.cargo/.crates2.json
       ~/.cargo/bin/
       ~/.cargo/registry/index/
       ~/.cargo/registry/cache/
       ~/.cargo/git/db/
       target/
-    key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+    key: ${{ runner.os }}-cargo-${{ env.BUILD_TYPE }}-${{ hashFiles('**/Cargo.lock') }}
+    restore-keys: |
+      ${{ runner.os }}-cargo-${{ env.BUILD_TYPE }}-
 ```
 
 ## Scala - SBT


### PR DESCRIPTION
Adds `restore-keys` for cargo - this helps improve build times by allowing the cache to be mostly pre-populated when deps are updated.

Adds two missing cache files.

Adds a build type parameter to the cache keys to account for different build profiles / targets.

<!--- Provide a general summary of your changes in the Title above -->

## Description

Example improvement for use with `cargo`.

## Motivation and Context
- Not all desired cache files were included
- Restoring the cache when deps change is very beneficial
- Easy build target parameter is very useful when using the cache for different build targets (very common to build debug for a tests job and release for some kind of publish job).

## How Has This Been Tested?

It's docs

## Screenshots (if appropriate):

## Types of changes
- [x] Documentation (add or update README or docs)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
