### PR TITLE
feat: Introduced `restore-only` flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ If you are using a `self-hosted` Windows runner, `GNU tar` and `zstd` are requir
 * `enableCrossOsArchive` - An optional boolean when enabled, allows Windows runners to save or restore caches that can be restored or saved respectively on other platforms. Default: `false`
 * `fail-on-cache-miss` - Fail the workflow if cache entry is not found. Default: `false`
 * `lookup-only` - If true, only checks if cache entry exists and skips download. Does not change save cache behavior. Default: `false`
+* `restore-only` - If true, only restores cache and skips save cache behavior. Default: `false`. Set it to `${{ github.event.repository != null && github.ref_name != github.event.repository.default_branch }}` to only save the cache when running on the default branch.
 
 #### Environment Variables
 

--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ If you are using a `self-hosted` Windows runner, `GNU tar` and `zstd` are requir
 * `enableCrossOsArchive` - An optional boolean when enabled, allows Windows runners to save or restore caches that can be restored or saved respectively on other platforms. Default: `false`
 * `fail-on-cache-miss` - Fail the workflow if cache entry is not found. Default: `false`
 * `lookup-only` - If true, only checks if cache entry exists and skips download. Does not change save cache behavior. Default: `false`
+* `restore-only` - If true, only restores cache and skips save cache behavior. Default: `false`. Set it to `${{ github.event.repository != null && github.ref_name != github.event.repository.default_branch }}` to only save the cache when running on the default branch.
 
 #### Environment Variables
 

--- a/__tests__/saveImpl.test.ts
+++ b/__tests__/saveImpl.test.ts
@@ -406,3 +406,34 @@ test("save with valid inputs uploads a cache", async () => {
 
     expect(failedMock).toHaveBeenCalledTimes(0);
 });
+
+test("save with restore-only should no-op", async () => {
+    const primaryKey = "Linux-node-bb828da54c148048dd17899ba9fda624811cfb43";
+    const savedCacheKey = "Linux-node-";
+
+    jest.spyOn(core, "getState")
+        // Cache Entry State
+        .mockImplementationOnce(() => {
+            return savedCacheKey;
+        })
+        // Cache Key State
+        .mockImplementationOnce(() => {
+            return primaryKey;
+        });
+
+    const inputPath = "node_modules";
+    testUtils.setInput(Inputs.Path, inputPath);
+
+    testUtils.setInput(Inputs.RestoreOnly, "true");
+
+    const infoMock = jest.spyOn(core, "info");
+
+    const saveCacheMock = jest.spyOn(cache, "saveCache");
+
+    await saveImpl(new StateProvider());
+
+    expect(saveCacheMock).toHaveBeenCalledTimes(0);
+    expect(infoMock).toHaveBeenCalledWith(
+        "Skipping saving cache as 'restore-only' option is set."
+    );
+});

--- a/__tests__/saveImpl.test.ts
+++ b/__tests__/saveImpl.test.ts
@@ -282,3 +282,34 @@ test("save with valid inputs uploads a cache", async () => {
 
     expect(core.setFailed).toHaveBeenCalledTimes(0);
 });
+
+test("save with restore-only should no-op", async () => {
+    const primaryKey = "Linux-node-bb828da54c148048dd17899ba9fda624811cfb43";
+    const savedCacheKey = "Linux-node-";
+
+    jest.spyOn(core, "getState")
+        // Cache Entry State
+        .mockImplementationOnce(() => {
+            return savedCacheKey;
+        })
+        // Cache Key State
+        .mockImplementationOnce(() => {
+            return primaryKey;
+        });
+
+    const inputPath = "node_modules";
+    testUtils.setInput(Inputs.Path, inputPath);
+
+    testUtils.setInput(Inputs.RestoreOnly, "true");
+
+    const infoMock = jest.spyOn(core, "info");
+
+    const saveCacheMock = jest.spyOn(cache, "saveCache");
+
+    await saveImpl(new StateProvider());
+
+    expect(saveCacheMock).toHaveBeenCalledTimes(0);
+    expect(infoMock).toHaveBeenCalledWith(
+        "Skipping saving cache as 'restore-only' option is set."
+    );
+});

