### PR TITLE
Add new setting save-on-success.

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ If you are using a `self-hosted` Windows runner, `GNU tar` and `zstd` are requir
 * `enableCrossOsArchive` - An optional boolean when enabled, allows Windows runners to save or restore caches that can be restored or saved respectively on other platforms. Default: `false`
 * `fail-on-cache-miss` - Fail the workflow if cache entry is not found. Default: `false`
 * `lookup-only` - If true, only checks if cache entry exists and skips download. Does not change save cache behavior. Default: `false`
+* `save-on-success` - If true, then the cache is written in the post action on success, or (if false) the cache will only be restored if available.
 
 #### Environment Variables
 

--- a/action.yml
+++ b/action.yml
@@ -26,13 +26,18 @@ inputs:
     description: 'Check if a cache entry exists for the given input(s) (key, restore-keys) without downloading the cache'
     default: 'false'
     required: false
+  save-on-success:
+    description: 'Whether the cache is written in the post action on success or (if false) is only restored'
+    default: 'true'
+    required: false
   save-always:
     description: 'Run the post step to save the cache even if another step before fails'
     default: 'false'
     required: false
     deprecationMessage: |
       save-always does not work as intended and will be removed in a future release.
-      A separate `actions/cache/restore` step should be used instead.
+      If you only want to control whether a new cache will be written use `save-always` instead.
+      Otherwise a separate `actions/cache/restore` step should be used instead.
       See https://github.com/actions/cache/tree/main/save#always-save-cache for more details.
 outputs:
   cache-hit:
@@ -41,7 +46,7 @@ runs:
   using: 'node20'
   main: 'dist/restore/index.js'
   post: 'dist/save/index.js'
-  post-if: "success()"
+  post-if: "success() && github.event.inputs.save-on-success"
 branding:
   icon: 'archive'
   color: 'gray-dark'


### PR DESCRIPTION
Proposal to implement https://github.com/actions/cache/issues/1570

## Description

Allows to control whether new caches can be written in post action on success.

## Motivation and Context

In some cases you want to read but not save a new cache. For instance when you run workflows on a tag action, then you probably want to read caches from the main/default branch, but you most likely do not want to create new caches. The current solution is to separate restore and save actions which is cumbersome.

In #1452 the always_save feature was removed.

I propose to add a new config save-on-success that defaults to true and can be set false to prevent cache writing. Now this new value can be set from available context - just like you could when separating the steps - granted the decision must be available upfront. That above described decision is in fact available immediately on job creation. So we can use the new setting to simplify the setup.

## How Has This Been Tested?


## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (add or update README or docs)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
