### PR TITLE
Fixed Cargo example not working for multiple archs

### DIFF
--- a/examples.md
+++ b/examples.md
@@ -618,7 +618,7 @@ whenever possible:
       ~/.cargo/registry/cache/
       ~/.cargo/git/db/
       target/
-    key: ${{ runner.os }}-{{ runner.arch }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+    key: ${{ runner.os }}-${{ runner.arch }}-cargo-${{ hashFiles('**/Cargo.lock') }}
 ```
 
 ## Scala - SBT

--- a/examples.md
+++ b/examples.md
@@ -618,7 +618,7 @@ whenever possible:
       ~/.cargo/registry/cache/
       ~/.cargo/git/db/
       target/
-    key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+    key: ${{ runner.os }}-{{ runner.arch }}-cargo-${{ hashFiles('**/Cargo.lock') }}
 ```
 
 ## Scala - SBT


### PR DESCRIPTION
Added runner.arch to the cache key in the Cargo example since otherwise an arm runner might pull an x86 cache which breaks the build. I got the following error without this fix:

```
/home/runner/work/_temp/98f299c6-8f8f-4624-b041-55b989a1682b.sh: line 1: /home/runner/.cargo/bin/cargo: cannot execute binary file: Exec format error
```

## Description
It's just a change to the Rust/Cargo example since the action works quite well it's just that the key used in the example does not consider the architecture of the runner which at least for Rust/Linux is quite important.

## Motivation and Context
Should help others since they might run into the same error as I did when just copy-pasting the example code, I for example just blindly assumed that runner.os might be something like "ubuntu-24.04" or "ubuntu-24.04-arm" to distinguish between the different architecture.


## How Has This Been Tested?
Added the runner.arch part to the cache key for my Rust project and now 

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation (add or update README or docs)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

Didn't run the test suite since I only changed a single line in the docs / EXAMPLES.md file.