### PR TITLE
docs: fix cleanup example to use pull_request_target trigger

### DIFF
--- a/tips-and-workarounds.md
+++ b/tips-and-workarounds.md
@@ -46,7 +46,7 @@ This workflow uses `gh-actions-cache` to delete all the caches created by a bran
 ```yaml
 name: cleanup caches by a branch
 on:
-  pull_request:
+  pull_request_target:
     types:
       - closed
   workflow_dispatch:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Change the workflow trigger event from `pull_request` to `pull_request_target` in the "cleanup caches by a branch" workflow example.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
When triggered by the `pull_request` event, the `GITHUB_TOKEN` does not have permission to delete the cache of the base repository in a cross-repository pull request. This results in the error `Error: Resource not accessible by integration`.
This problem can be avoided by using the `pull_request_target` event.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I've updated the workflow to use the `pull_request_target` event and triggered a GitHub Actions run.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation (add or update README or docs)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
