### PR TITLE
Offer a strategy to reduce cache churn

### DIFF
--- a/caching-strategies.md
+++ b/caching-strategies.md
@@ -304,3 +304,26 @@ steps:
   - name: Publish package to public
     run: ./publish.sh
 ```
+
+### Saving cache only if the build runs on the default branch
+
+Workflow runs can restore caches created in either the current branch or the default branch (usually `main`) [Reference](https://docs.github.com/en/actions/reference/workflows-and-actions/dependency-caching#restrictions-for-accessing-a-cache).
+
+By restricting caches to the default branch, we can reduce the risk that Github evicts a cache created on the default branch. If that happens, every PR will create its own cache, increasing the cache churn.
+
+We can condition the execution of the `actions/cache/save` action on the current branch:
+
+```yaml
+steps:
+  - uses: actions/checkout@v3
+  .
+  . // restore if need be
+  .
+  - name: Build
+    run: /build.sh
+  - uses: actions/cache/save@v3
+    if: ${{ github.ref == 'refs/heads/main' }} // check we are on the default branch
+    with:
+      path: path/to/dependencies
+      key: ${{ runner.os }}-${{ hashFiles('**/lockfiles') }}
+```


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This is a documentation change offering a new caching strategy meant to reduce cache churn by selecting on which runs a cache can be created.

## Motivation and Context
I am trying to check my reasoning and offer this best practice ahead of offering that `actions/cache` offers an option to perform cache save conditionally.

## How Has This Been Tested?
No tests - this is a doc change.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation (add or update README or docs)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [] I have added tests to cover my changes.
- [x] All new and existing tests passed.
