### PR TITLE
Deprecate `save-always` input

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,6 @@ See ["Caching dependencies to speed up workflows"](https://docs.github.com/en/ac
 ### v4
 
 * Updated to node 20
-* Added a `save-always` flag to save the cache even if a prior step fails
 
 ### v3
 

--- a/action.yml
+++ b/action.yml
@@ -29,7 +29,11 @@ inputs:
   save-always:
     description: 'Run the post step to save the cache even if another step before fails'
     default: 'false'
-    required: false    
+    required: false
+    deprecationMessage: |
+      save-always does not work as intended and will be removed in a future release.
+      A separate `actions/cache/restore` step should be used instead.
+      See https://github.com/actions/cache/tree/main/save#always-save-cache for more details.
 outputs:
   cache-hit:
     description: 'A boolean value to indicate an exact match was found for the primary key'
@@ -37,7 +41,7 @@ runs:
   using: 'node20'
   main: 'dist/restore/index.js'
   post: 'dist/save/index.js'
-  post-if: "success() || github.event.inputs.save-always"
+  post-if: "success()"
 branding:
   icon: 'archive'
   color: 'gray-dark'

--- a/caching-strategies.md
+++ b/caching-strategies.md
@@ -243,24 +243,7 @@ with:
 
 ### Saving cache even if the build fails
 
-There can be cases where a cache should be saved even if the build job fails. For example, a job can fail due to flaky tests but the caches can still be re-used. You can use `actions/cache/save` action to save the cache by using `if: always()` condition.
-
-Similarly, `actions/cache/save` action can be conditionally used based on the output of the previous steps. This way you get more control on when to save the cache.
-
-```yaml
-steps:
-  - uses: actions/checkout@v4
-  .
-  . // restore if need be
-  .
-  - name: Build
-    run: /build.sh
-  - uses: actions/cache/save@v4
-    if: always() // or any other condition to invoke the save action
-    with:
-      path: path/to/dependencies
-      key: ${{ runner.os }}-${{ hashFiles('**/lockfiles') }}
-```
+See [Always save cache](./save/README.md#always-save-cache).
 
 ### Saving cache once and reusing in multiple workflows
 


### PR DESCRIPTION
## Description

The `save-always` input added in v4 is not working as intended due to `post-if` expressions not supporting the input context.

To avoid breaking users who have already added this input to their workflows, it is being deprecated now and will be removed in the next major version (v5).

This also fixes our documentation for how to properly use the recommended alternative of a separate `actions/cache/save` step, which requires checking the `cache-hit` output to avoid attempting to save a cache that already exists.

## Motivation and Context

- https://github.com/actions/cache/issues/1315
- https://github.com/actions/cache/issues/1154

## How Has This Been Tested?

Validated that the input had a deprecation message: https://github.com/joshmgross/actions-testing/actions/runs/10395133356

## Screenshots (if appropriate):

![Deprecation message for `save-always`](https://github.com/user-attachments/assets/4b9994c7-9243-42ab-858d-eb03990374df)


## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation (add or update README or docs)

Since `save-always` is already broken, I do not consider this a breaking change.

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
