### PR TITLE
README: clarify that `cache-hit` returns a string and not a boolean

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,9 +65,9 @@ If you are using a `self-hosted` Windows runner, `GNU tar` and `zstd` are requir
 
 ### Outputs
 
-* `cache-hit` - A boolean value to indicate an exact match was found for the key.
+* `cache-hit` - A string `'true'` or `'false'` indicating whether an exact match was found for the key.
 
-    > **Note** `cache-hit` will only be set to `true` when a cache hit occurs for the exact `key` match. For a partial key match via `restore-keys` or a cache miss, it will be set to `false`.
+    > **Note** `cache-hit` will only be set to `'true'` when a cache hit occurs for the exact `key` match. For a partial key match via `restore-keys` or a cache miss, it will be set to `'false'`.
 
 See [Skipping steps based on cache-hit](#skipping-steps-based-on-cache-hit) for info on using this output
 

--- a/README.md
+++ b/README.md
@@ -65,11 +65,12 @@ If you are using a `self-hosted` Windows runner, `GNU tar` and `zstd` are requir
 
 ### Outputs
 
-* `cache-hit` - A string `'true'` or `'false'` indicating whether an exact match was found for the key.
+* `cache-hit` - A string with three possible values indicating whether a matching cache was found:
+  1. `'true'` if a cache exactly matching `key` was found.
+  2. `'false'` if a cache matching one of the `restore-keys` was found.
+  3. Empty if no matching cache was found (cache miss).
 
-    > **Note** `cache-hit` will only be set to `'true'` when a cache hit occurs for the exact `key` match. For a partial key match via `restore-keys` or a cache miss, it will be set to `'false'`.
-
-See [Skipping steps based on cache-hit](#skipping-steps-based-on-cache-hit) for info on using this output
+See [Skipping steps based on cache-hit](#skipping-steps-based-on-cache-hit) for info on using this output.
 
 ### Cache scopes
 

--- a/restore/README.md
+++ b/restore/README.md
@@ -14,12 +14,13 @@ The restore action restores a cache. It works similarly to the `cache` action ex
 
 ### Outputs
 
-* `cache-hit` - A string `'true'` or `'false'` to indicate whether an exact match was found for the key.
+* `cache-hit` - A string with three possible values indicating whether a matching cache was found:
+  1. `'true'` if a cache exactly matching `key` was found.
+     In this case, `cache-primary-key == cache-matched-key`.
+  2. `'false'` if a cache matching one of the `restore-keys` was found.
+  3. Empty if no matching cache was found (cache miss).
 * `cache-primary-key` - Cache primary key passed in the input to use in subsequent steps of the workflow.
 * `cache-matched-key` - Key of the cache that was restored, it could either be the primary key on cache-hit or a partial/complete match of one of the restore keys.
-
-> **Note**
-`cache-hit` will be set to `'true'` only when cache hit occurs for the exact `key` match. For a partial key match via `restore-keys` or a cache miss, it will be set to `'false'`.
 
 ### Environment Variables
 

--- a/restore/README.md
+++ b/restore/README.md
@@ -14,12 +14,12 @@ The restore action restores a cache. It works similarly to the `cache` action ex
 
 ### Outputs
 
-* `cache-hit` - A boolean value to indicate an exact match was found for the key.
+* `cache-hit` - A string `'true'` or `'false'` to indicate whether an exact match was found for the key.
 * `cache-primary-key` - Cache primary key passed in the input to use in subsequent steps of the workflow.
 * `cache-matched-key` - Key of the cache that was restored, it could either be the primary key on cache-hit or a partial/complete match of one of the restore keys.
 
 > **Note**
-`cache-hit` will be set to `true` only when cache hit occurs for the exact `key` match. For a partial key match via `restore-keys` or a cache miss, it will be set to `false`.
+`cache-hit` will be set to `'true'` only when cache hit occurs for the exact `key` match. For a partial key match via `restore-keys` or a cache miss, it will be set to `'false'`.
 
 ### Environment Variables
 


### PR DESCRIPTION
Rationale: if `cache-hit` was a boolean, then `!` could be used to get the opposite.
However, it is really a string, and this should be pointed out clearly in the documentation.
Because both `!'true'` and `!'false'` are `false`, so customers can shoot themselves in the foot here.

Closes #1262.
