### PR TITLE
Fix cache-hit output when cache missed

### DIFF
--- a/__tests__/restore.test.ts
+++ b/__tests__/restore.test.ts
@@ -260,7 +260,7 @@ test("Fail restore when fail on cache miss is enabled and primary + restore keys
     );
 
     expect(stateMock).toHaveBeenCalledWith("CACHE_KEY", key);
-    expect(setCacheHitOutputMock).toHaveBeenCalledTimes(0);
+    expect(setCacheHitOutputMock).toHaveBeenCalledTimes(1);
 
     expect(failedMock).toHaveBeenCalledWith(
         `Failed to restore cache entry. Exiting as fail-on-cache-miss is set. Input key: ${key}`

--- a/__tests__/restoreOnly.test.ts
+++ b/__tests__/restoreOnly.test.ts
@@ -86,7 +86,8 @@ test("restore with no cache found", async () => {
     );
 
     expect(outputMock).toHaveBeenCalledWith("cache-primary-key", key);
-    expect(outputMock).toHaveBeenCalledTimes(1);
+    expect(outputMock).toHaveBeenCalledWith("cache-hit", "false");
+    expect(outputMock).toHaveBeenCalledTimes(2);
     expect(failedMock).toHaveBeenCalledTimes(0);
 
     expect(infoMock).toHaveBeenCalledWith(

--- a/dist/restore-only/index.js
+++ b/dist/restore-only/index.js
@@ -59415,6 +59415,7 @@ function restoreImpl(stateProvider, earlyExit) {
             const lookupOnly = utils.getInputAsBool(constants_1.Inputs.LookupOnly);
             const cacheKey = yield cache.restoreCache(cachePaths, primaryKey, restoreKeys, { lookupOnly: lookupOnly }, enableCrossOsArchive);
             if (!cacheKey) {
+                core.setOutput(constants_1.Outputs.CacheHit, false.toString());
                 if (failOnCacheMiss) {
                     throw new Error(`Failed to restore cache entry. Exiting as fail-on-cache-miss is set. Input key: ${primaryKey}`);
                 }
@@ -59422,7 +59423,6 @@ function restoreImpl(stateProvider, earlyExit) {
                     primaryKey,
                     ...restoreKeys
                 ].join(", ")}`);
-                core.setOutput(constants_1.Outputs.CacheHit, false.toString());
                 return;
             }
             // Store the matched cache key in states

--- a/dist/restore-only/index.js
+++ b/dist/restore-only/index.js
@@ -59422,6 +59422,7 @@ function restoreImpl(stateProvider, earlyExit) {
                     primaryKey,
                     ...restoreKeys
                 ].join(", ")}`);
+                core.setOutput(constants_1.Outputs.CacheHit, false.toString());
                 return;
             }
             // Store the matched cache key in states

--- a/dist/restore/index.js
+++ b/dist/restore/index.js
@@ -59415,6 +59415,7 @@ function restoreImpl(stateProvider, earlyExit) {
             const lookupOnly = utils.getInputAsBool(constants_1.Inputs.LookupOnly);
             const cacheKey = yield cache.restoreCache(cachePaths, primaryKey, restoreKeys, { lookupOnly: lookupOnly }, enableCrossOsArchive);
             if (!cacheKey) {
+                core.setOutput(constants_1.Outputs.CacheHit, false.toString());
                 if (failOnCacheMiss) {
                     throw new Error(`Failed to restore cache entry. Exiting as fail-on-cache-miss is set. Input key: ${primaryKey}`);
                 }
@@ -59422,7 +59423,6 @@ function restoreImpl(stateProvider, earlyExit) {
                     primaryKey,
                     ...restoreKeys
                 ].join(", ")}`);
-                core.setOutput(constants_1.Outputs.CacheHit, false.toString());
                 return;
             }
             // Store the matched cache key in states

--- a/dist/restore/index.js
+++ b/dist/restore/index.js
@@ -59422,6 +59422,7 @@ function restoreImpl(stateProvider, earlyExit) {
                     primaryKey,
                     ...restoreKeys
                 ].join(", ")}`);
+                core.setOutput(constants_1.Outputs.CacheHit, false.toString());
                 return;
             }
             // Store the matched cache key in states

--- a/src/restoreImpl.ts
+++ b/src/restoreImpl.ts
@@ -51,6 +51,7 @@ export async function restoreImpl(
         );
 
         if (!cacheKey) {
+            core.setOutput(Outputs.CacheHit, false.toString());
             if (failOnCacheMiss) {
                 throw new Error(
                     `Failed to restore cache entry. Exiting as fail-on-cache-miss is set. Input key: ${primaryKey}`
@@ -62,7 +63,6 @@ export async function restoreImpl(
                     ...restoreKeys
                 ].join(", ")}`
             );
-            core.setOutput(Outputs.CacheHit, false.toString());
             return;
         }
 

--- a/src/restoreImpl.ts
+++ b/src/restoreImpl.ts
@@ -62,7 +62,7 @@ export async function restoreImpl(
                     ...restoreKeys
                 ].join(", ")}`
             );
-
+            core.setOutput(Outputs.CacheHit, false.toString());
             return;
         }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

fix https://github.com/actions/cache/issues/1334

According to the [README](https://github.com/actions/cache?tab=readme-ov-file#outputs), if the cache was not found, the output should be `'false'`. However, it actually returned an empty string. This seems to be due to the behavior of GitHub Actions to return an empty string if the output is not defined. Please see [these conversations](https://github.com/actions/cache/pull/1263).

I would like to change the code to return `'false'` when the cache is not found, per the README.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

In PR #1263, a README correction is suggested. This is a great initiative, thank you. However, to avoid confusion, how about changing the implementation instead?

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

The issue was caused by not defining an output for `cache-hit` when the cache was not found, and then returning. Therefore, I will set the output before returning.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (add or update README or docs)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
