### PR TITLE
Add force-overwrite for cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,10 @@ See ["Caching dependencies to speed up workflows"](https://docs.github.com/en/ac
 
 ## What's New
 
+### Unreleased
+
+* Added the `force-overwrite` flag to force overwrite any existing cache for incremental caching
+
 ### v4
 
 * Updated to node 20

--- a/action.yml
+++ b/action.yml
@@ -29,7 +29,11 @@ inputs:
   save-always:
     description: 'Run the post step to save the cache even if another step before fails'
     default: 'false'
-    required: false    
+    required: false
+  force-overwrite:
+    description: 'Delete any previous (incremental) cache before pushing a new cache even if a cache for the primary cache key exists'
+    default: 'false'
+    required: false
 outputs:
   cache-hit:
     description: 'A boolean value to indicate an exact match was found for the primary key'

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -5,7 +5,8 @@ export enum Inputs {
     UploadChunkSize = "upload-chunk-size", // Input for cache, save action
     EnableCrossOsArchive = "enableCrossOsArchive", // Input for cache, restore, save action
     FailOnCacheMiss = "fail-on-cache-miss", // Input for cache, restore action
-    LookupOnly = "lookup-only" // Input for cache, restore action
+    LookupOnly = "lookup-only", // Input for cache, restore action
+    ForceOverwrite = "force-overwrite" // Input for cache action
 }
 
 export enum Outputs {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This PR adds a `force-overwrite` options to force overwrite an already existing cache.

## Motivation and Context
When working with very long workflows and incremental changes any tiny change in cache can be helpful. That's why currently I delete a cache when it exists with the following workflow:

```yml
- name: Pull PHPStan cache
  id: pull-phpstan-cache
  uses: actions/cache/restore@v3
  with:
    path: ${{ env.PHPSTAN_CACHE_DIR }}
    key: phpstan-${{ github.ref_name }}
    restore-keys: |
      phpstan

- name: Run PHPStan
  run: composer run stan

- name: Install gh-actions cache plugin
  if: always()
  run: gh extension install actions/gh-actions-cache

- name: Clear previous version of PHPStan branch cache
  if: always()
  continue-on-error: true
  run: gh actions-cache delete phpstan-${{ github.ref_name }} -B ${{ github.ref }} --confirm

- name: Push PHPStan branch cache
  if: always()
  uses: actions/cache/save@v3
  with:
    path: ${{ env.PHPSTAN_CACHE_DIR }}
    key: phpstan-${{ github.ref_name }}
```

For context: without any caching the job will take about 20 minutes. With a main cache and a 'branch cache' that is never updated again, the job will take a few minutes after the first commit, but every next change results in the cache being further out of date and the job taking longer and longer. That's why deleting the existing cache will speed things up significantly.

## How Has This Been Tested?
N/A

## Screenshots (if appropriate):
N/A

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (add or update README or docs)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
