### PR TITLE
Revise `isGhes` logic

### DIFF
--- a/dist/restore-only/index.js
+++ b/dist/restore-only/index.js
@@ -59585,8 +59585,12 @@ const cache = __importStar(__nccwpck_require__(7799));
 const core = __importStar(__nccwpck_require__(2186));
 const constants_1 = __nccwpck_require__(9042);
 function isGhes() {
-    const ghUrl = new URL(process.env["GITHUB_SERVER_URL"] || "https://github.com");
-    return ghUrl.hostname.toUpperCase() !== "GITHUB.COM";
+    const ghUrl = new URL(process.env['GITHUB_SERVER_URL'] || 'https://github.com');
+    const hostname = ghUrl.hostname.trimEnd().toUpperCase();
+    const isGitHubHost = hostname === 'GITHUB.COM';
+    const isGitHubEnterpriseCloudHost = hostname.endsWith('.GHE.COM');
+    const isLocalHost = hostname.endsWith('.LOCALHOST');
+    return !isGitHubHost && !isGitHubEnterpriseCloudHost && !isLocalHost;
 }
 exports.isGhes = isGhes;
 function isExactKeyMatch(key, cacheKey) {

--- a/dist/restore-only/index.js
+++ b/dist/restore-only/index.js
@@ -59585,11 +59585,11 @@ const cache = __importStar(__nccwpck_require__(7799));
 const core = __importStar(__nccwpck_require__(2186));
 const constants_1 = __nccwpck_require__(9042);
 function isGhes() {
-    const ghUrl = new URL(process.env['GITHUB_SERVER_URL'] || 'https://github.com');
+    const ghUrl = new URL(process.env["GITHUB_SERVER_URL"] || "https://github.com");
     const hostname = ghUrl.hostname.trimEnd().toUpperCase();
-    const isGitHubHost = hostname === 'GITHUB.COM';
-    const isGitHubEnterpriseCloudHost = hostname.endsWith('.GHE.COM');
-    const isLocalHost = hostname.endsWith('.LOCALHOST');
+    const isGitHubHost = hostname === "GITHUB.COM";
+    const isGitHubEnterpriseCloudHost = hostname.endsWith(".GHE.COM");
+    const isLocalHost = hostname.endsWith(".LOCALHOST");
     return !isGitHubHost && !isGitHubEnterpriseCloudHost && !isLocalHost;
 }
 exports.isGhes = isGhes;

--- a/dist/restore/index.js
+++ b/dist/restore/index.js
@@ -59585,8 +59585,12 @@ const cache = __importStar(__nccwpck_require__(7799));
 const core = __importStar(__nccwpck_require__(2186));
 const constants_1 = __nccwpck_require__(9042);
 function isGhes() {
-    const ghUrl = new URL(process.env["GITHUB_SERVER_URL"] || "https://github.com");
-    return ghUrl.hostname.toUpperCase() !== "GITHUB.COM";
+    const ghUrl = new URL(process.env['GITHUB_SERVER_URL'] || 'https://github.com');
+    const hostname = ghUrl.hostname.trimEnd().toUpperCase();
+    const isGitHubHost = hostname === 'GITHUB.COM';
+    const isGitHubEnterpriseCloudHost = hostname.endsWith('.GHE.COM');
+    const isLocalHost = hostname.endsWith('.LOCALHOST');
+    return !isGitHubHost && !isGitHubEnterpriseCloudHost && !isLocalHost;
 }
 exports.isGhes = isGhes;
 function isExactKeyMatch(key, cacheKey) {

--- a/dist/restore/index.js
+++ b/dist/restore/index.js
@@ -59585,11 +59585,11 @@ const cache = __importStar(__nccwpck_require__(7799));
 const core = __importStar(__nccwpck_require__(2186));
 const constants_1 = __nccwpck_require__(9042);
 function isGhes() {
-    const ghUrl = new URL(process.env['GITHUB_SERVER_URL'] || 'https://github.com');
+    const ghUrl = new URL(process.env["GITHUB_SERVER_URL"] || "https://github.com");
     const hostname = ghUrl.hostname.trimEnd().toUpperCase();
-    const isGitHubHost = hostname === 'GITHUB.COM';
-    const isGitHubEnterpriseCloudHost = hostname.endsWith('.GHE.COM');
-    const isLocalHost = hostname.endsWith('.LOCALHOST');
+    const isGitHubHost = hostname === "GITHUB.COM";
+    const isGitHubEnterpriseCloudHost = hostname.endsWith(".GHE.COM");
+    const isLocalHost = hostname.endsWith(".LOCALHOST");
     return !isGitHubHost && !isGitHubEnterpriseCloudHost && !isLocalHost;
 }
 exports.isGhes = isGhes;

--- a/dist/save-only/index.js
+++ b/dist/save-only/index.js
@@ -59598,8 +59598,12 @@ const cache = __importStar(__nccwpck_require__(7799));
 const core = __importStar(__nccwpck_require__(2186));
 const constants_1 = __nccwpck_require__(9042);
 function isGhes() {
-    const ghUrl = new URL(process.env["GITHUB_SERVER_URL"] || "https://github.com");
-    return ghUrl.hostname.toUpperCase() !== "GITHUB.COM";
+    const ghUrl = new URL(process.env['GITHUB_SERVER_URL'] || 'https://github.com');
+    const hostname = ghUrl.hostname.trimEnd().toUpperCase();
+    const isGitHubHost = hostname === 'GITHUB.COM';
+    const isGitHubEnterpriseCloudHost = hostname.endsWith('.GHE.COM');
+    const isLocalHost = hostname.endsWith('.LOCALHOST');
+    return !isGitHubHost && !isGitHubEnterpriseCloudHost && !isLocalHost;
 }
 exports.isGhes = isGhes;
 function isExactKeyMatch(key, cacheKey) {

--- a/dist/save-only/index.js
+++ b/dist/save-only/index.js
@@ -59598,11 +59598,11 @@ const cache = __importStar(__nccwpck_require__(7799));
 const core = __importStar(__nccwpck_require__(2186));
 const constants_1 = __nccwpck_require__(9042);
 function isGhes() {
-    const ghUrl = new URL(process.env['GITHUB_SERVER_URL'] || 'https://github.com');
+    const ghUrl = new URL(process.env["GITHUB_SERVER_URL"] || "https://github.com");
     const hostname = ghUrl.hostname.trimEnd().toUpperCase();
-    const isGitHubHost = hostname === 'GITHUB.COM';
-    const isGitHubEnterpriseCloudHost = hostname.endsWith('.GHE.COM');
-    const isLocalHost = hostname.endsWith('.LOCALHOST');
+    const isGitHubHost = hostname === "GITHUB.COM";
+    const isGitHubEnterpriseCloudHost = hostname.endsWith(".GHE.COM");
+    const isLocalHost = hostname.endsWith(".LOCALHOST");
     return !isGitHubHost && !isGitHubEnterpriseCloudHost && !isLocalHost;
 }
 exports.isGhes = isGhes;

--- a/dist/save/index.js
+++ b/dist/save/index.js
@@ -59598,8 +59598,12 @@ const cache = __importStar(__nccwpck_require__(7799));
 const core = __importStar(__nccwpck_require__(2186));
 const constants_1 = __nccwpck_require__(9042);
 function isGhes() {
-    const ghUrl = new URL(process.env["GITHUB_SERVER_URL"] || "https://github.com");
-    return ghUrl.hostname.toUpperCase() !== "GITHUB.COM";
+    const ghUrl = new URL(process.env['GITHUB_SERVER_URL'] || 'https://github.com');
+    const hostname = ghUrl.hostname.trimEnd().toUpperCase();
+    const isGitHubHost = hostname === 'GITHUB.COM';
+    const isGitHubEnterpriseCloudHost = hostname.endsWith('.GHE.COM');
+    const isLocalHost = hostname.endsWith('.LOCALHOST');
+    return !isGitHubHost && !isGitHubEnterpriseCloudHost && !isLocalHost;
 }
 exports.isGhes = isGhes;
 function isExactKeyMatch(key, cacheKey) {

--- a/dist/save/index.js
+++ b/dist/save/index.js
@@ -59598,11 +59598,11 @@ const cache = __importStar(__nccwpck_require__(7799));
 const core = __importStar(__nccwpck_require__(2186));
 const constants_1 = __nccwpck_require__(9042);
 function isGhes() {
-    const ghUrl = new URL(process.env['GITHUB_SERVER_URL'] || 'https://github.com');
+    const ghUrl = new URL(process.env["GITHUB_SERVER_URL"] || "https://github.com");
     const hostname = ghUrl.hostname.trimEnd().toUpperCase();
-    const isGitHubHost = hostname === 'GITHUB.COM';
-    const isGitHubEnterpriseCloudHost = hostname.endsWith('.GHE.COM');
-    const isLocalHost = hostname.endsWith('.LOCALHOST');
+    const isGitHubHost = hostname === "GITHUB.COM";
+    const isGitHubEnterpriseCloudHost = hostname.endsWith(".GHE.COM");
+    const isLocalHost = hostname.endsWith(".LOCALHOST");
     return !isGitHubHost && !isGitHubEnterpriseCloudHost && !isLocalHost;
 }
 exports.isGhes = isGhes;

--- a/src/utils/actionUtils.ts
+++ b/src/utils/actionUtils.ts
@@ -4,10 +4,16 @@ import * as core from "@actions/core";
 import { RefKey } from "../constants";
 
 export function isGhes(): boolean {
-    const ghUrl = new URL(
-        process.env["GITHUB_SERVER_URL"] || "https://github.com"
-    );
-    return ghUrl.hostname.toUpperCase() !== "GITHUB.COM";
+  const ghUrl = new URL(
+    process.env['GITHUB_SERVER_URL'] || 'https://github.com'
+  );
+
+  const hostname = ghUrl.hostname.trimEnd().toUpperCase()
+  const isGitHubHost = hostname === 'GITHUB.COM'
+  const isGitHubEnterpriseCloudHost = hostname.endsWith('.GHE.COM')
+  const isLocalHost = hostname.endsWith('.LOCALHOST')
+
+  return !isGitHubHost && !isGitHubEnterpriseCloudHost && !isLocalHost
 }
 
 export function isExactKeyMatch(key: string, cacheKey?: string): boolean {

--- a/src/utils/actionUtils.ts
+++ b/src/utils/actionUtils.ts
@@ -4,16 +4,16 @@ import * as core from "@actions/core";
 import { RefKey } from "../constants";
 
 export function isGhes(): boolean {
-  const ghUrl = new URL(
-    process.env['GITHUB_SERVER_URL'] || 'https://github.com'
-  );
+    const ghUrl = new URL(
+        process.env["GITHUB_SERVER_URL"] || "https://github.com"
+    );
 
-  const hostname = ghUrl.hostname.trimEnd().toUpperCase()
-  const isGitHubHost = hostname === 'GITHUB.COM'
-  const isGitHubEnterpriseCloudHost = hostname.endsWith('.GHE.COM')
-  const isLocalHost = hostname.endsWith('.LOCALHOST')
+    const hostname = ghUrl.hostname.trimEnd().toUpperCase();
+    const isGitHubHost = hostname === "GITHUB.COM";
+    const isGitHubEnterpriseCloudHost = hostname.endsWith(".GHE.COM");
+    const isLocalHost = hostname.endsWith(".LOCALHOST");
 
-  return !isGitHubHost && !isGitHubEnterpriseCloudHost && !isLocalHost
+    return !isGitHubHost && !isGitHubEnterpriseCloudHost && !isLocalHost;
 }
 
 export function isExactKeyMatch(key: string, cacheKey?: string): boolean {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

I'm fixing the logic within helper method `isGhes` to ensure that it doesn't misrecognize GitHub Enterprise Cloud instances as GHES instances.


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
https://github.com/newsroom/press-releases/data-residency-in-the-eu

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (add or update README or docs)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
