### PR TITLE
Add cache-primary-key and cache-matched-key outputs to actions/cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,8 @@ If you are using a `self-hosted` Windows runner, `GNU tar` and `zstd` are requir
 * `cache-hit` - A string value to indicate an exact match was found for the key.
   * If there's a cache hit, this will be 'true' or 'false' to indicate if there's an exact match for `key`.
   * If there's a cache miss, this will be an empty string.
+* `cache-primary-key` - Cache primary key passed in the input to use in subsequent steps of the workflow.
+* `cache-matched-key` - Key of the cache that was restored, it could either be the primary key on cache-hit or a partial/complete match of one of the restore keys.
 
 See [Skipping steps based on cache-hit](#skipping-steps-based-on-cache-hit) for info on using this output
 

--- a/__tests__/restore.test.ts
+++ b/__tests__/restore.test.ts
@@ -149,7 +149,7 @@ test("restore with cache found for key", async () => {
     const infoMock = jest.spyOn(core, "info");
     const failedMock = jest.spyOn(core, "setFailed");
     const stateMock = jest.spyOn(core, "saveState");
-    const setCacheHitOutputMock = jest.spyOn(core, "setOutput");
+    const setOutputMock = jest.spyOn(core, "setOutput");
     const restoreCacheMock = jest
         .spyOn(cache, "restoreCache")
         .mockImplementationOnce(() => {
@@ -173,8 +173,10 @@ test("restore with cache found for key", async () => {
     expect(stateMock).toHaveBeenCalledWith("CACHE_RESULT", key);
     expect(stateMock).toHaveBeenCalledTimes(2);
 
-    expect(setCacheHitOutputMock).toHaveBeenCalledTimes(1);
-    expect(setCacheHitOutputMock).toHaveBeenCalledWith("cache-hit", "true");
+    expect(setOutputMock).toHaveBeenCalledTimes(3);
+    expect(setOutputMock).toHaveBeenCalledWith("cache-hit", "true");
+    expect(setOutputMock).toHaveBeenCalledWith("cache-primary-key", key);
+    expect(setOutputMock).toHaveBeenCalledWith("cache-matched-key", key);
 
     expect(infoMock).toHaveBeenCalledWith(`Cache restored from key: ${key}`);
     expect(failedMock).toHaveBeenCalledTimes(0);
@@ -194,7 +196,7 @@ test("restore with cache found for restore key", async () => {
     const infoMock = jest.spyOn(core, "info");
     const failedMock = jest.spyOn(core, "setFailed");
     const stateMock = jest.spyOn(core, "saveState");
-    const setCacheHitOutputMock = jest.spyOn(core, "setOutput");
+    const setOutputMock = jest.spyOn(core, "setOutput");
     const restoreCacheMock = jest
         .spyOn(cache, "restoreCache")
         .mockImplementationOnce(() => {
@@ -218,8 +220,10 @@ test("restore with cache found for restore key", async () => {
     expect(stateMock).toHaveBeenCalledWith("CACHE_RESULT", restoreKey);
     expect(stateMock).toHaveBeenCalledTimes(2);
 
-    expect(setCacheHitOutputMock).toHaveBeenCalledTimes(1);
-    expect(setCacheHitOutputMock).toHaveBeenCalledWith("cache-hit", "false");
+    expect(setOutputMock).toHaveBeenCalledTimes(3);
+    expect(setOutputMock).toHaveBeenCalledWith("cache-hit", "false");
+    expect(setOutputMock).toHaveBeenCalledWith("cache-primary-key", key);
+    expect(setOutputMock).toHaveBeenCalledWith("cache-matched-key", restoreKey);
     expect(infoMock).toHaveBeenCalledWith(
         `Cache restored from key: ${restoreKey}`
     );
@@ -239,7 +243,7 @@ test("Fail restore when fail on cache miss is enabled and primary + restore keys
 
     const failedMock = jest.spyOn(core, "setFailed");
     const stateMock = jest.spyOn(core, "saveState");
-    const setCacheHitOutputMock = jest.spyOn(core, "setOutput");
+    const setOutputMock = jest.spyOn(core, "setOutput");
     const restoreCacheMock = jest
         .spyOn(cache, "restoreCache")
         .mockImplementationOnce(() => {
@@ -260,7 +264,8 @@ test("Fail restore when fail on cache miss is enabled and primary + restore keys
     );
 
     expect(stateMock).toHaveBeenCalledWith("CACHE_KEY", key);
-    expect(setCacheHitOutputMock).toHaveBeenCalledTimes(0);
+    expect(setOutputMock).toHaveBeenCalledTimes(1);
+    expect(setOutputMock).toHaveBeenCalledWith("cache-primary-key", key);
 
     expect(failedMock).toHaveBeenCalledWith(
         `Failed to restore cache entry. Exiting as fail-on-cache-miss is set. Input key: ${key}`
@@ -282,7 +287,7 @@ test("restore when fail on cache miss is enabled and primary key doesn't match r
     const infoMock = jest.spyOn(core, "info");
     const failedMock = jest.spyOn(core, "setFailed");
     const stateMock = jest.spyOn(core, "saveState");
-    const setCacheHitOutputMock = jest.spyOn(core, "setOutput");
+    const setOutputMock = jest.spyOn(core, "setOutput");
     const restoreCacheMock = jest
         .spyOn(cache, "restoreCache")
         .mockImplementationOnce(() => {
@@ -306,8 +311,10 @@ test("restore when fail on cache miss is enabled and primary key doesn't match r
     expect(stateMock).toHaveBeenCalledWith("CACHE_RESULT", restoreKey);
     expect(stateMock).toHaveBeenCalledTimes(2);
 
-    expect(setCacheHitOutputMock).toHaveBeenCalledTimes(1);
-    expect(setCacheHitOutputMock).toHaveBeenCalledWith("cache-hit", "false");
+    expect(setOutputMock).toHaveBeenCalledTimes(3);
+    expect(setOutputMock).toHaveBeenCalledWith("cache-hit", "false");
+    expect(setOutputMock).toHaveBeenCalledWith("cache-primary-key", key);
+    expect(setOutputMock).toHaveBeenCalledWith("cache-matched-key", restoreKey);
 
     expect(infoMock).toHaveBeenCalledWith(
         `Cache restored from key: ${restoreKey}`

--- a/__tests__/restoreImpl.test.ts
+++ b/__tests__/restoreImpl.test.ts
@@ -112,7 +112,7 @@ test("restore on GHES with AC available ", async () => {
     const infoMock = jest.spyOn(core, "info");
     const failedMock = jest.spyOn(core, "setFailed");
     const stateMock = jest.spyOn(core, "saveState");
-    const setCacheHitOutputMock = jest.spyOn(core, "setOutput");
+    const setOutputMock = jest.spyOn(core, "setOutput");
     const restoreCacheMock = jest
         .spyOn(cache, "restoreCache")
         .mockImplementationOnce(() => {
@@ -133,8 +133,10 @@ test("restore on GHES with AC available ", async () => {
     );
 
     expect(stateMock).toHaveBeenCalledWith("CACHE_KEY", key);
-    expect(setCacheHitOutputMock).toHaveBeenCalledTimes(1);
-    expect(setCacheHitOutputMock).toHaveBeenCalledWith("cache-hit", "true");
+    expect(setOutputMock).toHaveBeenCalledTimes(3);
+    expect(setOutputMock).toHaveBeenCalledWith("cache-hit", "true");
+    expect(setOutputMock).toHaveBeenCalledWith("cache-primary-key", key);
+    expect(setOutputMock).toHaveBeenCalledWith("cache-matched-key", key);
 
     expect(infoMock).toHaveBeenCalledWith(`Cache restored from key: ${key}`);
     expect(failedMock).toHaveBeenCalledTimes(0);
@@ -334,7 +336,7 @@ test("restore with cache found for key", async () => {
     const infoMock = jest.spyOn(core, "info");
     const failedMock = jest.spyOn(core, "setFailed");
     const stateMock = jest.spyOn(core, "saveState");
-    const setCacheHitOutputMock = jest.spyOn(core, "setOutput");
+    const setOutputMock = jest.spyOn(core, "setOutput");
     const restoreCacheMock = jest
         .spyOn(cache, "restoreCache")
         .mockImplementationOnce(() => {
@@ -355,8 +357,11 @@ test("restore with cache found for key", async () => {
     );
 
     expect(stateMock).toHaveBeenCalledWith("CACHE_KEY", key);
-    expect(setCacheHitOutputMock).toHaveBeenCalledTimes(1);
-    expect(setCacheHitOutputMock).toHaveBeenCalledWith("cache-hit", "true");
+    expect(setOutputMock).toHaveBeenCalledTimes(3);
+    expect(setOutputMock).toHaveBeenCalledWith("cache-hit", "true");
+    expect(setOutputMock).toHaveBeenCalledWith("cache-primary-key", key);
+    expect(setOutputMock).toHaveBeenCalledWith("cache-matched-key", key);
+
 
     expect(infoMock).toHaveBeenCalledWith(`Cache restored from key: ${key}`);
     expect(failedMock).toHaveBeenCalledTimes(0);
@@ -376,7 +381,7 @@ test("restore with cache found for restore key", async () => {
     const infoMock = jest.spyOn(core, "info");
     const failedMock = jest.spyOn(core, "setFailed");
     const stateMock = jest.spyOn(core, "saveState");
-    const setCacheHitOutputMock = jest.spyOn(core, "setOutput");
+    const setOutputMock = jest.spyOn(core, "setOutput");
     const restoreCacheMock = jest
         .spyOn(cache, "restoreCache")
         .mockImplementationOnce(() => {
@@ -397,8 +402,10 @@ test("restore with cache found for restore key", async () => {
     );
 
     expect(stateMock).toHaveBeenCalledWith("CACHE_KEY", key);
-    expect(setCacheHitOutputMock).toHaveBeenCalledTimes(1);
-    expect(setCacheHitOutputMock).toHaveBeenCalledWith("cache-hit", "false");
+    expect(setOutputMock).toHaveBeenCalledTimes(3);
+    expect(setOutputMock).toHaveBeenCalledWith("cache-hit", "false");
+    expect(setOutputMock).toHaveBeenCalledWith("cache-primary-key", key);
+    expect(setOutputMock).toHaveBeenCalledWith("cache-matched-key", restoreKey);
     expect(infoMock).toHaveBeenCalledWith(
         `Cache restored from key: ${restoreKey}`
     );
@@ -417,7 +424,7 @@ test("restore with lookup-only set", async () => {
     const infoMock = jest.spyOn(core, "info");
     const failedMock = jest.spyOn(core, "setFailed");
     const stateMock = jest.spyOn(core, "saveState");
-    const setCacheHitOutputMock = jest.spyOn(core, "setOutput");
+    const setOutputMock = jest.spyOn(core, "setOutput");
     const restoreCacheMock = jest
         .spyOn(cache, "restoreCache")
         .mockImplementationOnce(() => {
@@ -441,8 +448,10 @@ test("restore with lookup-only set", async () => {
     expect(stateMock).toHaveBeenCalledWith("CACHE_RESULT", key);
     expect(stateMock).toHaveBeenCalledTimes(2);
 
-    expect(setCacheHitOutputMock).toHaveBeenCalledTimes(1);
-    expect(setCacheHitOutputMock).toHaveBeenCalledWith("cache-hit", "true");
+    expect(setOutputMock).toHaveBeenCalledTimes(3);
+    expect(setOutputMock).toHaveBeenCalledWith("cache-hit", "true");
+    expect(setOutputMock).toHaveBeenCalledWith("cache-primary-key", key);
+    expect(setOutputMock).toHaveBeenCalledWith("cache-matched-key", key);
 
     expect(infoMock).toHaveBeenCalledWith(
         `Cache found and can be restored from key: ${key}`

--- a/__tests__/restoreImpl.test.ts
+++ b/__tests__/restoreImpl.test.ts
@@ -362,7 +362,6 @@ test("restore with cache found for key", async () => {
     expect(setOutputMock).toHaveBeenCalledWith("cache-primary-key", key);
     expect(setOutputMock).toHaveBeenCalledWith("cache-matched-key", key);
 
-
     expect(infoMock).toHaveBeenCalledWith(`Cache restored from key: ${key}`);
     expect(failedMock).toHaveBeenCalledTimes(0);
 });

--- a/__tests__/stateProvider.test.ts
+++ b/__tests__/stateProvider.test.ts
@@ -54,7 +54,7 @@ test("StateProvider saves states", async () => {
     expect(cacheStateValue).toBe(cacheMatchedKey);
     expect(getStateMock).toHaveBeenCalledTimes(2);
     expect(saveStateMock).toHaveBeenCalledTimes(2);
-    expect(setOutputMock).toHaveBeenCalledTimes(0);
+    expect(setOutputMock).toHaveBeenCalledTimes(2);
 });
 
 test("NullStateProvider saves outputs", async () => {

--- a/action.yml
+++ b/action.yml
@@ -37,6 +37,10 @@ inputs:
 outputs:
   cache-hit:
     description: 'A boolean value to indicate an exact match was found for the primary key'
+  cache-primary-key:
+    description: 'A resolved cache key for which cache match was attempted'
+  cache-matched-key:
+    description: 'Key of the cache that was restored, it could either be the primary key on cache-hit or a partial/complete match of one of the restore keys'
 runs:
   using: 'node20'
   main: 'dist/restore/index.js'

--- a/dist/restore-only/index.js
+++ b/dist/restore-only/index.js
@@ -65114,21 +65114,22 @@ class StateProviderBase {
 class StateProvider extends StateProviderBase {
     constructor() {
         super(...arguments);
-        this.setState = core.saveState;
+        this.setState = (key, value) => { core.saveState(key, value); stateToOutput(key, value); };
         this.getState = core.getState;
     }
 }
 exports.StateProvider = StateProvider;
+const stateToOutputMap = new Map([
+    [constants_1.State.CacheMatchedKey, constants_1.Outputs.CacheMatchedKey],
+    [constants_1.State.CachePrimaryKey, constants_1.Outputs.CachePrimaryKey]
+]);
+function stateToOutput(key, value) {
+    core.setOutput(stateToOutputMap.get(key), value);
+}
 class NullStateProvider extends StateProviderBase {
     constructor() {
         super(...arguments);
-        this.stateToOutputMap = new Map([
-            [constants_1.State.CacheMatchedKey, constants_1.Outputs.CacheMatchedKey],
-            [constants_1.State.CachePrimaryKey, constants_1.Outputs.CachePrimaryKey]
-        ]);
-        this.setState = (key, value) => {
-            core.setOutput(this.stateToOutputMap.get(key), value);
-        };
+        this.setState = stateToOutput;
         // eslint-disable-next-line @typescript-eslint/no-unused-vars
         this.getState = (key) => "";
     }

--- a/dist/restore/index.js
+++ b/dist/restore/index.js
@@ -65114,21 +65114,22 @@ class StateProviderBase {
 class StateProvider extends StateProviderBase {
     constructor() {
         super(...arguments);
-        this.setState = core.saveState;
+        this.setState = (key, value) => { core.saveState(key, value); stateToOutput(key, value); };
         this.getState = core.getState;
     }
 }
 exports.StateProvider = StateProvider;
+const stateToOutputMap = new Map([
+    [constants_1.State.CacheMatchedKey, constants_1.Outputs.CacheMatchedKey],
+    [constants_1.State.CachePrimaryKey, constants_1.Outputs.CachePrimaryKey]
+]);
+function stateToOutput(key, value) {
+    core.setOutput(stateToOutputMap.get(key), value);
+}
 class NullStateProvider extends StateProviderBase {
     constructor() {
         super(...arguments);
-        this.stateToOutputMap = new Map([
-            [constants_1.State.CacheMatchedKey, constants_1.Outputs.CacheMatchedKey],
-            [constants_1.State.CachePrimaryKey, constants_1.Outputs.CachePrimaryKey]
-        ]);
-        this.setState = (key, value) => {
-            core.setOutput(this.stateToOutputMap.get(key), value);
-        };
+        this.setState = stateToOutput;
         // eslint-disable-next-line @typescript-eslint/no-unused-vars
         this.getState = (key) => "";
     }

--- a/dist/save-only/index.js
+++ b/dist/save-only/index.js
@@ -65127,21 +65127,22 @@ class StateProviderBase {
 class StateProvider extends StateProviderBase {
     constructor() {
         super(...arguments);
-        this.setState = core.saveState;
+        this.setState = (key, value) => { core.saveState(key, value); stateToOutput(key, value); };
         this.getState = core.getState;
     }
 }
 exports.StateProvider = StateProvider;
+const stateToOutputMap = new Map([
+    [constants_1.State.CacheMatchedKey, constants_1.Outputs.CacheMatchedKey],
+    [constants_1.State.CachePrimaryKey, constants_1.Outputs.CachePrimaryKey]
+]);
+function stateToOutput(key, value) {
+    core.setOutput(stateToOutputMap.get(key), value);
+}
 class NullStateProvider extends StateProviderBase {
     constructor() {
         super(...arguments);
-        this.stateToOutputMap = new Map([
-            [constants_1.State.CacheMatchedKey, constants_1.Outputs.CacheMatchedKey],
-            [constants_1.State.CachePrimaryKey, constants_1.Outputs.CachePrimaryKey]
-        ]);
-        this.setState = (key, value) => {
-            core.setOutput(this.stateToOutputMap.get(key), value);
-        };
+        this.setState = stateToOutput;
         // eslint-disable-next-line @typescript-eslint/no-unused-vars
         this.getState = (key) => "";
     }

--- a/dist/save/index.js
+++ b/dist/save/index.js
@@ -65127,21 +65127,22 @@ class StateProviderBase {
 class StateProvider extends StateProviderBase {
     constructor() {
         super(...arguments);
-        this.setState = core.saveState;
+        this.setState = (key, value) => { core.saveState(key, value); stateToOutput(key, value); };
         this.getState = core.getState;
     }
 }
 exports.StateProvider = StateProvider;
+const stateToOutputMap = new Map([
+    [constants_1.State.CacheMatchedKey, constants_1.Outputs.CacheMatchedKey],
+    [constants_1.State.CachePrimaryKey, constants_1.Outputs.CachePrimaryKey]
+]);
+function stateToOutput(key, value) {
+    core.setOutput(stateToOutputMap.get(key), value);
+}
 class NullStateProvider extends StateProviderBase {
     constructor() {
         super(...arguments);
-        this.stateToOutputMap = new Map([
-            [constants_1.State.CacheMatchedKey, constants_1.Outputs.CacheMatchedKey],
-            [constants_1.State.CachePrimaryKey, constants_1.Outputs.CachePrimaryKey]
-        ]);
-        this.setState = (key, value) => {
-            core.setOutput(this.stateToOutputMap.get(key), value);
-        };
+        this.setState = stateToOutput;
         // eslint-disable-next-line @typescript-eslint/no-unused-vars
         this.getState = (key) => "";
     }

--- a/src/stateProvider.ts
+++ b/src/stateProvider.ts
@@ -21,26 +21,28 @@ class StateProviderBase implements IStateProvider {
     }
 
     // eslint-disable-next-line @typescript-eslint/no-unused-vars, @typescript-eslint/no-empty-function
-    setState = (key: string, value: string) => {};
+    setState = (key: string, value: string) => { };
 
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     getState = (key: string) => "";
 }
 
 export class StateProvider extends StateProviderBase {
-    setState = core.saveState;
+    setState = (key: string, value: string) => { core.saveState(key, value); stateToOutput(key, value); };
     getState = core.getState;
 }
 
+const stateToOutputMap = new Map<string, string>([
+    [State.CacheMatchedKey, Outputs.CacheMatchedKey],
+    [State.CachePrimaryKey, Outputs.CachePrimaryKey]
+]);
+function stateToOutput(key: string, value: string) {
+    core.setOutput(stateToOutputMap.get(key) as string, value);
+}
 export class NullStateProvider extends StateProviderBase {
-    stateToOutputMap = new Map<string, string>([
-        [State.CacheMatchedKey, Outputs.CacheMatchedKey],
-        [State.CachePrimaryKey, Outputs.CachePrimaryKey]
-    ]);
 
-    setState = (key: string, value: string) => {
-        core.setOutput(this.stateToOutputMap.get(key) as string, value);
-    };
+    setState = stateToOutput;
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     getState = (key: string) => "";
 }
+

--- a/src/stateProvider.ts
+++ b/src/stateProvider.ts
@@ -21,14 +21,17 @@ class StateProviderBase implements IStateProvider {
     }
 
     // eslint-disable-next-line @typescript-eslint/no-unused-vars, @typescript-eslint/no-empty-function
-    setState = (key: string, value: string) => { };
+    setState = (key: string, value: string) => {};
 
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     getState = (key: string) => "";
 }
 
 export class StateProvider extends StateProviderBase {
-    setState = (key: string, value: string) => { core.saveState(key, value); stateToOutput(key, value); };
+    setState = (key: string, value: string) => {
+        core.saveState(key, value);
+        stateToOutput(key, value);
+    };
     getState = core.getState;
 }
 
@@ -40,9 +43,7 @@ function stateToOutput(key: string, value: string) {
     core.setOutput(stateToOutputMap.get(key) as string, value);
 }
 export class NullStateProvider extends StateProviderBase {
-
     setState = stateToOutput;
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     getState = (key: string) => "";
 }
-


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Add `cache-primary-key` and `cache-matched-key` outputs from `actions/cache/restore` action to `actions/cache` action

## Description
<!--- Describe your changes in detail -->
The `actions/cache/restore` action provides `cache-hit`, `cache-primary-key` and `cache-matched-key` outputs, but the `actions/cache` only exposes `cache-hit`.  

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Currently, determining the cache key that was matched requires using restore/save separately. This PR enables using the primary/matched cache keys in subsequent steps using `actions/cache`.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Updated test code in the repo. Also the PR branch from another repo

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (add or update README or docs)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
