### PR TITLE
Disable default save action for pull_request_target

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,8 @@ jobs:
 
 > **Note**
 > You must use the `cache` or `restore` action in your workflow before you need to use the files that might be restored from the cache. If the provided `key` matches an existing cache, a new cache is not created and if the provided `key` doesn't match an existing cache, a new cache is automatically created provided the job completes successfully.
+>
+> **`pull_request_target` exception:** When `actions/cache` is used in a `pull_request_target` workflow, the automatic post-step save is **skipped**. This is a security measure to prevent untrusted pull request code from poisoning caches accessible to privileged workflows. If really you need to save a cache in a trusted `pull_request_target` context (e.g., after validating the PR source), use [`actions/cache/save`](./save/README.md) explicitly with an appropriate `if` condition.
 
 ## Caching Strategies
 

--- a/action.yml
+++ b/action.yml
@@ -41,7 +41,7 @@ runs:
   using: 'node24'
   main: 'dist/restore/index.js'
   post: 'dist/save/index.js'
-  post-if: "success()"
+  post-if: "success() && github.event_name != 'pull_request_target'"
 branding:
   icon: 'archive'
   color: 'gray-dark'


### PR DESCRIPTION
Disables the default save action on actions/cache when the event is a pull_request_target to prevent unnecessary executions. This change optimizes the workflow by ensuring that the save action only occurs for relevant events.

This plug a cache poisoning attack vector used in a number of supply chain attacks.

For users who REALLY want to save the cache on a PRT workflow, they can still use actions/cache/save dircetly. The secure by default principle should apply to the standard  actions/cache action.

Technically this *is* a breaking change. A major version bump might be advised. But I'd personally backport this to all previous versions of actions/cache instead.

Fixes https://github.com/actions/cache/issues/1756

