### PR TITLE
Adjust storage warning

### DIFF
--- a/dist/restore-only/index.js
+++ b/dist/restore-only/index.js
@@ -189,12 +189,13 @@ function saveCache(paths, key, options, enableCrossOsArchive = false) {
             if (core.isDebug()) {
                 yield (0, tar_1.listTar)(archivePath, compressionMethod);
             }
-            const fileSizeLimit = 10 * 1024 * 1024 * 1024; // 10GB per repo limit
+            const fileSizeMultiplierGb = 10 // 10GB per repo limit
+            const fileSizeLimit = fileSizeMultiplierGb * 1024 * 1024 * 1024;
             const archiveFileSize = utils.getArchiveFileSizeInBytes(archivePath);
             core.debug(`File Size: ${archiveFileSize}`);
             // For GHES, this check will take place in ReserveCache API with enterprise file size limit
             if (archiveFileSize > fileSizeLimit && !utils.isGhes()) {
-                throw new Error(`Cache size of ~${Math.round(archiveFileSize / (1024 * 1024))} MB (${archiveFileSize} B) is over the 10GB limit, not saving cache.`);
+                throw new Error(`Cache size of ~${Math.round(archiveFileSize / (1024 * 1024))} MB (${archiveFileSize} B) is over the ${fileSizeMultiplierGb}GB limit, not saving cache.`);
             }
             core.debug('Reserving Cache');
             const reserveCacheResponse = yield cacheHttpClient.reserveCache(key, paths, {

--- a/dist/restore/index.js
+++ b/dist/restore/index.js
@@ -189,12 +189,13 @@ function saveCache(paths, key, options, enableCrossOsArchive = false) {
             if (core.isDebug()) {
                 yield (0, tar_1.listTar)(archivePath, compressionMethod);
             }
-            const fileSizeLimit = 10 * 1024 * 1024 * 1024; // 10GB per repo limit
+            const fileSizeMultiplierGb = 10 // 10GB per repo limit
+            const fileSizeLimit = fileSizeMultiplierGb * 1024 * 1024 * 1024;
             const archiveFileSize = utils.getArchiveFileSizeInBytes(archivePath);
             core.debug(`File Size: ${archiveFileSize}`);
             // For GHES, this check will take place in ReserveCache API with enterprise file size limit
             if (archiveFileSize > fileSizeLimit && !utils.isGhes()) {
-                throw new Error(`Cache size of ~${Math.round(archiveFileSize / (1024 * 1024))} MB (${archiveFileSize} B) is over the 10GB limit, not saving cache.`);
+                throw new Error(`Cache size of ~${Math.round(archiveFileSize / (1024 * 1024))} MB (${archiveFileSize} B) is over the ${fileSizeMultiplierGb}GB limit, not saving cache.`);
             }
             core.debug('Reserving Cache');
             const reserveCacheResponse = yield cacheHttpClient.reserveCache(key, paths, {

--- a/dist/save-only/index.js
+++ b/dist/save-only/index.js
@@ -189,12 +189,13 @@ function saveCache(paths, key, options, enableCrossOsArchive = false) {
             if (core.isDebug()) {
                 yield (0, tar_1.listTar)(archivePath, compressionMethod);
             }
-            const fileSizeLimit = 10 * 1024 * 1024 * 1024; // 10GB per repo limit
+            const fileSizeMultiplierGb = 10 // 10GB per repo limit
+            const fileSizeLimit = fileSizeMultiplierGb * 1024 * 1024 * 1024;
             const archiveFileSize = utils.getArchiveFileSizeInBytes(archivePath);
             core.debug(`File Size: ${archiveFileSize}`);
             // For GHES, this check will take place in ReserveCache API with enterprise file size limit
             if (archiveFileSize > fileSizeLimit && !utils.isGhes()) {
-                throw new Error(`Cache size of ~${Math.round(archiveFileSize / (1024 * 1024))} MB (${archiveFileSize} B) is over the 10GB limit, not saving cache.`);
+                throw new Error(`Cache size of ~${Math.round(archiveFileSize / (1024 * 1024))} MB (${archiveFileSize} B) is over the ${fileSizeMultiplierGb}GB limit, not saving cache.`);
             }
             core.debug('Reserving Cache');
             const reserveCacheResponse = yield cacheHttpClient.reserveCache(key, paths, {

--- a/dist/save/index.js
+++ b/dist/save/index.js
@@ -189,12 +189,13 @@ function saveCache(paths, key, options, enableCrossOsArchive = false) {
             if (core.isDebug()) {
                 yield (0, tar_1.listTar)(archivePath, compressionMethod);
             }
-            const fileSizeLimit = 10 * 1024 * 1024 * 1024; // 10GB per repo limit
+            const fileSizeMultiplierGb = 10 // 10GB per repo limit
+            const fileSizeLimit = fileSizeMultiplierGb * 1024 * 1024 * 1024;
             const archiveFileSize = utils.getArchiveFileSizeInBytes(archivePath);
             core.debug(`File Size: ${archiveFileSize}`);
             // For GHES, this check will take place in ReserveCache API with enterprise file size limit
             if (archiveFileSize > fileSizeLimit && !utils.isGhes()) {
-                throw new Error(`Cache size of ~${Math.round(archiveFileSize / (1024 * 1024))} MB (${archiveFileSize} B) is over the 10GB limit, not saving cache.`);
+                throw new Error(`Cache size of ~${Math.round(archiveFileSize / (1024 * 1024))} MB (${archiveFileSize} B) is over the ${fileSizeMultiplierGb}GB limit, not saving cache.`);
             }
             core.debug('Reserving Cache');
             const reserveCacheResponse = yield cacheHttpClient.reserveCache(key, paths, {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->

There's an issue with the total expected cache size warning/error when using [buildjet cache](https://github.com/BuildJet/cache) which is a fork from this repo. To avoid there being any discrepancies between the **actual** allowed cache size and the size mentioned within the error message, I moved the limit into it's own variable and added the limit variable into the error message.

This is the message that I see when using buildjets cache: 

<img width="965" alt="Screenshot 2024-02-13 at 8 54 45 AM" src="https://github.com/BuildJet/cache/assets/28793997/1968d459-9002-4a7a-9f67-a068388b4130">

```
Warning: Failed to save: Cache size of ~6148 MB (6446280578 B) is over the 10GB limit, not saving cache.
Cache saved with key: docker-image-cache4-Linux
```

The actual limit is 4.99 GB. The message states 10GB is the limit.

However, if I switch the caching action to use: `runs-on: ubuntu-latest` along with `uses: actions/cache@v4` then it works as expected. Example: 
 
<img width="957" alt="Screenshot 2024-02-13 at 8 45 41 AM" src="https://github.com/BuildJet/cache/assets/28793997/511eb912-9333-44af-b39f-0b37c5724421">

Working: 

        ---
        name: Test 
        
        on: [ pull_request ]
        
        permissions:
          id-token: write
          contents: read
        
        jobs:
          test:
            env:
              CI: true
        
            runs-on: ubuntu-latest
        
            steps:
              - name: Free Disk Space (Ubuntu)
                uses: jlumbroso/free-disk-space@v1.3.1
        
              - run: mkdir -p ~/docker-image-cache
        
              - id: docker-image-cache
                uses: actions/cache@v4
                with:
                    path: ~/docker-image-cache
                    key: docker-image-cache4-${{ runner.os }}          
        
              - name: Git checkout my app repos
                uses: myorg/repoName/.github/actions/checkout@v3
        
              - name: Load cache for docker images
                if: steps.docker-image-cache.outputs.cache-hit == 'true'
                run: |
                    docker load -i ~/docker-image-cache/myOrgImage1.tar
                    docker load -i ~/docker-image-cache/myOrgImage2.tar
                    docker load -i ~/docker-image-cache/myOrgImage3.tar
                    docker load -i ~/docker-image-cache/myOrgImage4.tar
                    docker load -i ~/docker-image-cache/myOrgImage5.tar
        
              - name: Pull the docker images 
                run:  |  
                     cd testApp
                     make pull-images
        
              - name: Create cache for docker images
                if: steps.docker-image-cache.outputs.cache-hit != 'true'
                run: |
                    docker image list --format "{{ .Repository }}:{{ .Tag }}"
                    docker save -o ~/docker-image-cache/myOrgImage1.tar $(docker image list --format "{{ .Repository }}:{{ .Tag }}" | grep "myOrgImage1")
                    docker save -o ~/docker-image-cache/myOrgImage2.tar $(docker image list --format "{{ .Repository }}:{{ .Tag }}" | grep "myOrgImage2")
                    docker save -o ~/docker-image-cache/myOrgImage3.tar $(docker image list --format "{{ .Repository }}:{{ .Tag }}" | grep "myOrgImage3")
                    docker save -o ~/docker-image-cache/myOrgImage4.tar $(docker image list --format "{{ .Repository }}:{{ .Tag }}" | grep "myOrgImage4")
                    docker save -o ~/docker-image-cache/myOrgImage5.tar $(docker image list --format "{{ .Repository }}:{{ .Tag }}" | grep "myOrgImage5")




Not working: 
 

          ---
          name: Test
          
          on: [ pull_request ]
          
          permissions:
            id-token: write
            contents: read
          
          jobs:
            test:
              env:
                CI: true
          
              runs-on: buildjet-4vcpu-ubuntu-2204
          
              steps:
                - name: Free Disk Space (Ubuntu)
                  uses: jlumbroso/free-disk-space@v1.3.1
          
                - run: mkdir -p ~/docker-image-cache
          
                - id: docker-image-cache
                  uses: buildjet/cache@v4
                  with:
                      path: ~/docker-image-cache
                      key: docker-image-cache4-${{ runner.os }}          
          
                - name: Git checkout my app repos
                  uses: myorg/repoName/.github/actions/checkout@v3
          
                - name: Load cache for docker images
                  if: steps.docker-image-cache.outputs.cache-hit == 'true'
                  run: |
                      docker load -i ~/docker-image-cache/myOrgImage1.tar
                      docker load -i ~/docker-image-cache/myOrgImage2.tar
                      docker load -i ~/docker-image-cache/myOrgImage3.tar
                      docker load -i ~/docker-image-cache/myOrgImage4.tar
                      docker load -i ~/docker-image-cache/myOrgImage5.tar
          
              - name: Pull the docker images 
                run:  |  
                     cd testApp
                     make pull-images
          
                - name: Create cache for docker images
                  if: steps.docker-image-cache.outputs.cache-hit != 'true'
                  run: |
                      docker image list --format "{{ .Repository }}:{{ .Tag }}"
                      docker save -o ~/docker-image-cache/myOrgImage1.tar $(docker image list --format "{{ .Repository }}:{{ .Tag }}" | grep "myOrgImage1")
                      docker save -o ~/docker-image-cache/myOrgImage2.tar $(docker image list --format "{{ .Repository }}:{{ .Tag }}" | grep "myOrgImage2")
                      docker save -o ~/docker-image-cache/myOrgImage3.tar $(docker image list --format "{{ .Repository }}:{{ .Tag }}" | grep "myOrgImage3")
                      docker save -o ~/docker-image-cache/myOrgImage4.tar $(docker image list --format "{{ .Repository }}:{{ .Tag }}" | grep "myOrgImage4")
                      docker save -o ~/docker-image-cache/myOrgImage5.tar $(docker image list --format "{{ .Repository }}:{{ .Tag }}" | grep "myOrgImage5")




## Motivation and Context


Should fix: https://github.com/BuildJet/cache/issues/2 

## How Has This Been Tested?

Tested this in my orgs pipeline yet as a fork from the buildjet cache modified with this change.

## Screenshots (if appropriate):

Shown above in description.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (add or update README or docs)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
