### PR TITLE
docs(action): update v5 references to v6 and fix outdated dates

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,6 @@
 
 [fork]: https://github.com/actions/cache/fork
 [pr]: https://github.com/actions/cache/compare
-[style]: https://github.com/styleguide/js
 [code-of-conduct]: CODE_OF_CONDUCT.md
 
 Hi there! We're thrilled that you'd like to contribute to this project. Your help is essential for keeping it great.

--- a/README.md
+++ b/README.md
@@ -18,23 +18,16 @@ See ["Caching dependencies to speed up workflows"](https://docs.github.com/en/ac
 ### ⚠️ Important changes
 
 > [!IMPORTANT]
-> `actions/cache@v5` runs on the Node.js 24 runtime and requires a minimum Actions Runner version of `2.327.1`.
+> `actions/cache@v6` runs on the Node.js 24 runtime and requires a minimum Actions Runner version of `2.327.1`.
 > If you are using self-hosted runners, ensure they are updated before upgrading.
 
 The cache backend service has been rewritten from the ground up for improved performance and reliability. [actions/cache](https://github.com/actions/cache) now integrates with the new cache service (v2) APIs.
 
-The new service will gradually roll out as of **February 1st, 2025**. The legacy service will also be sunset on the same date. Changes in these releases are **fully backward compatible**.
+The new cache backend service rollout began on **February 1st, 2025**, and the legacy service was sunset shortly after. Older pinned versions that did not integrate with the new cache service were deprecated; users should upgrade to a supported release such as `v4.2.0` or later.
 
-**We are deprecating some versions of this action**. We recommend upgrading to version `v4` or `v3` as soon as possible before **February 1st, 2025.** (Upgrade instructions below).
+If you are using pinned SHAs, please use the SHAs of versions `v4.2.0` or later.
 
-If you are using pinned SHAs, please use the SHAs of versions `v4.2.0` or `v3.4.0`.
-
-If you do not upgrade, all workflow runs using any of the deprecated [actions/cache](https://github.com/actions/cache) will fail.
-
-Upgrading to the recommended versions will not break your workflows.
-
-> **Additionally, if you are managing your own GitHub runners, you must update your runner version to `2.231.0` or newer to ensure compatibility with the new cache service.**
-> Failure to update both the action version and your runner version may result in workflow failures after the migration date.
+> **Additionally, if you are managing your own GitHub runners, ensure your runner version is `2.327.1` or newer.**
 
 Read more about the change & access the migration guide: [reference to the announcement](https://github.com/actions/cache/discussions/1510).
 
@@ -83,7 +76,7 @@ Create a workflow `.yml` file in your repository's `.github/workflows` directory
 
 If you are using this inside a container, a POSIX-compliant `tar` needs to be included and accessible from the execution path.
 
-Note: `actions/cache@v5` runs on Node.js 24 and requires a minimum Actions Runner version of `2.327.1`.
+Note: `actions/cache@v6` runs on Node.js 24 and requires a minimum Actions Runner version of `2.327.1`.
 
 If you are using a `self-hosted` Windows runner, `GNU tar` and `zstd` are required for [Cross-OS caching](https://github.com/actions/cache/blob/main/tips-and-workarounds.md#cross-os-cache) to work. They are also recommended to be installed in general so the performance is on par with `hosted` Windows runners.
 

--- a/restore/README.md
+++ b/restore/README.md
@@ -37,7 +37,7 @@ If you are using separate jobs to create and save your cache(s) to be reused by 
 steps:
   - uses: actions/checkout@v6
 
-  - uses: actions/cache/restore@v5
+  - uses: actions/cache/restore@v6
     id: cache
     with:
       path: path/to/dependencies
@@ -69,7 +69,7 @@ steps:
   - name: Build
     run: /build-parent-module.sh
 
-  - uses: actions/cache/save@v5
+  - uses: actions/cache/save@v6
     id: cache
     with:
       path: path/to/dependencies
@@ -82,7 +82,7 @@ steps:
 steps:
   - uses: actions/checkout@v6
 
-  - uses: actions/cache/restore@v5
+  - uses: actions/cache/restore@v6
     id: cache
     with:
       path: path/to/dependencies
@@ -109,7 +109,7 @@ To fail if there is no cache hit for the primary key, leave `restore-keys` empty
 steps:
   - uses: actions/checkout@v6
 
-  - uses: actions/cache/restore@v5
+  - uses: actions/cache/restore@v6
     id: cache
     with:
       path: path/to/dependencies

--- a/save/README.md
+++ b/save/README.md
@@ -31,7 +31,7 @@ steps:
   - name: Build artifacts
     run: /build.sh
 
-  - uses: actions/cache/save@v5
+  - uses: actions/cache/save@v6
     id: cache
     with:
       path: path/to/dependencies
@@ -47,7 +47,7 @@ Let's say we have a restore step that computes a key at runtime.
 #### Restore a cache
 
 ```yaml
-uses: actions/cache/restore@v5
+uses: actions/cache/restore@v6
 id: restore-cache
 with:
     key: cache-${{ hashFiles('**/lockfiles') }}
@@ -55,7 +55,7 @@ with:
 
 #### Case 1 - Where a user would want to reuse the key as it is
 ```yaml
-uses: actions/cache/save@v5
+uses: actions/cache/save@v6
 with:
     key: ${{ steps.restore-cache.outputs.cache-primary-key }}
 ```
@@ -63,7 +63,7 @@ with:
 #### Case 2 - Where the user would want to re-evaluate the key
 
 ```yaml
-uses: actions/cache/save@v5
+uses: actions/cache/save@v6
 with:
     key: npm-cache-${{hashfiles(package-lock.json)}}
 ```
@@ -95,7 +95,7 @@ jobs:
 
     - name: Restore cached Prime Numbers
       id: cache-prime-numbers-restore
-      uses: actions/cache/restore@v5
+      uses: actions/cache/restore@v6
       with:
         key: ${{ runner.os }}-prime-numbers
         path: |
@@ -107,7 +107,7 @@ jobs:
     - name: Always Save Prime Numbers
       id: cache-prime-numbers-save
       if: always() && steps.cache-prime-numbers-restore.outputs.cache-hit != 'true'
-      uses: actions/cache/save@v5
+      uses: actions/cache/save@v6
       with:
         key: ${{ steps.cache-prime-numbers-restore.outputs.cache-primary-key }}
         path: |


### PR DESCRIPTION
## Changes

Updates documentation to reflect the current v6 release:

- Update `actions/cache@v5` references to `actions/cache@v6`
- Update `actions/cache/restore@v5` references to `actions/cache/restore@v6`
- Update `actions/cache/save@v5` references to `actions/cache/save@v6`
- Rewrite the outdated cache service migration block now that the February 2025 deadline has passed
- Update self-hosted runner minimum version from `2.231.0` to `2.327.1` to match v6 requirements
- Remove unused `[style]` link reference from `CONTRIBUTING.md`

Closes #1772