### PR TITLE
prepare release v5.0.1

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -2,6 +2,10 @@
 
 ## Changelog
 
+### 5.0.1
+
+- Update `@azure/storage-blob` to `^12.29.1` via `@actions/cache@5.0.1` [#1685](https://github.com/actions/cache/pull/1685)
+
 ### 5.0.0
 
 > [!IMPORTANT]

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cache",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cache",
-      "version": "5.0.0",
+      "version": "5.0.1",
       "license": "MIT",
       "dependencies": {
         "@actions/cache": "^5.0.1",
@@ -463,7 +463,6 @@
       "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cache",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "private": true,
   "description": "Cache dependencies and build outputs",
   "main": "dist/restore/index.js",


### PR DESCRIPTION
## Summary
Bump version to v5.0.1 with release notes for the Node.js 24 punycode deprecation fix.

## Changes
- Bump version from 5.0.0 to 5.0.1
- Add release notes for v5.0.1 documenting the punycode deprecation fix

## Related PRs
- #1685 - fix: update @actions/cache for Node.js 24 punycode deprecation
- actions/toolkit#2213 - Fix cache storage-blob update