### PR TITLE
Fix cache key in examples.md for bun.lock

### DIFF
--- a/examples.md
+++ b/examples.md
@@ -49,7 +49,7 @@
   with:
     path: |
       ~/.bun/install/cache
-    key: ${{ runner.os }}-bun-${{ hashFiles('**/bun.lockb') }}
+    key: ${{ runner.os }}-bun-${{ hashFiles('**/bun.lock') }}
 ```
 
 ### Windows
@@ -59,7 +59,7 @@
   with:
     path: |
       ~\.bun
-    key: ${{ runner.os }}-bun-${{ hashFiles('**/bun.lockb') }}
+    key: ${{ runner.os }}-bun-${{ hashFiles('**/bun.lock') }}
 ```
 
 ## C# - NuGet


### PR DESCRIPTION
## Description

Updated examples for bun cache key to use 'bun.lock' instead of 'bun.lockdb'.

Bun [changed](https://bun.com/docs/pm/lockfile#text-based-lockfile) the format and file name a few minor versions ago.

## Motivation and Context

Keep docs up to date.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation (add or update README or docs)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
