### PR TITLE
Fix cache re-evaluation key example in caching strategies docs

### DIFF
--- a/caching-strategies.md
+++ b/caching-strategies.md
@@ -238,7 +238,7 @@ Case 2: Where the user would want to re-evaluate the key
 ```yaml
 uses: actions/cache/save@v5
 with:
-    key: npm-cache-${{hashfiles(package-lock.json)}}
+    key: cache-${{ hashFiles('**/lockfiles') }}
 ```
 
 ### Saving cache even if the build fails


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Based on the example provided, the save key here would always be different from the cache restore key. And on top of that, the function call for `hashFiles` looked incorrect on the save action (both in casing and for the files it was hashing).

This PR aligns the examples so they'd restore & save for the same purpose.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The documentation is a bit misleading here.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Documentation (add or update README or docs)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