--- a/action.yml
+++ b/action.yml
@@ -26,6 +26,10 @@ inputs:
     description: 'Check if a cache entry exists for the given input(s) (key, restore-keys) without downloading the cache'
     default: 'false'
     required: false
+  restore-only:
+    description: 'Downloads the cache if it exists, but skips saving it at the end of the job'
+    default: 'false'
+    required: false
   save-always:
     description: 'Run the post step to save the cache even if another step before fails'
     default: 'false'

--- a/dist/restore-only/index.js
+++ b/dist/restore-only/index.js
@@ -46306,7 +46306,8 @@ var Inputs;
     Inputs["UploadChunkSize"] = "upload-chunk-size";
     Inputs["EnableCrossOsArchive"] = "enableCrossOsArchive";
     Inputs["FailOnCacheMiss"] = "fail-on-cache-miss";
-    Inputs["LookupOnly"] = "lookup-only"; // Input for cache, restore action
+    Inputs["LookupOnly"] = "lookup-only";
+    Inputs["RestoreOnly"] = "restore-only"; // Input for cache, restore action
 })(Inputs || (exports.Inputs = Inputs = {}));
 var Outputs;
 (function (Outputs) {

--- a/dist/restore-only/index.js
+++ b/dist/restore-only/index.js
@@ -94801,7 +94801,8 @@ var Inputs;
     Inputs["UploadChunkSize"] = "upload-chunk-size";
     Inputs["EnableCrossOsArchive"] = "enableCrossOsArchive";
     Inputs["FailOnCacheMiss"] = "fail-on-cache-miss";
-    Inputs["LookupOnly"] = "lookup-only"; // Input for cache, restore action
+    Inputs["LookupOnly"] = "lookup-only";
+    Inputs["RestoreOnly"] = "restore-only"; // Input for cache, restore action
 })(Inputs || (Inputs = {}));
 var Outputs;
 (function (Outputs) {

--- a/dist/restore/index.js
+++ b/dist/restore/index.js
@@ -46306,7 +46306,8 @@ var Inputs;
     Inputs["UploadChunkSize"] = "upload-chunk-size";
     Inputs["EnableCrossOsArchive"] = "enableCrossOsArchive";
     Inputs["FailOnCacheMiss"] = "fail-on-cache-miss";
-    Inputs["LookupOnly"] = "lookup-only"; // Input for cache, restore action
+    Inputs["LookupOnly"] = "lookup-only";
+    Inputs["RestoreOnly"] = "restore-only"; // Input for cache, restore action
 })(Inputs || (exports.Inputs = Inputs = {}));
 var Outputs;
 (function (Outputs) {

--- a/dist/restore/index.js
+++ b/dist/restore/index.js
@@ -94801,7 +94801,8 @@ var Inputs;
     Inputs["UploadChunkSize"] = "upload-chunk-size";
     Inputs["EnableCrossOsArchive"] = "enableCrossOsArchive";
     Inputs["FailOnCacheMiss"] = "fail-on-cache-miss";
-    Inputs["LookupOnly"] = "lookup-only"; // Input for cache, restore action
+    Inputs["LookupOnly"] = "lookup-only";
+    Inputs["RestoreOnly"] = "restore-only"; // Input for cache, restore action
 })(Inputs || (Inputs = {}));
 var constants_Outputs;
 (function (Outputs) {

--- a/dist/save-only/index.js
+++ b/dist/save-only/index.js
@@ -46306,7 +46306,8 @@ var Inputs;
     Inputs["UploadChunkSize"] = "upload-chunk-size";
     Inputs["EnableCrossOsArchive"] = "enableCrossOsArchive";
     Inputs["FailOnCacheMiss"] = "fail-on-cache-miss";
-    Inputs["LookupOnly"] = "lookup-only"; // Input for cache, restore action
+    Inputs["LookupOnly"] = "lookup-only";
+    Inputs["RestoreOnly"] = "restore-only"; // Input for cache, restore action
 })(Inputs || (exports.Inputs = Inputs = {}));
 var Outputs;
 (function (Outputs) {
@@ -46399,6 +46400,10 @@ function saveImpl(stateProvider) {
             }
             if (!utils.isValidEvent()) {
                 utils.logWarning(`Event Validation Error: The event type ${process.env[constants_1.Events.Key]} is not supported because it's not tied to a branch or tag ref.`);
+                return;
+            }
+            if (utils.getInputAsBool(constants_1.Inputs.RestoreOnly)) {
+                core.info("Skipping saving cache as 'restore-only' option is set.");
                 return;
             }
             // If restore has stored a primary key in state, reuse that

--- a/dist/save-only/index.js
+++ b/dist/save-only/index.js
@@ -94806,7 +94806,8 @@ var Inputs;
     Inputs["UploadChunkSize"] = "upload-chunk-size";
     Inputs["EnableCrossOsArchive"] = "enableCrossOsArchive";
     Inputs["FailOnCacheMiss"] = "fail-on-cache-miss";
-    Inputs["LookupOnly"] = "lookup-only"; // Input for cache, restore action
+    Inputs["LookupOnly"] = "lookup-only";
+    Inputs["RestoreOnly"] = "restore-only"; // Input for cache, restore action
 })(Inputs || (Inputs = {}));
 var Outputs;
 (function (Outputs) {
@@ -94935,6 +94936,10 @@ async function saveImpl(stateProvider) {
         }
         if (!isValidEvent()) {
             logWarning(`Event Validation Error: The event type ${process.env[Events.Key]} is not supported because it's not tied to a branch or tag ref.`);
+            return;
+        }
+        if (getInputAsBool(Inputs.RestoreOnly)) {
+            info("Skipping saving cache as 'restore-only' option is set.");
             return;
         }
         // If restore has stored a primary key in state, reuse that

--- a/dist/save/index.js
+++ b/dist/save/index.js
@@ -46306,7 +46306,8 @@ var Inputs;
     Inputs["UploadChunkSize"] = "upload-chunk-size";
     Inputs["EnableCrossOsArchive"] = "enableCrossOsArchive";
     Inputs["FailOnCacheMiss"] = "fail-on-cache-miss";
-    Inputs["LookupOnly"] = "lookup-only"; // Input for cache, restore action
+    Inputs["LookupOnly"] = "lookup-only";
+    Inputs["RestoreOnly"] = "restore-only"; // Input for cache, restore action
 })(Inputs || (exports.Inputs = Inputs = {}));
 var Outputs;
 (function (Outputs) {
@@ -46399,6 +46400,10 @@ function saveImpl(stateProvider) {
             }
             if (!utils.isValidEvent()) {
                 utils.logWarning(`Event Validation Error: The event type ${process.env[constants_1.Events.Key]} is not supported because it's not tied to a branch or tag ref.`);
+                return;
+            }
+            if (utils.getInputAsBool(constants_1.Inputs.RestoreOnly)) {
+                core.info("Skipping saving cache as 'restore-only' option is set.");
                 return;
             }
             // If restore has stored a primary key in state, reuse that

--- a/dist/save/index.js
+++ b/dist/save/index.js
@@ -94806,7 +94806,8 @@ var Inputs;
     Inputs["UploadChunkSize"] = "upload-chunk-size";
     Inputs["EnableCrossOsArchive"] = "enableCrossOsArchive";
     Inputs["FailOnCacheMiss"] = "fail-on-cache-miss";
-    Inputs["LookupOnly"] = "lookup-only"; // Input for cache, restore action
+    Inputs["LookupOnly"] = "lookup-only";
+    Inputs["RestoreOnly"] = "restore-only"; // Input for cache, restore action
 })(Inputs || (Inputs = {}));
 var constants_Outputs;
 (function (Outputs) {
@@ -94935,6 +94936,10 @@ async function saveImpl(stateProvider) {
         }
         if (!isValidEvent()) {
             logWarning(`Event Validation Error: The event type ${process.env[Events.Key]} is not supported because it's not tied to a branch or tag ref.`);
+            return;
+        }
+        if (getInputAsBool(Inputs.RestoreOnly)) {
+            info("Skipping saving cache as 'restore-only' option is set.");
             return;
         }
         // If restore has stored a primary key in state, reuse that

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -5,7 +5,8 @@ export enum Inputs {
     UploadChunkSize = "upload-chunk-size", // Input for cache, save action
     EnableCrossOsArchive = "enableCrossOsArchive", // Input for cache, restore, save action
     FailOnCacheMiss = "fail-on-cache-miss", // Input for cache, restore action
-    LookupOnly = "lookup-only" // Input for cache, restore action
+    LookupOnly = "lookup-only", // Input for cache, restore action
+    RestoreOnly = "restore-only" // Input for cache, restore action
 }
 
 export enum Outputs {

--- a/src/saveImpl.ts
+++ b/src/saveImpl.ts
@@ -32,6 +32,11 @@ export async function saveImpl(
             return;
         }
 
+        if (utils.getInputAsBool(Inputs.RestoreOnly)) {
+            core.info("Skipping saving cache as 'restore-only' option is set.");
+            return;
+        }
+
         // If restore has stored a primary key in state, reuse that
         // Else re-evaluate from inputs
         const primaryKey =

--- a/src/utils/testUtils.ts
+++ b/src/utils/testUtils.ts
@@ -16,6 +16,7 @@ interface CacheInput {
     enableCrossOsArchive?: boolean;
     failOnCacheMiss?: boolean;
     lookupOnly?: boolean;
+    restoreOnly?: boolean;
 }
 
 export function setInputs(input: CacheInput): void {
@@ -32,6 +33,8 @@ export function setInputs(input: CacheInput): void {
         setInput(Inputs.FailOnCacheMiss, input.failOnCacheMiss.toString());
     input.lookupOnly !== undefined &&
         setInput(Inputs.LookupOnly, input.lookupOnly.toString());
+    input.restoreOnly !== undefined &&
+        setInput(Inputs.RestoreOnly, input.restoreOnly.toString());
 }
 
 export function clearInputs(): void {
@@ -42,4 +45,5 @@ export function clearInputs(): void {
     delete process.env[getInputName(Inputs.EnableCrossOsArchive)];
     delete process.env[getInputName(Inputs.FailOnCacheMiss)];
     delete process.env[getInputName(Inputs.LookupOnly)];
+    delete process.env[getInputName(Inputs.RestoreOnly)];
 }


### PR DESCRIPTION
Introduces controlling when to save the cache with a flag.

## Description
Introduces a new `restore-only` flag into the main `@actions/cache`. If set, the action will download the cache, but it will skip its saving at the post actions phase.

Fixes #1730

## Motivation and Context
It's true that we do have the `@actions/cache/restore` and `@actions/cache/save` actions, but this change serves a new unsupported use-case: "only feed the cache given a condition".

This use case is a generalisation of the one I'm interesting on to support, which is "only feed the cache at the default branch". A topic you raise at [force-deletion-of-caches-overriding-default-cache-eviction-policy](https://github.com/actions/cache/blob/main/tips-and-workarounds.md#force-deletion-of-caches-overriding-default-cache-eviction-policy). After carefully reviewing the setup options for the action, we concluded there is no straight forward way (currently) to achieve this.

The change will also allow us to align our ad-hocs `@actions/cache` with the default [`gradle/actions/setup-gradle`](https://github.com/gradle/actions/blob/main/setup-gradle/README.md)'s behavior, where its `cache-read-only` (defaulting to `${{ github.event.repository != null && github.ref_name != github.event.repository.default_branch }}`) behaves the same.

Right now, to support our use case, we have been forced to create an internal wrapper `composite` action that runs `@actions/cache/restore` or `@actions/cache` based on this condition.
`@actions/cache/save` is not fully suitable for the use case, because it does not runs as a post action.

## How Has This Been Tested?
A dedicated unit test was added to the `saveImpl.test.ts` suite.

Test PR in the fork running CI: https://github.com/gmazzo/actions-cache/pull/1

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (add or update README or docs)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
