### PR TITLE
Avoid re-evaluation of the key input in restore implementation

### DIFF
--- a/dist/restore-only/index.js
+++ b/dist/restore-only/index.js
@@ -59427,7 +59427,7 @@ function restoreImpl(stateProvider, earlyExit) {
             }
             // Store the matched cache key in states
             stateProvider.setState(constants_1.State.CacheMatchedKey, cacheKey);
-            const isExactKeyMatch = utils.isExactKeyMatch(core.getInput(constants_1.Inputs.Key, { required: true }), cacheKey);
+            const isExactKeyMatch = utils.isExactKeyMatch(primaryKey, cacheKey);
             core.setOutput(constants_1.Outputs.CacheHit, isExactKeyMatch.toString());
             if (lookupOnly) {
                 core.info(`Cache found and can be restored from key: ${cacheKey}`);

--- a/dist/restore/index.js
+++ b/dist/restore/index.js
@@ -59427,7 +59427,7 @@ function restoreImpl(stateProvider, earlyExit) {
             }
             // Store the matched cache key in states
             stateProvider.setState(constants_1.State.CacheMatchedKey, cacheKey);
-            const isExactKeyMatch = utils.isExactKeyMatch(core.getInput(constants_1.Inputs.Key, { required: true }), cacheKey);
+            const isExactKeyMatch = utils.isExactKeyMatch(primaryKey, cacheKey);
             core.setOutput(constants_1.Outputs.CacheHit, isExactKeyMatch.toString());
             if (lookupOnly) {
                 core.info(`Cache found and can be restored from key: ${cacheKey}`);

--- a/src/restoreImpl.ts
+++ b/src/restoreImpl.ts
@@ -69,11 +69,7 @@ export async function restoreImpl(
         // Store the matched cache key in states
         stateProvider.setState(State.CacheMatchedKey, cacheKey);
 
-        const isExactKeyMatch = utils.isExactKeyMatch(
-            core.getInput(Inputs.Key, { required: true }),
-            cacheKey
-        );
-
+        const isExactKeyMatch = utils.isExactKeyMatch(primaryKey, cacheKey);
         core.setOutput(Outputs.CacheHit, isExactKeyMatch.toString());
         if (lookupOnly) {
             core.info(`Cache found and can be restored from key: ${cacheKey}`);


### PR DESCRIPTION
## Description
This PR fixes the re-evaluation of the key input for setting the `cache-hit` output in the restore implementation.

## Motivation and Context
I noticed that the restore implementation re-evaluates the key input on setting the `cache-hit` output. 
This does not cause any real issue, the change just refactors the code.

## How Has This Been Tested?
I have run the unit tests `restoreImpl.test.ts` which covers the code I changed.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (add or update README or docs)
- [x] Refactoring (non-breaking change which does not change the behavior)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
