### PR TITLE
Restore original behavior of `cache-hit` output

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,9 +64,9 @@ If you are using a `self-hosted` Windows runner, `GNU tar` and `zstd` are requir
 
 ### Outputs
 
-* `cache-hit` - A boolean value to indicate an exact match was found for the key.
-
-    > **Note** `cache-hit` will only be set to `true` when a cache hit occurs for the exact `key` match. For a partial key match via `restore-keys` or a cache miss, it will be set to `false`.
+* `cache-hit` - A string value to indicate an exact match was found for the key.
+  * If there's a cache hit, this will be 'true' or 'false' to indicate if there's an exact match for `key`.
+  * If there's a cache miss, this will be an empty string.
 
 See [Skipping steps based on cache-hit](#skipping-steps-based-on-cache-hit) for info on using this output
 

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,5 +1,8 @@
 # Releases
 
+### 4.1.1
+- Restore original behavior of `cache-hit` output - [#1467](https://github.com/actions/cache/pull/1467)
+
 ### 4.1.0
 - Ensure `cache-hit` output is set when a cache is missed - [#1404](https://github.com/actions/cache/pull/1404)
 - Deprecate `save-always` input - [#1452](https://github.com/actions/cache/pull/1452)

--- a/__tests__/restore.test.ts
+++ b/__tests__/restore.test.ts
@@ -260,7 +260,7 @@ test("Fail restore when fail on cache miss is enabled and primary + restore keys
     );
 
     expect(stateMock).toHaveBeenCalledWith("CACHE_KEY", key);
-    expect(setCacheHitOutputMock).toHaveBeenCalledTimes(1);
+    expect(setCacheHitOutputMock).toHaveBeenCalledTimes(0);
 
     expect(failedMock).toHaveBeenCalledWith(
         `Failed to restore cache entry. Exiting as fail-on-cache-miss is set. Input key: ${key}`

--- a/__tests__/restoreOnly.test.ts
+++ b/__tests__/restoreOnly.test.ts
@@ -86,8 +86,7 @@ test("restore with no cache found", async () => {
     );
 
     expect(outputMock).toHaveBeenCalledWith("cache-primary-key", key);
-    expect(outputMock).toHaveBeenCalledWith("cache-hit", "false");
-    expect(outputMock).toHaveBeenCalledTimes(2);
+    expect(outputMock).toHaveBeenCalledTimes(1);
     expect(failedMock).toHaveBeenCalledTimes(0);
 
     expect(infoMock).toHaveBeenCalledWith(

--- a/dist/restore-only/index.js
+++ b/dist/restore-only/index.js
@@ -59415,7 +59415,8 @@ function restoreImpl(stateProvider, earlyExit) {
             const lookupOnly = utils.getInputAsBool(constants_1.Inputs.LookupOnly);
             const cacheKey = yield cache.restoreCache(cachePaths, primaryKey, restoreKeys, { lookupOnly: lookupOnly }, enableCrossOsArchive);
             if (!cacheKey) {
-                core.setOutput(constants_1.Outputs.CacheHit, false.toString());
+                // `cache-hit` is intentionally not set to `false` here to preserve existing behavior
+                // See https://github.com/actions/cache/issues/1466
                 if (failOnCacheMiss) {
                     throw new Error(`Failed to restore cache entry. Exiting as fail-on-cache-miss is set. Input key: ${primaryKey}`);
                 }

--- a/dist/restore/index.js
+++ b/dist/restore/index.js
@@ -59415,7 +59415,8 @@ function restoreImpl(stateProvider, earlyExit) {
             const lookupOnly = utils.getInputAsBool(constants_1.Inputs.LookupOnly);
             const cacheKey = yield cache.restoreCache(cachePaths, primaryKey, restoreKeys, { lookupOnly: lookupOnly }, enableCrossOsArchive);
             if (!cacheKey) {
-                core.setOutput(constants_1.Outputs.CacheHit, false.toString());
+                // `cache-hit` is intentionally not set to `false` here to preserve existing behavior
+                // See https://github.com/actions/cache/issues/1466
                 if (failOnCacheMiss) {
                     throw new Error(`Failed to restore cache entry. Exiting as fail-on-cache-miss is set. Input key: ${primaryKey}`);
                 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cache",
-  "version": "4.1.0",
+  "version": "4.1.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "cache",
-      "version": "4.1.0",
+      "version": "4.1.1",
       "license": "MIT",
       "dependencies": {
         "@actions/cache": "^3.2.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cache",
-  "version": "4.1.0",
+  "version": "4.1.1",
   "private": true,
   "description": "Cache dependencies and build outputs",
   "main": "dist/restore/index.js",

--- a/src/restoreImpl.ts
+++ b/src/restoreImpl.ts
@@ -51,7 +51,9 @@ export async function restoreImpl(
         );
 
         if (!cacheKey) {
-            core.setOutput(Outputs.CacheHit, false.toString());
+            // `cache-hit` is intentionally not set to `false` here to preserve existing behavior
+            // See https://github.com/actions/cache/issues/1466
+
             if (failOnCacheMiss) {
                 throw new Error(
                     `Failed to restore cache entry. Exiting as fail-on-cache-miss is set. Input key: ${primaryKey}`


### PR DESCRIPTION
- #1262
- #1466

As described in #1466, #1404 broke workflows that relied on the previous behavior of `cache-hit` being an empty string when there was a cache miss:

```
if: ${{ steps.cache-restore.outputs.cache-hit }}
```

If `cache-hit` is an empty string, this would work as expected. When cache-hit is `false`, this is a non-empty string and treated as "true".

Actions outputs do not support proper boolean values, and we can't guarantee how users are interpreting this string output.

This PR reverts #1404 and updates the README to clarify all possible values of `cache-hit`:
1. 'true' if there's an exact match
2. 'false' if there's a cache hit with a restore key
3. '' if there's a cache miss


This is likely confusing to users, but we should maintain the existing behavior to avoid breaking existing workflows.