### PR TITLE
Document `path` behaviour and access restrictions

### DIFF
--- a/caching-strategies.md
+++ b/caching-strategies.md
@@ -165,6 +165,10 @@ steps:
     run: /publish.sh
 ```
 
+> [!IMPORTANT]
+> 
+> The `path` must match on both the centralized job and the target job, otherwise there will be no cache-hit whatsoever. Also take notes of the [restrictions for accessing caches across workflows](https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/caching-dependencies-to-speed-up-workflows#restrictions-for-accessing-a-cache).  
+
 ### Failing/Exiting the workflow if cache with exact key is not found
 
 You can use the output of this action to exit the workflow on cache miss. This way you can restrict your workflow to only initiate the build when `cache-hit` occurs, in other words, cache with exact key is found.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
The cache restore strategy behavior seems to include the `path` somehow, which may come as a surprise when trying to reuse caches across jobs/workflows.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Thanks to [this comment](https://github.com/actions/cache/issues/1491#issuecomment-2450718907.) which saved me some headache; I thought it wouldn't hurt to add some warning for the next person.

Possibly related to: #1561, #1491 and #1426.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

The behavior was confirmed (`v4`) when trying to re-use a cache built from a separate workflow job. No cache-hit initially because of a slightly different `path` value; cache hit as soon as this was fixed on the consumer side.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation (add or update README or docs)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
