### PR TITLE
docs: GitHub is spelled incorrectly in caching-strategies.md

### DIFF
--- a/caching-strategies.md
+++ b/caching-strategies.md
@@ -102,7 +102,7 @@ The [GitHub Context](https://docs.github.com/en/actions/learn-github-actions/con
 
 While setting paths for caching dependencies it is important to give correct path depending on the hosted runner you are using or whether the action is running in a container job. Assigning different `path` for save and restore will result in cache miss.
 
-Below are GiHub hosted runner specific paths one should take care of when writing a workflow which saves/restores caches across OS.
+Below are GitHub hosted runner specific paths one should take care of when writing a workflow which saves/restores caches across OS.
 
 #### Ubuntu Paths
 


### PR DESCRIPTION
> ## Description
> Update the word [GiHub](https://github.com/actions/cache/blob/main/caching-strategies.md#understanding-how-to-choose-path) 3 lines under the start of that section, because it's confusing to read. It should be "GitHub"
> 
> ## Motivation and Context
> I was reading the caching strategies and got a confused when "GiHub" was mentioned, had to to do a double take :)
> ## How Has This Been Tested?
> Nope, its only docs
> 
> ## Screenshots (if appropriate):
> N/A
> 
> ## Types of changes
> * [ ]  Bug fix (non-breaking change which fixes an issue)
> * [ ]  New feature (non-breaking change which adds functionality)
> * [ ]  Breaking change (fix or feature that would cause existing functionality to change)
> * [x]  Documentation (add or update README or docs)
> 
> ## Checklist:
> * [ ]  My code follows the code style of this project.
> * [x]  My change requires a change to the documentation.
> * [x]  I have updated the documentation accordingly.
> * [x]  I have read the **CONTRIBUTING** document.
> * [ ]  I have added tests to cover my changes.
> * [ ]  All new and existing tests passed.