### PR TITLE
Prepare `4.1.0` release

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,5 +1,9 @@
 # Releases
 
+### 4.1.0
+- Ensure `cache-hit` output is set when a cache is missed - [#1404](https://github.com/actions/cache/pull/1404)
+- Deprecate `save-always` input - [#1452](https://github.com/actions/cache/pull/1452)
+
 ### 4.0.2
 
 - Fixed restore `fail-on-cache-miss` not working.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cache",
-  "version": "4.0.2",
+  "version": "4.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "cache",
-      "version": "4.0.2",
+      "version": "4.1.0",
       "license": "MIT",
       "dependencies": {
         "@actions/cache": "^3.2.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cache",
-  "version": "4.0.2",
+  "version": "4.1.0",
   "private": true,
   "description": "Cache dependencies and build outputs",
   "main": "dist/restore/index.js",


### PR DESCRIPTION
This includes the changes from #1404 and #1452.

All other changes were documentation updates, so I did not include them in the release notes.