### PR TITLE
update examples.md for Bun v1.2 lockfile format

### DIFF
--- a/examples.md
+++ b/examples.md
@@ -49,7 +49,7 @@
   with:
     path: |
       ~/.bun/install/cache
-    key: ${{ runner.os }}-bun-${{ hashFiles('**/bun.lockb') }}
+    key: ${{ runner.os }}-bun-${{ hashFiles('**/bun.lock') }}
 ```
 
 ### Windows
@@ -59,7 +59,7 @@
   with:
     path: |
       ~\.bun
-    key: ${{ runner.os }}-bun-${{ hashFiles('**/bun.lockb') }}
+    key: ${{ runner.os }}-bun-${{ hashFiles('**/bun.lock') }}
 ```
 
 ## C# - NuGet


### PR DESCRIPTION
## Description
Updated the action-cache examples in `examples.md` to reflect Bun v1.2’s switch from the binary lockfile `bun.lockb` to the new text-based `bun.lock`.

_Note: If you’re on Bun < v1.2 you’ll need to continue caching the legacy bun.lockb file or bump your version to take advantage of the new format._ Maybe that should be specified in the .md?

## Motivation and Context
Bun v1.2 introduced a potentially breaking change in its default lockfile format. Workflows that look for the legacy lockfile bun.lockb could silently miss cache hits when running on Bun >= v1.2, leading to slower installs and unexpected rebuilds. This documentation update ensures that users following examples will cache and restore dependencies correctly on newer Bun versions.

## How Has This Been Tested?
Not yet tested in CI — these changes are strictly to documentation.

Users should apply the updated examples to their workflows and verify that the cache key correctly picks up bun.lock (e.g. by inspecting the Actions “Cache hit” log).

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x ] Documentation (add or update README or docs)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ x] My code follows the code style of this project.
- [x ] My change requires a change to the documentation.
- [ x] I have updated the documentation accordingly.
- [ x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
