### PR TITLE
docs: Make the "always save prime numbers" example more clear

### DIFF
--- a/save/README.md
+++ b/save/README.md
@@ -79,8 +79,10 @@ To avoid saving a cache that already exists, the `cache-hit` output from a resto
 The `cache-primary-key` output from the restore step should also be used to ensure
 the cache key does not change during the build if it's calculated based on file contents.
 
+Here's an example where we imagine we're calculating a lot of prime numbers and want to cache them:
+
 ```yaml
-name: Always Caching Primes
+name: Always Caching Prime Numbers
 
 on: push
 
@@ -91,23 +93,23 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
-    - name: Restore cached Primes
-      id: cache-primes-restore
+    - name: Restore cached Prime Numbers
+      id: cache-prime-numbers-restore
       uses: actions/cache/restore@v4
       with:
-        key: ${{ runner.os }}-primes
+        key: ${{ runner.os }}-prime-numbers
         path: |
           path/to/dependencies
           some/other/dependencies
 
     # Intermediate workflow steps
 
-    - name: Always Save Primes
-      id: cache-primes-save
-      if: always() && steps.cache-primes-restore.outputs.cache-hit != 'true'
+    - name: Always Save Prime Numbers
+      id: cache-prime-numbers-save
+      if: always() && steps.cache-prime-numbers-restore.outputs.cache-hit != 'true'
       uses: actions/cache/save@v4
       with:
-        key: ${{ steps.cache-primes-restore.outputs.cache-primary-key }}
+        key: ${{ steps.cache-prime-numbers-restore.outputs.cache-primary-key }}
         path: |
           path/to/dependencies
           some/other/dependencies


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Update the ["Always save cache" example](https://github.com/actions/cache/tree/main/save#always-save-cache) to make it clear that it's talking about prime numbers

## Motivation and Context
I was dropped into that docs page without much context from our GitHub actions CI output
```
Warning: Input 'save-always' has been deprecated with message: save-always does not work as intended and will be removed in a future release.
A separate `actions/cache/restore` step should be used instead.
See https://github.com/actions/cache/tree/main/save#always-save-cache for more details.
```
And when I just looked at the example it wasn't immediately clear to me what "Primes" was. If it was "primes" as in "This action 'primes' the cache" or if it was "primes" as in "prime numbers". 
Reading it through a few times I'm guessing it's the latter; prime numbers. So this PR updates the docs to remove the ambiguity.


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Not tested

## Screenshots (if appropriate):

N/A

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation (add or update README or docs)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
